### PR TITLE
fix(i18n): migrate hardcoded German strings on public/auth pages (1/4)

### DIFF
--- a/apps/frontend/src/app/auth/impersonate-complete/page.tsx
+++ b/apps/frontend/src/app/auth/impersonate-complete/page.tsx
@@ -37,11 +37,12 @@ export default function ImpersonateCompletePage() {
 }
 
 function LoadingShell() {
+  const t = useT();
   return (
     <div className="min-h-screen flex items-center justify-center bg-surface-canvas">
       <div className="max-w-md w-full mx-4 rounded-lg border border-line-subtle bg-surface-raised p-6 text-center">
-        <h1 className="text-lg font-semibold mb-2">Support-Login</h1>
-        <p className="text-sm text-ink-tertiary">Session wird angelegt…</p>
+        <h1 className="text-lg font-semibold mb-2">{t("impersonate.supportLoginTitle")}</h1>
+        <p className="text-sm text-ink-tertiary">{t("impersonate.creatingSession")}</p>
       </div>
     </div>
   );
@@ -113,17 +114,17 @@ function Inner() {
         {error ? (
           <>
             <h1 className="text-lg font-semibold text-semantic-danger mb-2">
-              Impersonate fehlgeschlagen
+              {t("impersonate.failedTitle")}
             </h1>
             <p className="text-sm text-ink-secondary mb-4">{error}</p>
             <a href="/" className="text-sm text-accent hover:underline">
-              Zurück zur Startseite
+              {t("impersonate.backToHome")}
             </a>
           </>
         ) : (
           <>
-            <h1 className="text-lg font-semibold mb-2">Support-Login</h1>
-            <p className="text-sm text-ink-tertiary">Session wird angelegt…</p>
+            <h1 className="text-lg font-semibold mb-2">{t("impersonate.supportLoginTitle")}</h1>
+            <p className="text-sm text-ink-tertiary">{t("impersonate.creatingSession")}</p>
           </>
         )}
       </div>

--- a/apps/frontend/src/app/auth/reset-password/page.tsx
+++ b/apps/frontend/src/app/auth/reset-password/page.tsx
@@ -38,11 +38,12 @@ type State =
   | { kind: "done" };
 
 export default function ResetPasswordPage() {
+  const t = useT();
   return (
     <Suspense
       fallback={
         <div className="min-h-screen flex items-center justify-center bg-surface-canvas">
-          <div className="text-ui text-ink-tertiary">Lädt…</div>
+          <div className="text-ui text-ink-tertiary">{t("common.loading")}</div>
         </div>
       }
     >

--- a/apps/frontend/src/app/e/[token]/page.tsx
+++ b/apps/frontend/src/app/e/[token]/page.tsx
@@ -101,7 +101,7 @@ export default function PublicExportPage() {
   if (loading) {
     return (
       <FullScreenCenter>
-        <div className="text-ui text-ink-tertiary">Wird geladen…</div>
+        <div className="text-ui text-ink-tertiary">{t("common.loading")}</div>
       </FullScreenCenter>
     );
   }

--- a/apps/frontend/src/app/g/[slug]/page.tsx
+++ b/apps/frontend/src/app/g/[slug]/page.tsx
@@ -16,11 +16,12 @@ import { useT } from "@/lib/i18n";
 // Next.js 16 verlangt einen <Suspense>-Boundary um useSearchParams() —
 // sonst kann die Page nicht prerendert werden.
 export default function PublicGalleryPage() {
+  const t = useT();
   return (
     <Suspense
       fallback={
         <div className="min-h-screen flex items-center justify-center bg-surface-canvas">
-          <div className="text-ui text-ink-tertiary">Lädt…</div>
+          <div className="text-ui text-ink-tertiary">{t("common.loading")}</div>
         </div>
       }
     >

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -476,7 +476,7 @@ export default function LoginPage() {
               href="/auth/forgot-password"
               className="text-ui-xs text-ink-tertiary hover:text-ink-primary transition-colors duration-motion"
             >
-              Passwort vergessen?
+              {t("forgotPassword.title")}
             </Link>
           </div>
 

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -23,13 +23,27 @@
  * sehen will, geht direkt zu /api/v1/health.
  */
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
+import { headers, cookies } from "next/headers";
 import Link from "next/link";
 
 import { TenantPicker } from "@/components/landing/TenantPicker";
+import { dictionaries, type Locale, type Dict } from "@/lib/i18n/dict";
 
 const MODE = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE ?? "single";
 const DOMAIN_BASE = process.env.NEXT_PUBLIC_DOMAIN_BASE ?? "";
+
+// Server Component — kein useT() verfügbar (das ist Client-Context).
+// Locale kommt aus dem gleichen Cookie wie im Client (siehe lib/i18n.tsx),
+// nur hier serverseitig gelesen für die eine Handvoll Strings dieser Page.
+function pickString(dict: Dict, path: string): string {
+  const parts = path.split(".");
+  let current: Dict | string = dict;
+  for (const part of parts) {
+    if (typeof current === "string") return path;
+    current = current[part] as Dict | string;
+  }
+  return typeof current === "string" ? current : path;
+}
 
 export default async function HomePage() {
   // Single-Mode: direkt durchleiten.
@@ -57,6 +71,12 @@ export default async function HomePage() {
     redirect("/login");
   }
 
+  const cookieStore = await cookies();
+  const rawLocale = cookieStore.get("lumio_locale")?.value;
+  const locale: Locale =
+    rawLocale && rawLocale in dictionaries ? (rawLocale as Locale) : "en";
+  const dict = dictionaries[locale];
+
   // Apex: Tenant-Picker rendern. Form-Submit redirected auf Subdomain.
   return (
     <main className="min-h-screen flex items-center justify-center p-8 bg-surface-canvas">
@@ -75,12 +95,14 @@ export default async function HomePage() {
             Lumio
           </div>
           <h1 className="text-display-xl font-medium tracking-tight text-ink-primary">
-            Foto- &amp; Video-Sharing
+            {pickString(dict, "landing.heroTitle")}
             <br />
-            <span className="text-ink-secondary">für Profis.</span>
+            <span className="text-ink-secondary">
+              {pickString(dict, "landing.heroTitleAccent")}
+            </span>
           </h1>
           <p className="text-ui-lg text-ink-tertiary leading-relaxed">
-            Schnelles Proofing, Auswahl und Auslieferung von Shootings.
+            {pickString(dict, "landing.heroSubtitle")}
           </p>
         </header>
 
@@ -91,14 +113,14 @@ export default async function HomePage() {
             href="https://lumio-app.de"
             className="hover:text-ink-secondary"
           >
-            Self-hosted Version
+            {pickString(dict, "landing.selfHosted")}
           </Link>
           <span>·</span>
           <a
             href="https://github.com/markusthiel/lumio"
             className="hover:text-ink-secondary"
           >
-            Quellcode
+            {pickString(dict, "landing.sourceCode")}
           </a>
         </div>
       </div>

--- a/apps/frontend/src/lib/i18n/de.ts
+++ b/apps/frontend/src/lib/i18n/de.ts
@@ -2130,6 +2130,10 @@ export const de: Dict = {
     noToken: "Kein Token im Link.",
     errCookie: "Session-Cookie wurde nicht akzeptiert. Bitte Cookies/Tracking-Schutz für diese Domain erlauben.",
     errToken: "Token ungültig oder abgelaufen. Bitte erneut vom Super-Admin starten.",
+    supportLoginTitle: "Support-Login",
+    creatingSession: "Session wird angelegt…",
+    failedTitle: "Impersonate fehlgeschlagen",
+    backToHome: "Zurück zur Startseite",
   },
 
   storageBanner: {
@@ -2353,5 +2357,12 @@ export const de: Dict = {
   },
   announcement: {
     dismiss: "Banner ausblenden",
+  },
+  landing: {
+    heroTitle: "Foto- & Video-Sharing",
+    heroTitleAccent: "für Profis.",
+    heroSubtitle: "Schnelles Proofing, Auswahl und Auslieferung von Shootings.",
+    selfHosted: "Self-hosted Version",
+    sourceCode: "Quellcode",
   },
 };

--- a/apps/frontend/src/lib/i18n/en.ts
+++ b/apps/frontend/src/lib/i18n/en.ts
@@ -2123,6 +2123,10 @@ export const en: Dict = {
     noToken: "No token in the link.",
     errCookie: "Session cookie was not accepted. Please allow cookies/tracking protection for this domain.",
     errToken: "Token invalid or expired. Please start again from the super admin.",
+    supportLoginTitle: "Support login",
+    creatingSession: "Creating session…",
+    failedTitle: "Impersonation failed",
+    backToHome: "Back to home",
   },
 
   storageBanner: {
@@ -2346,5 +2350,12 @@ export const en: Dict = {
   },
   announcement: {
     dismiss: "Dismiss banner",
+  },
+  landing: {
+    heroTitle: "Photo & video sharing",
+    heroTitleAccent: "for professionals.",
+    heroSubtitle: "Fast proofing, selection, and delivery of shoots.",
+    selfHosted: "Self-hosted version",
+    sourceCode: "Source code",
   },
 };


### PR DESCRIPTION
## Context

#4 turned out to be much larger than its description suggests: an audit of the whole frontend found roughly 260-280 hardcoded German strings across ~48 files (bypassing the dictionary entirely), 79 hardcoded `de-DE` locale calls for dates/numbers across 34 files, and a static `<html lang="en">` that's never synced with the active locale.

Given the size, I'm splitting this into 4 reviewable PRs instead of one huge diff:
1. **This PR** — public marketing landing page + login/auth flow (highest user-facing impact, smallest surface)
2. Studio interface + shared components
3. Super-admin interface (the largest single chunk — reportedly near-zero `t()` usage in several pages)
4. Locale-aware dates/numbers/currency/sorting + `document.documentElement.lang` sync

## This PR

- `app/page.tsx` — the apex landing page (multi-tenant cloud mode) had its entire hero copy hardcoded in German. It's a Server Component, so `useT()` isn't available; added a small server-side cookie-based lookup instead of pulling client-only i18n into it.
- `app/login/page.tsx` — "Passwort vergessen?" link was hardcoded; reused the existing `forgotPassword.title` key (already identical in both languages) instead of adding a duplicate.
- `app/auth/impersonate-complete/page.tsx` — support-login flow (heading, "session is being created", failure state, back-to-home link) was fully hardcoded; added `impersonate.*` keys.
- `app/auth/reset-password/page.tsx`, `app/g/[slug]/page.tsx`, `app/e/[token]/page.tsx` — Suspense-fallback "Lädt…"/"Wird geladen…" text lived outside the component that already had `t()` in scope; wired up `common.loading`.
- New keys added to **both** `en.ts` and `de.ts` per the issue's technical requirements.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `next build` (production build succeeds, `/` still statically optimized in default single-tenant mode)
- [x] Drove the dev server with Playwright in multi-tenant mode (`NEXT_PUBLIC_DEPLOYMENT_MODE=multi`) with `lumio_locale=en` and `=de`: landing page and login page render fully in the selected language, and the German output is byte-for-byte the same copy as before (no regression to existing German behavior)

Part of #4