### PR TITLE
fix(i18n): migrate hardcoded German strings in Studio interface (2/4)

### DIFF
--- a/apps/frontend/src/app/studio/[id]/page.tsx
+++ b/apps/frontend/src/app/studio/[id]/page.tsx
@@ -1940,7 +1940,7 @@ export default function GalleryDetailPage() {
                 size="sm"
                 onClick={() => setDupDialog(null)}
               >
-                Abbrechen
+                {t("common.cancel")}
               </Button>
               {dupDialog.newFiles.length > 0 && (
                 <Button
@@ -2019,7 +2019,7 @@ export default function GalleryDetailPage() {
                 onClick={() => setConfirmDialog(null)}
                 disabled={bulkPending}
               >
-                Abbrechen
+                {t("common.cancel")}
               </Button>
               <Button
                 variant={confirmDialog.confirmVariant}
@@ -2073,7 +2073,7 @@ export default function GalleryDetailPage() {
                 size="sm"
                 onClick={() => setLimitDialog(null)}
               >
-                Schließen
+                {t("common.close")}
               </Button>
               <Link
                 href="/studio/billing"
@@ -2379,7 +2379,7 @@ function Lightbox({
         aria-label={t("studio.lbClose")}
         className="absolute top-3 left-4 z-30 flex items-center gap-2 text-white/80 hover:text-white transition-colors text-ui-sm leading-none"
       >
-        <span className="text-xl leading-none">✕</span> Schließen
+        <span className="text-xl leading-none">✕</span> {t("common.close")}
       </button>
       <div className="absolute top-4 left-1/2 -translate-x-1/2 z-30 text-white/60 text-ui-sm tabular-nums">
         {i + 1} / {files.length}
@@ -2418,7 +2418,7 @@ function Lightbox({
           </div>
         ) : (
           <div className="text-white/50 text-ui px-12 py-24">
-            Keine Vorschau verfügbar
+            {t("studio.lbNoPreview")}
           </div>
         )
       ) : url ? (
@@ -2448,7 +2448,7 @@ function Lightbox({
         </div>
       ) : (
         <div className="text-white/50 text-ui px-12 py-24">
-          Keine Vorschau verfügbar
+          {t("studio.lbNoPreview")}
         </div>
       )}
       <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-30 text-center text-white/60 text-ui-sm max-w-[80vw] truncate px-4">

--- a/apps/frontend/src/app/studio/account/page.tsx
+++ b/apps/frontend/src/app/studio/account/page.tsx
@@ -350,9 +350,7 @@ function EmailSection({
             />
           </Row>
           <p className="text-ui-xs text-ink-tertiary leading-relaxed">
-            Aus Sicherheitsgründen brauchen wir dein aktuelles Passwort. Wir
-            schicken einen Bestätigungslink an die neue Adresse — erst danach
-            ist der Wechsel aktiv.
+            {t("account.changeEmailSecurityNote")}
           </p>
           {error && (
             <div className="text-ui-sm text-semantic-danger">{error}</div>

--- a/apps/frontend/src/app/studio/analytics/page.tsx
+++ b/apps/frontend/src/app/studio/analytics/page.tsx
@@ -103,7 +103,7 @@ export default function AnalyticsPage() {
       )}
 
       {loading && !data && (
-        <div className="text-sm text-ink-tertiary">Lädt…</div>
+        <div className="text-sm text-ink-tertiary">{t("common.loading")}</div>
       )}
 
       {data && (

--- a/apps/frontend/src/app/studio/appearance/page.tsx
+++ b/apps/frontend/src/app/studio/appearance/page.tsx
@@ -490,7 +490,7 @@ export default function AppearancePage() {
       applyStudioAccent(appearance.studioAccentColor);
       applyStudioTheme(appearance.studioTheme);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Speichern fehlgeschlagen");
+      setError(e instanceof Error ? e.message : t("appearance.saveFailed"));
     } finally {
       setSaving(false);
     }
@@ -520,7 +520,7 @@ export default function AppearancePage() {
         )}
 
         {loading ? (
-          <div className="text-sm text-ink-tertiary">Lädt…</div>
+          <div className="text-sm text-ink-tertiary">{t("common.loading")}</div>
         ) : !appearance ? null : (
           <>
             {/* ============ STUDIO-BACKEND ============ */}

--- a/apps/frontend/src/app/studio/billing/page.tsx
+++ b/apps/frontend/src/app/studio/billing/page.tsx
@@ -133,7 +133,7 @@ export default function BillingPage() {
     return (
       <>
         <PageHeader breadcrumb={[{ label: t("nav.studio"), href: "/studio" }, { label: t("billing.title") }]} title={t("billing.title")} />
-        <div className="px-6 sm:px-8 lg:px-12 py-6 text-ui-sm text-ink-tertiary">Lädt …</div>
+        <div className="px-6 sm:px-8 lg:px-12 py-6 text-ui-sm text-ink-tertiary">{t("common.loading")}</div>
       </>
     );
   }

--- a/apps/frontend/src/app/studio/collections/[id]/page.tsx
+++ b/apps/frontend/src/app/studio/collections/[id]/page.tsx
@@ -85,7 +85,7 @@ export default function CollectionEditPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-screen text-ui text-ink-tertiary">
-        Lädt…
+        {t("common.loading")}
       </div>
     );
   }
@@ -124,14 +124,12 @@ export default function CollectionEditPage() {
         <section className="rounded-lg border border-line-subtle bg-surface-raised p-5 space-y-3">
           <h2 className="text-sm font-medium">{t("collections.filter")}</h2>
           <p className="text-xs text-ink-tertiary">
-            Alle Filter sind UND-verknüpft — eine Galerie muss alle
-            gesetzten Bedingungen erfüllen um in der Collection zu
-            erscheinen.
+            {t("collections.filterAndNote")}
           </p>
 
           <div>
             <label className="block text-ui-xs uppercase tracking-wide text-ink-tertiary mb-1">
-              Modus
+              {t("studio.modeLabel")}
             </label>
             <select
               value={filter.mode ?? ""}
@@ -174,7 +172,7 @@ export default function CollectionEditPage() {
           {allTags.length > 0 && (
             <div>
               <label className="block text-ui-xs uppercase tracking-wide text-ink-tertiary mb-2">
-                Tags (alle gewählten müssen vorhanden sein)
+                {t("collections.tagsAllRequired")}
               </label>
               <div className="flex flex-wrap gap-1.5">
                 {allTags.map((tag) => {
@@ -202,10 +200,10 @@ export default function CollectionEditPage() {
 
         <div className="flex justify-end gap-2">
           <Button variant="ghost" onClick={() => router.push("/studio")}>
-            Abbrechen
+            {t("common.cancel")}
           </Button>
           <Button variant="primary" onClick={save} disabled={saving || !name.trim()}>
-            {saving ? "Speichert…" : t("common.save")}
+            {saving ? t("common.saving") : t("common.save")}
           </Button>
         </div>
       </div>

--- a/apps/frontend/src/app/studio/page.tsx
+++ b/apps/frontend/src/app/studio/page.tsx
@@ -249,7 +249,7 @@ export default function StudioPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-screen text-ui text-ink-tertiary">
-        Lädt…
+        {t("common.loading")}
       </div>
     );
   }
@@ -259,7 +259,7 @@ export default function StudioPage() {
     <>
       <PageHeader
         title={t("studio.galleriesTitle")}
-        description={user.name ? `Angemeldet als ${user.name}` : user.email}
+        description={user.name ? t("studio.loggedInAs", { name: user.name }) : user.email}
         actions={
           <Button variant="primary" size="md" onClick={() => setShowCreate(true)}>
             {t("studio.newGallery")}
@@ -482,7 +482,7 @@ export default function StudioPage() {
               onClick={deleteActiveCollection}
               className="text-ui-xs text-semantic-danger/80 hover:text-semantic-danger ml-2"
             >
-              Aktive löschen
+              {t("studio.deleteActiveCollection")}
             </button>
           )}
         </div>
@@ -516,7 +516,7 @@ export default function StudioPage() {
               onClick={clearFilters}
               className="text-ui-xs text-ink-tertiary hover:text-ink-secondary ml-1"
             >
-              Filter zurücksetzen
+              {t("studio.resetFilters")}
             </button>
           )}
         </div>
@@ -721,7 +721,7 @@ function SaveCollectionDialog({
             Filter
           </div>
           <p className="text-ui-xs text-ink-tertiary mb-3">
-            Galerien müssen alle gesetzten Bedingungen erfüllen.
+            {t("studio.filterAndNote")}
           </p>
 
           <div className="space-y-3">
@@ -902,7 +902,7 @@ function GalleryCard({
     <div className="flex items-center gap-2.5 text-ui-xs text-ink-tertiary">
       <span>{t("studio.nFiles", { n: g.fileCount ?? 0 })}</span>
       {stats && stats.visits > 0 && (
-        <span className="inline-flex items-center gap-1" title="Besuche">
+        <span className="inline-flex items-center gap-1" title={t("studio.statsVisitsTooltip")}>
           <svg
             width="12"
             height="12"
@@ -920,7 +920,7 @@ function GalleryCard({
         </span>
       )}
       {stats && stats.likes > 0 && (
-        <span className="inline-flex items-center gap-1" title="Favoriten">
+        <span className="inline-flex items-center gap-1" title={t("studio.statsLikesTooltip")}>
           <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 21s-7-4.6-9.5-8.3C.9 10.2 1.5 7 4.3 6c1.9-.7 3.7.2 4.7 1.6C10 6.2 11.8 5.3 13.7 6c2.8 1 3.4 4.2 1.8 6.7C19 16.4 12 21 12 21z" />
           </svg>

--- a/apps/frontend/src/app/studio/print-shop/products/page.tsx
+++ b/apps/frontend/src/app/studio/print-shop/products/page.tsx
@@ -107,7 +107,7 @@ export default function PrintProductsPage() {
   }
 
   if (!products || !providers) {
-    return <div className="text-sm text-ink-tertiary">Lädt…</div>;
+    return <div className="text-sm text-ink-tertiary">{t("common.loading")}</div>;
   }
 
   const enabledProviders = providers.filter((p) => p.enabled);

--- a/apps/frontend/src/app/studio/print-shop/providers/page.tsx
+++ b/apps/frontend/src/app/studio/print-shop/providers/page.tsx
@@ -59,7 +59,7 @@ export default function PrintProvidersPage() {
   }, [load]);
 
   if (!available || !mine) {
-    return <div className="text-sm text-ink-tertiary">Lädt…</div>;
+    return <div className="text-sm text-ink-tertiary">{t("common.loading")}</div>;
   }
 
   const mineKeys = new Set(mine.map((p) => p.providerKey));

--- a/apps/frontend/src/app/studio/print-shop/settings/page.tsx
+++ b/apps/frontend/src/app/studio/print-shop/settings/page.tsx
@@ -144,11 +144,7 @@ function SettingsInner() {
   }
 
   async function disconnect() {
-    if (
-      !confirm(
-        "Stripe-Connect-Account wirklich trennen? Du kannst danach keine Online-Bestellungen mehr empfangen."
-      )
-    ) {
+    if (!confirm(t("printSettings.disconnectConfirm"))) {
       return;
     }
     setSaving(true);

--- a/apps/frontend/src/app/studio/team/page.tsx
+++ b/apps/frontend/src/app/studio/team/page.tsx
@@ -361,8 +361,7 @@ function InviteDialog({
     <Modal onClose={pending ? () => {} : onClose}>
       <h2 className="text-lg font-medium text-ink-primary">{t("team.inviteUser")}</h2>
       <p className="text-ui-sm text-ink-secondary mt-2">
-        Der eingeladene User erhält eine E-Mail mit einem Setup-Link (gültig 72
-        Stunden) und kann sich danach mit eigenem Passwort einloggen.
+        {t("team.inviteDesc")}
       </p>
       <div className="space-y-3 mt-4">
         <Field label={t("team.fieldName")}>
@@ -396,15 +395,15 @@ function InviteDialog({
             className={inputCls}
           >
             <option value="admin">
-              Admin — kann Galerien und Team verwalten
+              {t("team.roleAdminDesc")}
             </option>
             {canInviteOwner && (
               <option value="owner">
-                Owner — kann zusätzlich Owner-Rollen vergeben
+                {t("team.roleOwnerDesc")}
               </option>
             )}
             <option value="member">
-              Member — eingeschränkter Zugriff
+              {t("team.roleMemberDesc")}
             </option>
           </select>
         </Field>

--- a/apps/frontend/src/app/studio/templates/[id]/page.tsx
+++ b/apps/frontend/src/app/studio/templates/[id]/page.tsx
@@ -115,7 +115,7 @@ export default function TemplateEditorPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-screen text-ui text-ink-tertiary">
-        Lädt…
+        {t("common.loading")}
       </div>
     );
   }
@@ -123,7 +123,7 @@ export default function TemplateEditorPage() {
     return (
       <div className="px-6 sm:px-8 lg:px-12 py-8">
         <div className="text-ui text-semantic-danger">
-          {error ?? "Template nicht gefunden."}
+          {error ?? t("templates.notFound")}
         </div>
       </div>
     );
@@ -141,10 +141,10 @@ export default function TemplateEditorPage() {
         actions={
           <>
             <Button variant="danger" onClick={remove}>
-              Löschen
+              {t("common.delete")}
             </Button>
             <Button variant="primary" onClick={save} disabled={saving}>
-              {saving ? "Speichert…" : t("common.save")}
+              {saving ? t("common.saving") : t("common.save")}
             </Button>
           </>
         }
@@ -165,12 +165,12 @@ export default function TemplateEditorPage() {
               className="w-full rounded border border-line-subtle bg-surface-sunken text-ink-primary px-3 py-2 text-ui focus:border-accent focus:outline-none transition-colors duration-motion"
             />
           </Field>
-          <Field label="Beschreibung (intern)">
+          <Field label={t("templates.descriptionInternal")}>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={2}
-              placeholder="Wann nutze ich dieses Template?"
+              placeholder={t("templates.descriptionPlaceholder")}
               className="w-full rounded-md border border-line-subtle px-3 py-2 text-sm"
             />
           </Field>
@@ -243,7 +243,7 @@ export default function TemplateEditorPage() {
               onChange={(e) => setBrandingId(e.target.value)}
               className="w-full rounded-md border border-line-subtle px-3 py-2 text-sm bg-surface-raised"
             >
-              <option value="">{t("templates.tenantDefault")}</option>
+              <option value="">{t("studio.brandingTenantDefault")}</option>
               {brandings.map((b) => (
                 <option key={b.id} value={b.id}>
                   {b.name}

--- a/apps/frontend/src/app/studio/templates/page.tsx
+++ b/apps/frontend/src/app/studio/templates/page.tsx
@@ -36,7 +36,7 @@ export default function TemplatesPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-screen text-ui text-ink-tertiary">
-        Lädt…
+        {t("common.loading")}
       </div>
     );
   }
@@ -59,12 +59,10 @@ export default function TemplatesPage() {
         {templates.length === 0 ? (
           <div className="rounded-md border border-dashed border-line-subtle bg-surface-sunken p-12 text-center">
             <div className="text-ink-tertiary text-ui">
-              Noch keine Templates angelegt.
+              {t("templates.emptyTitle")}
             </div>
             <p className="text-ui-xs text-ink-tertiary mt-2 max-w-md mx-auto">
-              Templates sparen Zeit beim Anlegen wiederkehrender
-              Galerie-Typen wie Hochzeit, Newborn oder Portrait —
-              alle Settings werden als Defaults übernommen.
+              {t("templates.emptyHint")}
             </p>
             <button
               onClick={() => setShowCreate(true)}
@@ -187,7 +185,7 @@ function CreateTemplateDialog({
           autoFocus
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder="z.B. Hochzeit, Newborn, Portrait"
+          placeholder={t("templates.namePlaceholder")}
           className="w-full rounded-md border border-line-subtle px-3 py-2 text-sm"
         />
         {error && (
@@ -201,14 +199,14 @@ function CreateTemplateDialog({
             onClick={onClose}
             className="text-sm px-3 py-2 rounded-md border border-line-subtle hover:bg-surface-sunken"
           >
-            Abbrechen
+            {t("common.cancel")}
           </button>
           <button
             type="submit"
             disabled={pending}
             className="text-sm px-3 py-2 rounded-md bg-accent text-accent-contrast hover:bg-accent-hover disabled:opacity-50"
           >
-            {pending ? "Wird erstellt…" : "Erstellen"}
+            {pending ? t("common.creating") : t("common.create")}
           </button>
         </div>
       </form>

--- a/apps/frontend/src/components/gallery/VideoPlayer.tsx
+++ b/apps/frontend/src/components/gallery/VideoPlayer.tsx
@@ -9,6 +9,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { useT } from "@/lib/i18n";
 
 /**
  * Adaptive Video-Player mit sichtbarer Filmstrip-Scrub-Leiste,
@@ -94,6 +95,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     },
     ref
   ) {
+    const t = useT();
     const videoRef = useRef<HTMLVideoElement | null>(null);
     const mediaRef = useRef<HTMLDivElement | null>(null);
     const barRef = useRef<HTMLDivElement | null>(null);
@@ -404,7 +406,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
               onPointerCancel={onPointerUp}
               onPointerLeave={onPointerLeave}
               role="slider"
-              aria-label="Video-Position"
+              aria-label={t("gallery.videoPositionLabel")}
               aria-valuemin={0}
               aria-valuemax={Math.round(duration)}
               aria-valuenow={Math.round(current)}

--- a/apps/frontend/src/components/studio/AppearanceFields.tsx
+++ b/apps/frontend/src/components/studio/AppearanceFields.tsx
@@ -85,7 +85,7 @@ export function OverlayField({
         />
       </label>
       <label className="flex items-center gap-2 text-sm text-ink-secondary flex-1 min-w-[180px]">
-        Stärke
+        {t("appearance.strength")}
         <input
           type="range"
           min={0}
@@ -200,7 +200,7 @@ export function AssetField({
             className={`border rounded text-xs text-center flex items-center justify-center ${previewBg} ${previewCls}`}
             style={previewStyle}
           >
-            <span className={emptyTextCls}>Noch nichts hochgeladen.</span>
+            <span className={emptyTextCls}>{t("appearance.nothingUploadedYet")}</span>
           </div>
         )}
         <div className="flex justify-between items-center gap-2">

--- a/apps/frontend/src/components/studio/DangerZone.tsx
+++ b/apps/frontend/src/components/studio/DangerZone.tsx
@@ -123,16 +123,16 @@ export function DangerZone({
     return (
       <section className="rounded-md border border-semantic-danger/30 bg-semantic-danger/[0.06] p-5 space-y-3">
         <h2 className="text-ui font-medium text-semantic-danger">
-          Studio-Löschung läuft
+          {t("dangerZone.statusHeading")}
         </h2>
         <dl className="grid grid-cols-[200px_1fr] gap-y-2 gap-x-3 text-ui-sm">
           <dt className="text-ink-secondary">Status</dt>
           <dd className="text-ink-primary font-medium">
-            Pending Deletion (Karenzphase)
+            {t("dangerZone.statusPendingLabel")}
           </dd>
           {requestedDate && (
             <>
-              <dt className="text-ink-secondary">Angefordert am</dt>
+              <dt className="text-ink-secondary">{t("dangerZone.requestedOn")}</dt>
               <dd className="text-ink-primary">
                 {requestedDate.toLocaleString("de-DE", {
                   day: "2-digit",
@@ -152,12 +152,12 @@ export function DangerZone({
               year: "numeric",
             })}{" "}
             <span className="text-ink-tertiary">
-              ({daysLeft} {daysLeft === 1 ? "Tag" : "Tage"})
+              ({daysLeft} {daysLeft === 1 ? t("dangerZone.daySingular") : t("dangerZone.dayPlural")})
             </span>
           </dd>
           <dt className="text-ink-secondary">Stripe-Subscription</dt>
           <dd className="text-ink-primary">
-            Gekündigt — bei Reaktivierung manuell neu starten.
+            {t("dangerZone.stripeCancelledNote")}
           </dd>
         </dl>
         <Button

--- a/apps/frontend/src/components/studio/GalleryHeaderEditor.tsx
+++ b/apps/frontend/src/components/studio/GalleryHeaderEditor.tsx
@@ -697,7 +697,7 @@ function RgbaPicker({
         className="h-8 w-12 rounded border border-line-subtle bg-transparent cursor-pointer"
       />
       <label className="text-ui-xs text-ink-tertiary flex items-center gap-1.5">
-        Stärke
+        {t("appearance.strength")}
         <input
           type="range"
           min={0}

--- a/apps/frontend/src/components/studio/MarkdownField.tsx
+++ b/apps/frontend/src/components/studio/MarkdownField.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { useT } from "@/lib/i18n";
 
 /**
  * Markdown-Textarea mit Live-Preview-Toggle.
@@ -42,6 +43,7 @@ export function MarkdownField({
   previewClassName?: string;
 }) {
   const [mode, setMode] = useState<"edit" | "preview">("edit");
+  const t = useT();
 
   return (
     <div className="space-y-1">
@@ -57,7 +59,7 @@ export function MarkdownField({
                 : "bg-surface-raised text-ink-tertiary hover:text-ink-primary"
             }`}
           >
-            Bearbeiten
+            {t("common.edit")}
           </button>
           <button
             type="button"
@@ -69,7 +71,7 @@ export function MarkdownField({
             }`}
             disabled={!value.trim()}
           >
-            Vorschau
+            {t("studio.preview")}
           </button>
         </div>
       </div>
@@ -96,7 +98,7 @@ export function MarkdownField({
             </ReactMarkdown>
           ) : (
             <div className="text-ink-tertiary text-ui-xs italic">
-              Leer — schreibe etwas im Bearbeiten-Modus.
+              {t("common.markdownEmptyPreview")}
             </div>
           )}
         </div>

--- a/apps/frontend/src/components/studio/NotificationSettings.tsx
+++ b/apps/frontend/src/components/studio/NotificationSettings.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
+import { useT } from "@/lib/i18n";
 
 interface NotificationEvent {
   key: string;
@@ -15,6 +16,7 @@ interface NotificationEvent {
  * Lädt und speichert eigenständig; speichert direkt beim Umschalten.
  */
 export function NotificationSettings({ canEdit }: { canEdit: boolean }) {
+  const t = useT();
   const [events, setEvents] = useState<NotificationEvent[]>([]);
   const [prefs, setPrefs] = useState<Record<string, boolean>>({});
   // null = kein Billing aktiviert / keine Subscription → Toggle nicht zeigen
@@ -36,7 +38,7 @@ export function NotificationSettings({ canEdit }: { canEdit: boolean }) {
           setMarketingEnabled(r.marketingEmailsEnabled);
         }
       } catch {
-        setError("Einstellungen konnten nicht geladen werden.");
+        setError(t("notifications.loadError"));
       } finally {
         setLoading(false);
       }
@@ -54,7 +56,7 @@ export function NotificationSettings({ canEdit }: { canEdit: boolean }) {
       setPrefs(r.prefs);
     } catch {
       setPrefs((p) => ({ ...p, [key]: !p[key] }));
-      setError("Speichern fehlgeschlagen.");
+      setError(t("notifications.saveFailed"));
     } finally {
       setSavingKey(null);
     }
@@ -70,7 +72,7 @@ export function NotificationSettings({ canEdit }: { canEdit: boolean }) {
       setMarketingEnabled(r.marketingEmailsEnabled);
     } catch {
       setMarketingEnabled(!next);
-      setError("Speichern fehlgeschlagen.");
+      setError(t("notifications.saveFailed"));
     } finally {
       setMarketingSaving(false);
     }
@@ -80,14 +82,13 @@ export function NotificationSettings({ canEdit }: { canEdit: boolean }) {
     <section className="rounded-lg border border-line-subtle bg-surface-raised p-5 space-y-6">
       {/* Transaktionale Benachrichtigungen */}
       <div>
-        <h2 className="text-lg font-semibold">E-Mail-Benachrichtigungen</h2>
+        <h2 className="text-lg font-semibold">{t("notifications.heading")}</h2>
         <p className="text-ui-sm text-ink-tertiary mt-0.5 mb-4">
-          Wähle, worüber dich Lumio per E-Mail informiert. Mails gehen an den
-          Studio-Owner.
+          {t("notifications.desc")}
         </p>
 
         {loading ? (
-          <div className="text-ui-sm text-ink-tertiary">Lädt…</div>
+          <div className="text-ui-sm text-ink-tertiary">{t("common.loading")}</div>
         ) : (
           <div className="divide-y divide-line-subtle">
             {events.map((e) => {
@@ -116,9 +117,9 @@ export function NotificationSettings({ canEdit }: { canEdit: boolean }) {
                     title={
                       canEdit
                         ? on
-                          ? "Aktiviert"
-                          : "Deaktiviert"
-                        : "Nur Owner/Admin können das ändern"
+                          ? t("notifications.enabledTitle")
+                          : t("notifications.disabledTitle")
+                        : t("notifications.onlyOwnerAdminTitle")
                     }
                   >
                     <span
@@ -138,19 +139,17 @@ export function NotificationSettings({ canEdit }: { canEdit: boolean }) {
       {/* Marketing-Mails (nur wenn Billing aktiv) */}
       {!loading && marketingEnabled !== null && (
         <div className="border-t border-line-subtle pt-5">
-          <h3 className="font-semibold text-ink-primary">Produkt-Mails</h3>
+          <h3 className="font-semibold text-ink-primary">{t("notifications.productMailsHeading")}</h3>
           <p className="text-ui-sm text-ink-tertiary mt-0.5 mb-4">
-            Gelegentliche Hinweise zu deinem Trial oder Abo (z.&nbsp;B.
-            Ablauf-Erinnerung). Kein Newsletter, keine Werbung Dritter.
+            {t("notifications.productMailsDesc")}
           </p>
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0">
               <div className="font-medium text-ink-primary">
-                Produkt- &amp; Lifecycle-Mails
+                {t("notifications.productLifecycleLabel")}
               </div>
               <div className="text-ui-sm text-ink-tertiary">
-                Trial-Reminder, Reaktivierungs-Hinweise. Maximal eine Mail
-                pro Kategorie.
+                {t("notifications.productLifecycleDesc")}
               </div>
             </div>
             <button
@@ -166,9 +165,9 @@ export function NotificationSettings({ canEdit }: { canEdit: boolean }) {
               title={
                 canEdit
                   ? marketingEnabled
-                    ? "Aktiviert"
-                    : "Deaktiviert"
-                  : "Nur Owner/Admin können das ändern"
+                    ? t("notifications.enabledTitle")
+                    : t("notifications.disabledTitle")
+                  : t("notifications.onlyOwnerAdminTitle")
               }
             >
               <span
@@ -187,7 +186,7 @@ export function NotificationSettings({ canEdit }: { canEdit: boolean }) {
       )}
       {!canEdit && !loading && (
         <p className="text-ui-xs text-ink-tertiary">
-          Nur Owner und Admins können Benachrichtigungen ändern.
+          {t("notifications.onlyOwnerAdminChange")}
         </p>
       )}
     </section>

--- a/apps/frontend/src/components/studio/PasskeysSection.tsx
+++ b/apps/frontend/src/components/studio/PasskeysSection.tsx
@@ -51,9 +51,7 @@ export function PasskeysSection() {
 
   async function addPasskey() {
     setError(null);
-    const label = window.prompt(
-      'Bezeichnung für diesen Passkey (z.B. "MacBook" oder "YubiKey #1"):'
-    );
+    const label = window.prompt(t("passkeys.labelPrompt"));
     if (!label || !label.trim()) return;
 
     setAdding(true);
@@ -91,9 +89,7 @@ export function PasskeysSection() {
   }
 
   async function removePasskey(id: string, label: string) {
-    if (
-      !window.confirm(`Passkey "${label}" wirklich entfernen?`)
-    )
+    if (!window.confirm(t("passkeys.removeConfirm", { label })))
       return;
     try {
       await api.deleteWebauthnCredential(id);
@@ -108,8 +104,7 @@ export function PasskeysSection() {
       <section className="rounded-lg border border-line-subtle bg-surface-raised p-5">
         <h2 className="text-sm font-medium">Passkeys</h2>
         <p className="text-xs text-ink-tertiary mt-1">
-          Dieser Browser unterstützt keine WebAuthn-/Passkey-Anmeldung. Auf
-          einem aktuellen Chrome, Safari oder Firefox sollte es funktionieren.
+          {t("passkeys.notSupported")}
         </p>
       </section>
     );
@@ -156,8 +151,9 @@ export function PasskeysSection() {
               <div>
                 <div className="font-medium">{c.label}</div>
                 <div className="text-xs text-ink-tertiary mt-0.5">
-                  Hinzugefügt {formatDate(c.createdAt)}
-                  {c.lastUsedAt && ` · zuletzt verwendet ${formatDate(c.lastUsedAt)}`}
+                  {t("passkeys.addedOn", { date: formatDate(c.createdAt) })}
+                  {c.lastUsedAt &&
+                    t("passkeys.lastUsedOn", { date: formatDate(c.lastUsedAt) })}
                 </div>
               </div>
               <button
@@ -165,7 +161,7 @@ export function PasskeysSection() {
                 onClick={() => removePasskey(c.id, c.label)}
                 className="text-xs text-semantic-danger hover:underline"
               >
-                Entfernen
+                {t("common.remove")}
               </button>
             </li>
           ))}

--- a/apps/frontend/src/components/studio/ProofingPanel.tsx
+++ b/apps/frontend/src/components/studio/ProofingPanel.tsx
@@ -76,7 +76,7 @@ export function ProofingPanel({
           embedded ? "py-16" : "h-screen"
         }`}
       >
-        Lädt…
+        {t("common.loading")}
       </div>
     );
   }
@@ -84,7 +84,7 @@ export function ProofingPanel({
     return (
       <div className="px-6 sm:px-8 lg:px-12 py-6">
         <div className="text-ui text-semantic-danger bg-semantic-danger/10 border border-semantic-danger/30 rounded-sm px-3 py-2 max-w-3xl">
-          {error ?? "Galerie nicht gefunden."}
+          {error ?? t("proofing.notFound")}
         </div>
       </div>
     );
@@ -95,7 +95,7 @@ export function ProofingPanel({
       {!embedded && (
         <PageHeader
           breadcrumb={[
-            { label: "Studio", href: "/studio" },
+            { label: t("nav.studio"), href: "/studio" },
             { label: data.gallery.title, href: `/studio/${data.gallery.id}` },
             { label: t("annotation.selectionOverview") },
           ]}
@@ -164,7 +164,7 @@ export function ProofingPanel({
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 21s-7-4.6-9.5-8.3C.9 10.2 1.5 7 4.3 6c1.9-.7 3.7.2 4.7 1.6C10 6.2 11.8 5.3 13.7 6c2.8 1 3.4 4.2 1.8 6.7C19 16.4 12 21 12 21z" />
                 </svg>
-                Favoriten
+                {t("proofing.favoritesFilter")}
               </button>
               <button
                 type="button"
@@ -187,7 +187,7 @@ export function ProofingPanel({
                 >
                   <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
                 </svg>
-                Kommentare
+                {t("proofing.comments")}
               </button>
               {filterActive && (
                 <button
@@ -242,15 +242,15 @@ export function ProofingPanel({
                           className={`w-3.5 h-3.5 rounded-full border border-white/60 shadow-sm ${colorBg(
                             colorTag
                           )}`}
-                          aria-label={`Farbe: ${colorTag}`}
-                          title={`Farbe: ${colorTag}`}
+                          aria-label={t("proofing.colorBadge", { color: colorTag })}
+                          title={t("proofing.colorBadge", { color: colorTag })}
                         />
                       )}
                       {hasLike && (
                         <span
                           className="w-5 h-5 rounded-full bg-black/55 text-white inline-flex items-center justify-center shadow-sm"
-                          aria-label="Favorit"
-                          title="Favorit"
+                          aria-label={t("proofing.favoriteBadge")}
+                          title={t("proofing.favoriteBadge")}
                         >
                           <svg
                             width="11"
@@ -266,12 +266,16 @@ export function ProofingPanel({
                     {commentCount > 0 && (
                       <span
                         className="absolute bottom-1.5 left-1.5 inline-flex items-center gap-0.5 h-5 px-1.5 rounded-full bg-black/55 text-white text-[10px] font-medium shadow-sm"
-                        aria-label={`${commentCount} Kommentar${
-                          commentCount === 1 ? "" : "e"
-                        }`}
-                        title={`${commentCount} Kommentar${
-                          commentCount === 1 ? "" : "e"
-                        }`}
+                        aria-label={
+                          commentCount === 1
+                            ? t("proofing.commentCountSg", { n: commentCount })
+                            : t("proofing.commentCountPl", { n: commentCount })
+                        }
+                        title={
+                          commentCount === 1
+                            ? t("proofing.commentCountSg", { n: commentCount })
+                            : t("proofing.commentCountPl", { n: commentCount })
+                        }
                       >
                         <svg
                           width="11"
@@ -297,11 +301,11 @@ export function ProofingPanel({
 
         {/* Top-Stats */}
         <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <StatCard label="Dateien" value={data.totals.fileCount} />
-          <StatCard label="Mit Like" value={data.totals.withLike} />
-          <StatCard label="Mit Rating" value={data.totals.withRating} />
+          <StatCard label={t("proofing.files")} value={data.totals.fileCount} />
+          <StatCard label={t("proofing.withLike")} value={data.totals.withLike} />
+          <StatCard label={t("proofing.withRating")} value={data.totals.withRating} />
           <StatCard
-            label="Farb-Tags gesamt"
+            label={t("proofing.colorTags")}
             value={Object.values(data.totals.byLabel).reduce(
               (sum, n) => sum + n,
               0
@@ -312,7 +316,7 @@ export function ProofingPanel({
         {/* Label-Verteilung */}
         {Object.keys(data.totals.byLabel).length > 0 && (
           <section className="rounded-md border border-line-subtle bg-surface-raised p-4">
-            <h2 className="text-ui-md font-medium mb-3">Farb-Tags</h2>
+            <h2 className="text-ui-md font-medium mb-3">{t("proofing.colorTagsHeader")}</h2>
             <div className="flex flex-wrap gap-3">
               {Object.entries(data.totals.byLabel).map(([label, count]) => (
                 <div
@@ -334,15 +338,15 @@ export function ProofingPanel({
         {data.perAccess.length > 0 && (
           <section className="rounded-lg border border-line-subtle bg-surface-raised">
             <h2 className="text-sm font-medium px-4 py-3 border-b border-line-subtle">
-              Beteiligung pro Share-Link
+              {t("proofing.perAccess")}
             </h2>
             <table className="w-full text-sm">
               <thead className="bg-surface-sunken text-xs text-ink-tertiary">
                 <tr>
-                  <th className="text-left px-4 py-2">Bezeichnung</th>
-                  <th className="text-right px-4 py-2">Picks/Likes</th>
-                  <th className="text-right px-4 py-2">Likes</th>
-                  <th className="text-right px-4 py-2">Kommentare</th>
+                  <th className="text-left px-4 py-2">{t("proofing.label")}</th>
+                  <th className="text-right px-4 py-2">{t("proofing.picks")}</th>
+                  <th className="text-right px-4 py-2">{t("proofing.likes")}</th>
+                  <th className="text-right px-4 py-2">{t("proofing.comments")}</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-line-subtle">
@@ -361,11 +365,9 @@ export function ProofingPanel({
 
         {/* Export-Aktionen */}
         <section className="rounded-lg border border-line-subtle bg-surface-raised p-4">
-          <h2 className="text-sm font-medium mb-1">Exporte</h2>
+          <h2 className="text-sm font-medium mb-1">{t("proofing.exports")}</h2>
           <p className="text-xs text-ink-tertiary mb-3">
-            CSV für Tabellenkalkulation, XMP-Sidecars für Lightroom Classic
-            oder Capture One. Lege die XMPs neben deine Original-RAWs, dann
-            in Lightroom <em>Metadaten → Aus Datei lesen</em>.
+            {t("proofing.exportsHint")}
           </p>
           <div className="flex flex-wrap gap-2">
             <a
@@ -373,40 +375,35 @@ export function ProofingPanel({
               className="text-sm px-3 py-1.5 rounded bg-accent text-accent-contrast hover:bg-accent-hover"
               download
             >
-              CSV herunterladen
+              {t("proofing.csv")}
             </a>
             <a
               href={api.xmpExportUrl(data.gallery.id)}
               className="text-sm px-3 py-1.5 rounded bg-accent text-accent-contrast hover:bg-accent-hover"
               download
             >
-              XMP-Sidecars (ZIP)
+              {t("proofing.xmp")}
             </a>
           </div>
           <div className="text-xs text-ink-tertiary mt-3 leading-relaxed">
-            <strong>Hinweis zu Farb-Tags:</strong> Lightroom erkennt
-            Farb-Labels anhand des aktiven Label-Sets. Stelle in Lightroom
-            unter <em>Metadaten → Farbbeschriftungs-Sets</em> auf
-            „Lightroom-Standard" (englisch) — Lumio schreibt „Red"/„Yellow"/
-            „Green". Bei deutschem Label-Set („Rot"/„Gelb"/„Grün") werden
-            die Sterne erkannt, die Farben nicht.
+            {t("proofing.lightroomHint")}
           </div>
         </section>
 
         {/* Files-Liste */}
         <section className="rounded-lg border border-line-subtle bg-surface-raised">
           <h2 className="text-sm font-medium px-4 py-3 border-b border-line-subtle">
-            Dateien
+            {t("proofing.files")}
             {data.fileCountTotal > data.files.length && (
               <span className="text-xs text-ink-tertiary font-normal ml-2">
-                — zeigt {data.files.length} von {data.fileCountTotal}
+                {t("proofing.showingOf", { shown: data.files.length, total: data.fileCountTotal })}
               </span>
             )}
           </h2>
           <table className="w-full text-sm">
             <thead className="bg-surface-sunken text-xs text-ink-tertiary">
               <tr>
-                <th className="text-left px-4 py-2">Datei</th>
+                <th className="text-left px-4 py-2">{t("proofing.fileColumn")}</th>
                 <th className="text-center px-4 py-2">Rating</th>
                 <th className="text-center px-4 py-2">Label</th>
                 <th className="text-center px-4 py-2">Liked</th>
@@ -452,7 +449,7 @@ export function ProofingPanel({
                     colSpan={5}
                     className="px-4 py-6 text-center text-sm text-ink-tertiary"
                   >
-                    Noch keine Auswahl von Kunden.
+                    {t("proofing.noClientSelection")}
                   </td>
                 </tr>
               )}

--- a/apps/frontend/src/components/studio/SectionsEditor.tsx
+++ b/apps/frontend/src/components/studio/SectionsEditor.tsx
@@ -283,13 +283,13 @@ function SectionRow({
                   color: section.autoTag.color,
                   border: `1px solid ${section.autoTag.color}55`,
                 }}
-                title={`Smart-Section: befüllt sich aus Tag "${section.autoTag.name}"`}
+                title={t("studio.sectionSmartTitle", { name: section.autoTag.name })}
               >
                 <span
                   className="inline-block w-1.5 h-1.5 rounded-full"
                   style={{ backgroundColor: section.autoTag.color }}
                 />
-                Auto: {section.autoTag.name}
+                {t("studio.sectionAutoPrefix", { name: section.autoTag.name })}
               </span>
             )}
           </div>
@@ -496,7 +496,7 @@ function SectionEditForm({
           Section verschoben (und nicht-passende raus). */}
       <div className="pt-2 border-t border-line-subtle">
         <label className="block text-ui-xs text-ink-tertiary mb-1">
-          Smart-Section (aus Tag befüllen)
+          {t("studio.sectionSmartLabel")}
         </label>
         <div className="flex items-center gap-2">
           <select
@@ -555,7 +555,7 @@ function SectionEditForm({
           disabled={saving}
           className="text-ui-sm h-8 px-3 rounded text-ink-secondary hover:text-ink-primary hover:bg-surface-overlay disabled:opacity-50 transition-colors duration-motion"
         >
-          {t("studio.cancel")}
+          {t("common.cancel")}
         </button>
         <button
           type="button"
@@ -563,7 +563,7 @@ function SectionEditForm({
           disabled={saving}
           className="text-ui-sm h-8 px-3 rounded bg-accent text-accent-contrast hover:bg-accent-hover disabled:opacity-50 transition-colors duration-motion"
         >
-          {saving ? "…" : t("studio.save")}
+          {saving ? "…" : t("common.save")}
         </button>
       </div>
     </div>

--- a/apps/frontend/src/components/studio/SharePanel.tsx
+++ b/apps/frontend/src/components/studio/SharePanel.tsx
@@ -183,7 +183,7 @@ export function SharePanel({
         // die neuen Adressen zeigt
         if (payload.updateDefaults) void load();
       } else {
-        alert("Einladung konnte nicht verschickt werden.");
+        alert(t("share.inviteFailed"));
       }
     } catch (err) {
       alert(

--- a/apps/frontend/src/components/studio/StudioShell.tsx
+++ b/apps/frontend/src/components/studio/StudioShell.tsx
@@ -130,17 +130,17 @@ interface NavItem {
 }
 
 const NAV: NavItem[] = [
-  { href: "/studio",            labelKey: "nav.galleries",  fallback: "Galerien",      icon: "galleries",  prefix: "/studio" },
+  { href: "/studio",            labelKey: "nav.galleries",  fallback: "Galleries",     icon: "galleries",  prefix: "/studio" },
   { href: "/studio/analytics",  labelKey: "nav.analytics",  fallback: "Analytics",     icon: "analytics",  prefix: "/studio/analytics",  rolesAllowed: ["owner", "admin"], requiresFeature: "advanced_analytics" },
-  { href: "/studio/print-shop", labelKey: "nav.printShop",  fallback: "Print-Shop",    icon: "print",      prefix: "/studio/print-shop", rolesAllowed: ["owner", "admin"], requiresFeature: "print_shop" },
+  { href: "/studio/print-shop", labelKey: "nav.printShop",  fallback: "Print shop",    icon: "print",      prefix: "/studio/print-shop", rolesAllowed: ["owner", "admin"], requiresFeature: "print_shop" },
   // Sammeleintrag „Gestaltung" → Tabs: Branding · Templates · Tags
-  { href: "/studio/brandings",  labelKey: "nav.design",     fallback: "Gestaltung",    icon: "design",     prefix: "/studio/brandings",
+  { href: "/studio/brandings",  labelKey: "nav.design",     fallback: "Design",        icon: "design",     prefix: "/studio/brandings",
     matchPrefixes: ["/studio/brandings", "/studio/templates", "/studio/tags", "/studio/appearance"] },
   // Sammeleintrag „Einstellungen" → Tabs: Allgemein · Team · Integrationen · Datenexport · Audit · AV-Vertrag
-  { href: "/studio/settings",   labelKey: "nav.settings",   fallback: "Einstellungen", icon: "settings",   prefix: "/studio/settings",
+  { href: "/studio/settings",   labelKey: "nav.settings",   fallback: "Settings",      icon: "settings",   prefix: "/studio/settings",
     matchPrefixes: ["/studio/settings", "/studio/team", "/studio/webhooks", "/studio/exports", "/studio/audit", "/studio/avv"] },
   // Sammeleintrag „Konto" → Tabs: Mein Konto · Plan & Speicher
-  { href: "/studio/account",    labelKey: "nav.accountGroup", fallback: "Konto",       icon: "account",    prefix: "/studio/account",
+  { href: "/studio/account",    labelKey: "nav.accountGroup", fallback: "Account",     icon: "account",    prefix: "/studio/account",
     matchPrefixes: ["/studio/account", "/studio/billing"] },
 ];
 
@@ -302,7 +302,7 @@ export function StudioShell({ children }: { children: React.ReactNode }) {
                 /* eslint-disable-next-line @next/next/no-img-element */
                 <img
                   src={logo}
-                  alt="Studio-Logo"
+                  alt={t("nav.studioLogoAlt")}
                   className="h-7 max-w-[150px] object-contain"
                 />
               ) : (
@@ -530,7 +530,7 @@ function SidebarFooter({
 
   const logoutLabel = (() => {
     const translated = t("nav.logout");
-    return translated === "nav.logout" ? "Abmelden" : translated;
+    return translated === "nav.logout" ? "Logout" : translated;
   })();
 
   return (

--- a/apps/frontend/src/components/studio/TwoFactorSection.tsx
+++ b/apps/frontend/src/components/studio/TwoFactorSection.tsx
@@ -288,7 +288,7 @@ function BackupCodesPanel({
           onClick={copyAll}
           className="text-xs px-2 py-1 rounded border border-line-subtle hover:bg-surface-sunken"
         >
-          {copied ? "✓ kopiert" : "Kopieren"}
+          {copied ? t("settings.copiedAllCodes") : t("settings.copyAllCodes")}
         </button>
         <button
           onClick={onDone}

--- a/apps/frontend/src/lib/i18n/de.ts
+++ b/apps/frontend/src/lib/i18n/de.ts
@@ -49,6 +49,7 @@ export const de: Dict = {
     remove: "Entfernen",
     upload: "Hochladen",
     replace: "Ersetzen",
+    markdownEmptyPreview: "Leer — schreibe etwas im Bearbeiten-Modus.",
   },
 
   nav: {
@@ -69,6 +70,7 @@ export const de: Dict = {
     menuOpen: "Menü öffnen",
     menuClose: "Menü schließen",
     logout: "Abmelden",
+    studioLogoAlt: "Studio-Logo",
   },
 
   subtabs: {
@@ -168,6 +170,11 @@ export const de: Dict = {
     firstGallery: "Erste Galerie erstellen →",
     files: "Dateien",
     liked: "geliked",
+    loggedInAs: "Angemeldet als {name}",
+    deleteActiveCollection: "Aktive löschen",
+    resetFilters: "Filter zurücksetzen",
+    statsVisitsTooltip: "Besuche",
+    statsLikesTooltip: "Favoriten",
 
     // Gallery detail page
     proofingLink: "Auswahl-Übersicht →",
@@ -310,6 +317,9 @@ export const de: Dict = {
     sectionAvailableEmpty: "Alle Bilder sind bereits zugeordnet.",
     sectionRemoveFromChapter: "Aus dem Kapitel entfernen",
     sectionAddToChapter: "In dieses Kapitel verschieben",
+    sectionSmartTitle: 'Smart-Section: befüllt sich aus Tag "{name}"',
+    sectionAutoPrefix: "Auto: {name}",
+    sectionSmartLabel: "Smart-Section (aus Tag befüllen)",
     eventLogo: "Event-Logo",
     eventLogoHint:
       "Klein über dem Galerie-Titel sichtbar. Z.B. Hochzeitsmonogramm oder Event-Branding. PNG mit transparentem Hintergrund empfohlen.",
@@ -566,6 +576,7 @@ export const de: Dict = {
     cleanupFailedMessage:
       "Diese Dateien konnten nicht verarbeitet werden — z.B. wegen ungültigen Formaten oder Worker-Fehlern. File-Records werden entfernt und ggf. vorhandene S3-Objekte mit.",
     modeLabel: "Modus",
+    filterAndNote: "Galerien müssen alle gesetzten Bedingungen erfüllen.",
     modeSelection: "Auswahl / Proofing",
     modeSelectionDesc: "Kunde kann Medien auswählen, kommentieren und markieren.",
     modePresentation: "Präsentation",
@@ -614,9 +625,11 @@ export const de: Dict = {
     lbZoomInTitle: "Vergrößern (+)",
     lbActualSize: "Originalgröße",
     lbActualSizeTitle: "Originalgröße (0)",
+    lbNoPreview: "Keine Vorschau verfügbar",
   },
 
   gallery: {
+    videoPositionLabel: "Video-Position",
     locked: "Diese Galerie ist passwortgeschützt.",
     open: "Galerie öffnen",
     password: "Passwort",
@@ -738,6 +751,15 @@ export const de: Dict = {
   },
 
   proofing: {
+    notFound: "Galerie nicht gefunden.",
+    favoritesFilter: "Favoriten",
+    favoriteBadge: "Favorit",
+    colorBadge: "Farbe: {color}",
+    commentCountSg: "{n} Kommentar",
+    commentCountPl: "{n} Kommentare",
+    showingOf: "— zeigt {shown} von {total}",
+    fileColumn: "Datei",
+    noClientSelection: "Noch keine Auswahl von Kunden.",
     title: "Auswahl-Übersicht",
     files: "Dateien",
     withLike: "Mit Like",
@@ -790,6 +812,8 @@ export const de: Dict = {
     twoFactorBackup:
       "Speichere diese Backup-Codes an einem sicheren Ort. Jeder lässt sich einmalig nutzen, falls du keinen Zugriff mehr aufs Gerät hast.",
     twoFactorBackupSaved: "Ich habe die Codes gespeichert",
+    copyAllCodes: "Kopieren",
+    copiedAllCodes: "✓ kopiert",
     twoFactorConfirmDisable:
       "Bestätige mit einem aktuellen Code, um 2FA zu deaktivieren:",
     slugChangeError: "Studio-Adresse konnte nicht geändert werden",
@@ -1074,6 +1098,8 @@ export const de: Dict = {
     confirmationSentTo:
       "Eine Bestätigungsmail wurde an {email} geschickt. Klick den Link in der Mail, um den Wechsel abzuschließen.",
     changeEmail: "E-Mail-Adresse ändern",
+    changeEmailSecurityNote:
+      "Aus Sicherheitsgründen brauchen wir dein aktuelles Passwort. Wir schicken einen Bestätigungslink an die neue Adresse — erst danach ist der Wechsel aktiv.",
     newEmail: "Neue E-Mail-Adresse",
     currentPassword: "Aktuelles Passwort",
     requesting: "Wird angefordert…",
@@ -1097,6 +1123,11 @@ export const de: Dict = {
     descAdmin:
       "User dieses Studios. Als Admin kannst du Mitglieder einladen und verwalten — Owner-Rollen bleiben dem Owner vorbehalten.",
     inviteUser: "User einladen",
+    inviteDesc:
+      "Der eingeladene User erhält eine E-Mail mit einem Setup-Link (gültig 72 Stunden) und kann sich danach mit eigenem Passwort einloggen.",
+    roleAdminDesc: "Admin — kann Galerien und Team verwalten",
+    roleOwnerDesc: "Owner — kann zusätzlich Owner-Rollen vergeben",
+    roleMemberDesc: "Member — eingeschränkter Zugriff",
     fieldName: "Name",
     fieldEmail: "E-Mail",
     fieldRole: "Rolle",
@@ -1214,6 +1245,9 @@ export const de: Dict = {
   },
 
   appearance: {
+    saveFailed: "Speichern fehlgeschlagen",
+    strength: "Stärke",
+    nothingUploadedYet: "Noch nichts hochgeladen.",
     studioColorHex: "Studio-Akzentfarbe muss ein Hex-Wert sein, z.B. #3a87fe",
     loginColorHex: "Login-Akzentfarbe muss ein Hex-Wert sein, z.B. #3a87fe",
     title: "Studio & Login",
@@ -1286,6 +1320,12 @@ export const de: Dict = {
   dangerZone: {
     nameMismatch: "Der eingegebene Studio-Name stimmt nicht.",
     finalDeletion: "Endgültige Löschung",
+    statusHeading: "Studio-Löschung läuft",
+    statusPendingLabel: "Pending Deletion (Karenzphase)",
+    requestedOn: "Angefordert am",
+    stripeCancelledNote: "Gekündigt — bei Reaktivierung manuell neu starten.",
+    daySingular: "Tag",
+    dayPlural: "Tage",
     wrongPassword: "Passwort ist nicht korrekt.",
     title: "Studio löschen",
     description:
@@ -1389,6 +1429,8 @@ export const de: Dict = {
   },
 
   printSettings: {
+    disconnectConfirm:
+      "Stripe-Connect-Account wirklich trennen? Du kannst danach keine Online-Bestellungen mehr empfangen.",
     onboardingIncomplete:
       "Stripe-Onboarding ist noch unvollständig. Klicke nochmal auf 'Einrichten'.",
     syncFailed: "Sync fehlgeschlagen",
@@ -2083,6 +2125,12 @@ export const de: Dict = {
     none: "Noch keine Passkeys registriert.",
     add: "Passkey hinzufügen",
     addError: "Passkey konnte nicht hinzugefügt werden.",
+    labelPrompt: 'Bezeichnung für diesen Passkey (z.B. "MacBook" oder "YubiKey #1"):',
+    removeConfirm: 'Passkey "{label}" wirklich entfernen?',
+    notSupported:
+      "Dieser Browser unterstützt keine WebAuthn-/Passkey-Anmeldung. Auf einem aktuellen Chrome, Safari oder Firefox sollte es funktionieren.",
+    addedOn: "Hinzugefügt {date}",
+    lastUsedOn: " · zuletzt verwendet {date}",
   },
 
   bulkSel: {
@@ -2114,6 +2162,9 @@ export const de: Dict = {
     draft: "Entwurf",
     active: "Aktiv",
     archived: "Archiviert",
+    filterAndNote:
+      "Alle Filter sind UND-verknüpft — eine Galerie muss alle gesetzten Bedingungen erfüllen um in der Collection zu erscheinen.",
+    tagsAllRequired: "Tags (alle gewählten müssen vorhanden sein)",
   },
   templates: {
     watermarkActive: "Wasserzeichen aktiv",
@@ -2125,6 +2176,14 @@ export const de: Dict = {
     deleteConfirm: "Template löschen? Bereits angelegte Galerien sind nicht betroffen.",
     defaultDescLabel: "Default-Beschreibung für neue Galerien",
     defaultDescPlaceholder: "Wird als Default-Text in die Galerie übernommen — pro Galerie editierbar.",
+    notFound: "Template nicht gefunden.",
+    descriptionInternal: "Beschreibung (intern)",
+    descriptionPlaceholder: "Wann nutze ich dieses Template?",
+    emptyTitle: "Noch keine Templates angelegt.",
+    emptyHint:
+      "Templates sparen Zeit beim Anlegen wiederkehrender Galerie-Typen wie Hochzeit, Newborn oder Portrait — alle Settings werden als Defaults übernommen.",
+    namePlaceholder: "z.B. Hochzeit, Newborn, Portrait",
+    days: "Tage",
   },
   impersonate: {
     noToken: "Kein Token im Link.",
@@ -2353,5 +2412,21 @@ export const de: Dict = {
   },
   announcement: {
     dismiss: "Banner ausblenden",
+  },
+  notifications: {
+    loadError: "Einstellungen konnten nicht geladen werden.",
+    saveFailed: "Speichern fehlgeschlagen.",
+    heading: "E-Mail-Benachrichtigungen",
+    desc: "Wähle, worüber dich Lumio per E-Mail informiert. Mails gehen an den Studio-Owner.",
+    enabledTitle: "Aktiviert",
+    disabledTitle: "Deaktiviert",
+    onlyOwnerAdminTitle: "Nur Owner/Admin können das ändern",
+    productMailsHeading: "Produkt-Mails",
+    productMailsDesc:
+      "Gelegentliche Hinweise zu deinem Trial oder Abo (z. B. Ablauf-Erinnerung). Kein Newsletter, keine Werbung Dritter.",
+    productLifecycleLabel: "Produkt- & Lifecycle-Mails",
+    productLifecycleDesc:
+      "Trial-Reminder, Reaktivierungs-Hinweise. Maximal eine Mail pro Kategorie.",
+    onlyOwnerAdminChange: "Nur Owner und Admins können Benachrichtigungen ändern.",
   },
 };

--- a/apps/frontend/src/lib/i18n/en.ts
+++ b/apps/frontend/src/lib/i18n/en.ts
@@ -47,6 +47,7 @@ export const en: Dict = {
     remove: "Remove",
     upload: "Upload",
     replace: "Replace",
+    markdownEmptyPreview: "Empty — write something in edit mode.",
   },
 
   nav: {
@@ -67,6 +68,7 @@ export const en: Dict = {
     menuOpen: "Open menu",
     menuClose: "Close menu",
     logout: "Logout",
+    studioLogoAlt: "Studio logo",
   },
 
   subtabs: {
@@ -166,6 +168,11 @@ export const en: Dict = {
     firstGallery: "Create first gallery →",
     files: "Files",
     liked: "liked",
+    loggedInAs: "Logged in as {name}",
+    deleteActiveCollection: "Delete active",
+    resetFilters: "Reset filters",
+    statsVisitsTooltip: "Visits",
+    statsLikesTooltip: "Likes",
 
     // Gallery detail page
     proofingLink: "Selection overview →",
@@ -308,6 +315,9 @@ export const en: Dict = {
     sectionAvailableEmpty: "All images already assigned.",
     sectionRemoveFromChapter: "Remove from chapter",
     sectionAddToChapter: "Add to this chapter",
+    sectionSmartTitle: 'Smart section: fills from tag "{name}"',
+    sectionAutoPrefix: "Auto: {name}",
+    sectionSmartLabel: "Smart section (fill from tag)",
     eventLogo: "Event logo",
     eventLogoHint:
       "Small, shown above the gallery title. E.g. wedding monogram or event branding. PNG with transparent background recommended.",
@@ -564,6 +574,7 @@ export const en: Dict = {
     cleanupFailedMessage:
       "These files could not be processed — e.g. due to invalid formats or worker errors. File records are removed, along with any existing S3 objects.",
     modeLabel: "Mode",
+    filterAndNote: "Galleries must satisfy all set conditions.",
     modeSelection: "Selection / Proofing",
     modeSelectionDesc: "The client can select, comment on and flag media.",
     modePresentation: "Presentation",
@@ -612,9 +623,11 @@ export const en: Dict = {
     lbZoomInTitle: "Zoom in (+)",
     lbActualSize: "Actual size",
     lbActualSizeTitle: "Actual size (0)",
+    lbNoPreview: "No preview available",
   },
 
   gallery: {
+    videoPositionLabel: "Video position",
     locked: "This gallery is password-protected.",
     open: "Open gallery",
     password: "Password",
@@ -735,6 +748,15 @@ export const en: Dict = {
   },
 
   proofing: {
+    notFound: "Gallery not found.",
+    favoritesFilter: "Favorites",
+    favoriteBadge: "Favorite",
+    colorBadge: "Color: {color}",
+    commentCountSg: "{n} comment",
+    commentCountPl: "{n} comments",
+    showingOf: "— showing {shown} of {total}",
+    fileColumn: "File",
+    noClientSelection: "No client selection yet.",
     title: "Selection overview",
     files: "Files",
     withLike: "With like",
@@ -786,6 +808,8 @@ export const en: Dict = {
     twoFactorBackup:
       "Save these backup codes in a safe place. Each can be used once if you lose access to your device.",
     twoFactorBackupSaved: "I've saved the codes",
+    copyAllCodes: "Copy",
+    copiedAllCodes: "✓ Copied",
     twoFactorConfirmDisable: "Confirm with a current code to disable 2FA:",
     slugChangeError: "The studio address could not be changed",
     domainInUse: "This domain is already in use.",
@@ -1069,6 +1093,8 @@ export const en: Dict = {
     confirmationSentTo:
       "A confirmation email was sent to {email}. Click the link in the email to complete the change.",
     changeEmail: "Change email address",
+    changeEmailSecurityNote:
+      "For security reasons we need your current password. We'll send a confirmation link to the new address — the change only takes effect after that.",
     newEmail: "New email address",
     currentPassword: "Current password",
     requesting: "Requesting…",
@@ -1092,6 +1118,11 @@ export const en: Dict = {
     descAdmin:
       "Users of this studio. As an admin you can invite and manage members — owner roles are reserved for the owner.",
     inviteUser: "Invite user",
+    inviteDesc:
+      "The invited user receives an email with a setup link (valid 72 hours) and can then sign in with their own password.",
+    roleAdminDesc: "Admin — can manage galleries and team",
+    roleOwnerDesc: "Owner — can additionally grant owner roles",
+    roleMemberDesc: "Member — restricted access",
     fieldName: "Name",
     fieldEmail: "Email",
     fieldRole: "Role",
@@ -1207,6 +1238,9 @@ export const en: Dict = {
   },
 
   appearance: {
+    saveFailed: "Saving failed",
+    strength: "Strength",
+    nothingUploadedYet: "Nothing uploaded yet.",
     studioColorHex: "Studio accent color must be a hex value, e.g. #3a87fe",
     loginColorHex: "Login accent color must be a hex value, e.g. #3a87fe",
     title: "Studio & login",
@@ -1279,6 +1313,12 @@ export const en: Dict = {
   dangerZone: {
     nameMismatch: "The entered studio name does not match.",
     finalDeletion: "Final deletion",
+    statusHeading: "Studio deletion in progress",
+    statusPendingLabel: "Pending deletion (grace period)",
+    requestedOn: "Requested on",
+    stripeCancelledNote: "Cancelled — restart manually upon reactivation.",
+    daySingular: "day",
+    dayPlural: "days",
     wrongPassword: "Password is not correct.",
     title: "Delete studio",
     description:
@@ -1382,6 +1422,8 @@ export const en: Dict = {
   },
 
   printSettings: {
+    disconnectConfirm:
+      "Really disconnect the Stripe Connect account? You won't be able to receive online orders afterwards.",
     onboardingIncomplete:
       "Stripe onboarding is still incomplete. Click 'Set up' again.",
     syncFailed: "Sync failed",
@@ -2076,6 +2118,12 @@ export const en: Dict = {
     none: "No passkeys registered yet.",
     add: "Add passkey",
     addError: "Passkey could not be added.",
+    labelPrompt: 'Label for this passkey (e.g. "MacBook" or "YubiKey #1"):',
+    removeConfirm: 'Really remove passkey "{label}"?',
+    notSupported:
+      "This browser doesn't support WebAuthn/passkey sign-in. It should work on a current Chrome, Safari or Firefox.",
+    addedOn: "Added {date}",
+    lastUsedOn: " · last used {date}",
   },
 
   bulkSel: {
@@ -2107,6 +2155,9 @@ export const en: Dict = {
     draft: "Draft",
     active: "Active",
     archived: "Archived",
+    filterAndNote:
+      "All filters are AND-combined — a gallery must satisfy every set condition to appear in the collection.",
+    tagsAllRequired: "Tags (all selected must be present)",
   },
   templates: {
     watermarkActive: "Watermark active",
@@ -2118,6 +2169,14 @@ export const en: Dict = {
     deleteConfirm: "Delete template? Galleries already created are not affected.",
     defaultDescLabel: "Default description for new galleries",
     defaultDescPlaceholder: "Used as default text in the gallery — editable per gallery.",
+    notFound: "Template not found.",
+    descriptionInternal: "Description (internal)",
+    descriptionPlaceholder: "When do I use this template?",
+    emptyTitle: "No templates created yet.",
+    emptyHint:
+      "Templates save time creating recurring gallery types like wedding, newborn or portrait — all settings are used as defaults.",
+    namePlaceholder: "e.g. Wedding, Newborn, Portrait",
+    days: "days",
   },
   impersonate: {
     noToken: "No token in the link.",
@@ -2346,5 +2405,21 @@ export const en: Dict = {
   },
   announcement: {
     dismiss: "Dismiss banner",
+  },
+  notifications: {
+    loadError: "Settings could not be loaded.",
+    saveFailed: "Saving failed.",
+    heading: "Email notifications",
+    desc: "Choose what Lumio notifies you about by email. Emails go to the studio owner.",
+    enabledTitle: "Enabled",
+    disabledTitle: "Disabled",
+    onlyOwnerAdminTitle: "Only owner/admin can change this",
+    productMailsHeading: "Product emails",
+    productMailsDesc:
+      "Occasional notes about your trial or subscription (e.g. expiry reminder). No newsletter, no third-party ads.",
+    productLifecycleLabel: "Product & lifecycle emails",
+    productLifecycleDesc:
+      "Trial reminders, reactivation notices. Maximum one email per category.",
+    onlyOwnerAdminChange: "Only owners and admins can change notifications.",
   },
 };


### PR DESCRIPTION
Part 2/4 of #4 (see #7 for 1/4 — public/auth pages). Same approach: literal German text moved into the dictionary, new keys added to **both** `en.ts` and `de.ts`, existing keys reused wherever an exact match already existed instead of adding duplicates.

## Scope

Studio backend pages (galleries list + detail, account, appearance, billing, collections, print shop products/providers/settings, team, templates) and shared components used across them: `NotificationSettings`, `PasskeysSection`, `ProofingPanel`, `SectionsEditor`, `DangerZone`, `MarkdownField`, `SharePanel`, `TwoFactorSection`, `AppearanceFields`, `GalleryHeaderEditor`, `StudioShell` nav, and the gallery `VideoPlayer`. A few of these (`NotificationSettings`, `ProofingPanel`) had essentially zero `t()` usage before this — every visible string was a literal.

## Bonus fixes found along the way

While verifying key coverage I found three **pre-existing** broken references — not introduced by this PR, but real bugs: `SectionsEditor.tsx` called `t("studio.cancel")` / `t("studio.save")` and the template editor called `t("templates.tenantDefault")`. None of those keys exist in either dictionary, so users were seeing the literal key string (`studio.cancel`) rendered as button text, in **any** language. Fixed by pointing at the correct existing keys (`common.cancel`/`common.save`, `studio.brandingTenantDefault`).

Also: `StudioShell`'s nav fallback strings (used only if a dictionary lookup ever fails) were hardcoded in German — inconsistent with the app's English-default fallback chain described in `lib/i18n.tsx`. Switched to English.

## Out of scope here

`de-DE`-hardcoded date/number formatting in these same files (e.g. `DangerZone.tsx`, `PasskeysSection.tsx`) is left as-is — that's part 4/4 along with the `document.lang` sync, since it needs locale-aware `Intl` plumbing rather than a dictionary swap, and mixing the two concerns in one diff seemed harder to review.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `next build` (production build succeeds)
- [x] Every `t()` call touched or added in this diff verified **programmatically** against both `en.ts` and `de.ts` — 805 distinct key paths across the 25 changed files, zero unresolved in either dictionary (catches typos/wrong-section references that `tsc` can't, since `t()` takes a plain string)
- [x] Dev server smoke test in English and German — no console/page errors

Part of #4