### PR TITLE
docs: add Italian translation

### DIFF
--- a/CONTRIBUTING.de.md
+++ b/CONTRIBUTING.de.md
@@ -1,4 +1,4 @@
-[English](CONTRIBUTING.md) · **Deutsch**
+[English](CONTRIBUTING.md) · **Deutsch** · [Italiano](CONTRIBUTING.it.md)
 
 # Contributing to Lumio
 

--- a/CONTRIBUTING.it.md
+++ b/CONTRIBUTING.it.md
@@ -1,0 +1,115 @@
+[English](CONTRIBUTING.md) · [Deutsch](CONTRIBUTING.de.md) · **Italiano**
+
+# Contribuire a Lumio
+
+Grazie per voler contribuire!
+
+## Avvio rapido
+
+1. Leggi un issue o aprine uno nuovo prima di lavorare a modifiche più grandi.
+2. Fai un fork del repo, nuovo branch (`feat/your-feature` o `fix/your-fix`).
+3. `cp .env.example .env`, `docker compose up -d` — vedi [docs/DEVELOPMENT.md](docs/DEVELOPMENT.it.md).
+4. Scrivi codice, aggiungi test dove ha senso.
+5. Pull request con una descrizione chiara.
+
+## Cosa ci piace vedere
+
+- **Bug fix** con un caso di test riproducibile
+- **Miglioramenti di performance** con misurazioni prima/dopo
+- **Traduzioni** — vedi [Aggiungere una traduzione](#aggiungere-una-traduzione)
+- **Documentazione** — anche piccole correzioni di refusi
+- **Test di formati RAW** — se hai una fotocamera insolita, i file di esempio valgono oro
+
+## Convenzioni di codice
+
+- **TypeScript**: strict mode, niente `any` senza giustificazione
+- **Python**: PEP 8, type hints, ruff per il linting
+- **Commit**: Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`)
+- **Titoli delle PR**: stessa convenzione dei commit
+
+## Nota sulla licenza
+
+Lumio è sotto la **Functional Source License 1.1 (FSL-1.1-ALv2)** — una licenza *source-available* (non open source OSI). Contribuendo, accetti che il tuo codice venga pubblicato sotto questa licenza.
+
+Se in futuro dovesse essere offerta una dual license commerciale per fork proprietari, ci riserviamo il diritto a un DCO o CLA per contributi significativi — se ne discuterà quando diventerà rilevante in pratica.
+
+## Politica linguistica
+
+**L'inglese è la lingua primaria del progetto. Il tedesco è una traduzione.**
+
+Questo vale per:
+
+- **UI del frontend** — `en.ts` è il dizionario di riferimento. Le nuove chiavi
+  vengono aggiunte prima a `en.ts`, poi a `de.ts` e a ogni altra lingua.
+  L'inglese è la locale predefinita e il fallback per le chiavi mancanti.
+- **Commenti nel codice e identificatori** — i nuovi commenti sono in inglese. I commenti
+  tedeschi esistenti vengono riscritti in modo opportunistico quando un file viene
+  comunque toccato; nessun commit separato di riscrittura di massa.
+- **Messaggi di commit e descrizioni delle PR** — inglese.
+- **Documentazione** — l'inglese è il `.md` canonico, il tedesco vive in `*.de.md`.
+- **Formattazione dipendente dalla locale** — date, numeri, valute e ordinamento
+  seguono la locale *attiva* dell'interfaccia. Non hardcodare mai un identificatore
+  di locale come `"de-DE"` in `Intl.*`, `toLocaleDateString`, `toLocaleString` o
+  `localeCompare`.
+
+### Eccezioni deliberate
+
+Queste restano tedesco-first, di proposito:
+
+- **Le email transazionali inviate dall'API.** I destinatari sono i *clienti finali*
+  di uno studio, non l'operatore dello studio. La loro lingua segue lo studio, non
+  il nostro default. Finché non esisterà una locale per tenant, i template in
+  `apps/api/src/services/mail*.ts` restano in tedesco — passarli all'inglese
+  sarebbe un regresso per ogni studio tedesco esistente.
+- **L'accordo sul trattamento dei dati** (`apps/api/src/services/dpa.ts`). È un
+  contratto ai sensi dell'Art. 28 GDPR tra due soggetti giuridici tedeschi; la
+  versione tedesca è quella vincolante. Una versione inglese può essere *aggiunta*
+  in seguito, ma sarebbe una traduzione non vincolante e richiederebbe la revisione
+  di un responsabile della protezione dei dati.
+- **I siti marketing tedeschi** (`lumio-app.de`, `lumio-cloud.de`). Si rivolgono
+  al mercato tedesco e sono repository separati. Solo `lumio-cloud.com` è
+  inglese-first.
+- Le voci di **`CHANGELOG.md`** sono bilingue, testo tedesco prima, poi un
+  separatore `**🇬🇧 English**`. È un vincolo del tooling di release, non
+  un'affermazione sulla priorità linguistica.
+
+## Aggiungere una traduzione
+
+Le stringhe dell'UI del frontend vivono come dizionari TypeScript in
+`apps/frontend/src/lib/i18n/` — nessun servizio di localizzazione esterno, solo file semplici.
+
+Per aggiungere una nuova lingua (esempio: ceco, `cs`):
+
+1. **Copia `en.ts` in `cs.ts`** in `apps/frontend/src/lib/i18n/` e traduci i
+   valori. Mantieni ogni chiave e la struttura di nesting esattamente come in `en.ts` —
+   il tipo `Dict` permette solo valori stringa, e le chiavi mancanti ricadono sull'inglese.
+2. **Registra la locale in `dict.ts`**: aggiungi l'import, estendi il
+   tipo `Locale` (`"en" | "de" | "cs"`) e aggiungi la voce a `dictionaries`.
+3. **Aggiungi la locale a `SUPPORTED`** in `apps/frontend/src/lib/i18n.tsx` così che
+   il rilevamento via cookie/`navigator.language` la intercetti.
+4. **Aggiorna i selettori di lingua.** Alcuni componenti portano l'unione delle
+   locale e le etichette leggibili direttamente. Trovali con:
+   ```bash
+   grep -rn '"en" | "de"' apps/frontend/src
+   ```
+   (attualmente `components/gallery/GalleryShell.tsx` e
+   `app/studio/settings/page.tsx`) e aggiungi lì la tua lingua.
+5. **Verifica**: `npx tsc --noEmit` in `apps/frontend` deve passare — il sistema
+   di tipi individua chiavi mancanti o in eccesso.
+
+Le traduzioni parziali vanno bene per una prima PR — le chiavi non tradotte
+ricadono sull'inglese. Segnala nella PR quali sezioni mancano ancora.
+
+La documentazione (`docs/*.md`) segue una convenzione separata: l'inglese è il
+`.md` canonico, il tedesco vive in `*.de.md`. Altre lingue per la documentazione
+sono benvenute, ma apri prima un issue così da concordare lo schema dei nomi.
+
+## Codice di condotta
+
+Sii gentile. Sii specifico. Sii paziente. Costruiamo tutto questo nel nostro tempo libero o a margine di altro — il rispetto reciproco lo rende molto più piacevole.
+
+Attacchi personali, discriminazione o spam portano all'esclusione.
+
+## Domande?
+
+Apri un issue o scrivi nella sezione Discussions del repository GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](CONTRIBUTING.de.md)
+**English** · [Deutsch](CONTRIBUTING.de.md) · [Italiano](CONTRIBUTING.it.md)
 
 # Contributing to Lumio
 

--- a/README.de.md
+++ b/README.de.md
@@ -1,4 +1,4 @@
-[English](README.md) · **Deutsch**
+[English](README.md) · **Deutsch** · [Italiano](README.it.md)
 
 <p align="center">
   <picture>

--- a/README.it.md
+++ b/README.it.md
@@ -1,0 +1,252 @@
+[English](README.md) · [Deutsch](README.de.md) · **Italiano**
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="brand/readme/logo-readme-dark.png">
+    <img src="brand/readme/logo-readme.png" alt="Lumio" width="260">
+  </picture>
+</p>
+
+<p align="center">
+  <strong>Galleria fotografica e video self-hosted per fotografi e studi.</strong><br>
+  Un'alternativa self-hostable a Picdrop, Pixieset e Pic-Time — i tuoi dati restano con te.
+</p>
+
+<p align="center">
+  <a href="https://github.com/markusthiel/lumio/releases"><img alt="Release" src="https://img.shields.io/github/v/tag/markusthiel/lumio?label=release&color=FF4D2E&labelColor=12121A&style=flat-square"></a>
+  <a href="#licenza"><img alt="License" src="https://img.shields.io/badge/license-FSL--1.1--ALv2-FF4D2E?labelColor=12121A&style=flat-square"></a>
+  <a href="#quick-start"><img alt="Docker Compose" src="https://img.shields.io/badge/deploy-Docker%20Compose-FF4D2E?labelColor=12121A&style=flat-square"></a>
+  <a href="https://lumio-app.de"><img alt="Website" src="https://img.shields.io/badge/docs-lumio--app.de-FF4D2E?labelColor=12121A&style=flat-square"></a>
+</p>
+
+![Galleria Lumio dal punto di vista del cliente](docs/images/01-gallery.jpg)
+
+---
+
+## Per chi è pensato Lumio?
+
+Tre configurazioni tipiche — la Quick Start qui sotto copre la prima; tutto il resto è opzionale.
+
+| Sei… | Setup | Doc |
+|---|---|---|
+| **Fotografo o studio** | Single mode, MinIO, un dominio | [Quick Start](#quick-start) — 5 minuti |
+| **Agenzia con più clienti fotografi** (self-hosted, per la tua attività) | Multi mode senza billing, tenant creati manualmente tramite super admin | [docs/MULTI_TENANT.md](docs/MULTI_TENANT.it.md) |
+
+In **single mode** il tenant viene creato automaticamente al primo avvio — ti serve solo `create-admin` per il tuo primo utente. Nessun super admin, nessun Stripe.
+
+> **Vuoi offrire Lumio come SaaS a terzi paganti?** Questo è *Competing Use* e non è liberamente consentito dalla licenza (è il modello di business dietro il nostro lumio-cloud.de). Una licenza commerciale è disponibile su richiesta — vedi [Licenza](#licenza). La modalità SaaS è documentata in [docs/SAAS_MODE.md](docs/SAAS_MODE.it.md).
+
+---
+
+## Funzionalità
+
+- 🚀 **Veloce** — Caricamenti diretti su S3, gallerie virtualizzate, miniature libvips
+- 📷 **Supporto RAW** — CR2, CR3, NEF, ARW, RAF, DNG, ORF, PEF, RW2, X3F via LibRaw
+- 🎬 **Streaming video** — Bitrate adattivo HLS, anteprime scrubbing, poster frame
+- 💬 **Proofing** — Like, color tag, valutazioni a stelle, commenti, annotazioni disegnate su foto **e video** (ancorate nel tempo), votazione di team
+- 🎨 **Whitelabel** — Logo, colori, domini personalizzati per studio o galleria
+- 🔐 **Sicuro** — URL firmati, password Argon2, audit log
+- ☁️ **Archiviazione flessibile** — MinIO, S3, R2, B2, Wasabi, Hetzner Object Storage
+- 🐳 **Docker-first** — `docker compose up` e funziona
+
+Lo studio — gestisci gallerie, collezioni smart, filtri per tag, proofing di team:
+
+![Dashboard dello studio Lumio](docs/images/02-studio-dashboard.png)
+
+---
+
+## Uno sguardo più da vicino
+
+**Proofing e annotazioni** — I clienti mettono like alle immagini, assegnano color tag e disegnano annotazioni direttamente sulla foto, con commenti per ogni foto.
+
+![Proofing con annotazioni e color tag](docs/images/03-proofing.jpg)
+
+![Annotazione diretta sull'immagine](docs/images/feat-annotation.jpg)
+
+**Video proofing** — Anche i video vengono revisionati come una foto: i clienti scorrono il video tramite filmstrip, posizionano annotazioni in un punto preciso nel tempo e disegnano direttamente sul fermo immagine — con una nota opzionale per ogni annotazione.
+
+![Annotazione video in un punto preciso nel tempo](docs/images/feat-video-annotation.jpg)
+
+Scrubbing tramite filmstrip — trascinando lungo la barra viene mostrata un'anteprima del fotogramma corrispondente con il relativo timestamp:
+
+![Anteprima scrubbing con fotogramma e timestamp](docs/images/feat-video-scrubbing.jpg)
+
+**Caricamento e formati** — Drag & drop con caricamenti paralleli, rilevamento dei duplicati e sezioni smart. JPEG, PNG, WebP, RAW, HEIC/HEIF, video e PDF — fino al limite di file configurabile.
+
+![Caricamento con i formati supportati](docs/images/feat-upload.png)
+
+**Auto-tagging con IA** — Le immagini vengono taggate automaticamente (modello CLIP); i suggerimenti possono essere filtrati per soglia di confidenza e applicati. I clienti possono opzionalmente filtrare per tag.
+
+![Auto-tagging con IA e griglia immagini](docs/images/04-ai-tagging.jpg)
+
+**Design della galleria** — Per ogni galleria: layout, disposizione delle immagini, transizioni della slideshow, immagine hero, logo dell'evento, colori. Whitelabel fin nel dettaglio.
+
+![Design e layout della galleria](docs/images/05-gallery-design.png)
+
+**Analytics** — Visualizzazioni, immagini più popolari, download e un funnel di engagement dalla visita all'ordine.
+
+![Statistiche e funnel di engagement](docs/images/06-analytics.png)
+
+**Print shop** — Vendi stampe, tele e fotolibri direttamente dalla galleria. I tuoi provider, prodotti, spedizione, opzionalmente con pagamento Stripe.
+
+![Configurazione del print shop](docs/images/07-print-shop.png)
+
+**Sicurezza e GDPR** — Accordo sul trattamento dei dati ai sensi dell'Art. 28 GDPR firmabile elettronicamente, link di condivisione con scadenza e password, audit log e autenticazione a due fattori.
+
+![Accordo sul trattamento dei dati (DPA) ai sensi dell'Art. 28 GDPR](docs/images/feat-dsgvo.jpg)
+
+**Webhook e integrazioni** — Notifica strumenti esterni tramite HTTP POST sugli eventi della galleria. Ogni richiesta è firmata con il tuo webhook secret.
+
+![Configurazione dei webhook](docs/images/feat-webhooks.jpg)
+
+**Modalità chiara o scura** — Il backend dello studio in chiaro o scuro, con un proprio colore di accento e varianti del logo per entrambe le modalità. (Gli altri screenshot qui mostrano la modalità scura.)
+
+![Backend dello studio in modalità chiara con selettore del tono di base](docs/images/feat-theme.jpg)
+
+---
+
+## Quick Start
+
+**5 minuti da zero alla tua prima galleria.** Requisiti: Docker + Docker Compose v2 (amd64 o arm64). Dettagli: [docs/REQUIREMENTS.md](docs/REQUIREMENTS.it.md).
+
+### 1. Clona il repository e imposta i secret
+
+```bash
+git clone https://github.com/markusthiel/lumio.git
+cd lumio
+cp .env.example .env
+
+# Generate and insert secure passwords
+sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=')|" .env
+sed -i "s|^JWT_SECRET=.*|JWT_SECRET=$(openssl rand -base64 32 | tr -d '/+=')|" .env
+sed -i "s|^SESSION_SECRET=.*|SESSION_SECRET=$(openssl rand -base64 32 | tr -d '/+=')|" .env
+sed -i "s|^S3_ACCESS_KEY=.*|S3_ACCESS_KEY=$(openssl rand -hex 12)|" .env
+sed -i "s|^S3_SECRET_KEY=.*|S3_SECRET_KEY=$(openssl rand -base64 32 | tr -d '/+=')|" .env
+```
+
+### 2. Avvia
+
+```bash
+docker compose up -d
+```
+
+Questo compila i container e avvia Postgres, Redis, MinIO, API, frontend, worker e Caddy. Il primo avvio richiede 3–5 min (build + migrazione del DB).
+
+Verifica lo stato:
+
+```bash
+docker compose ps
+```
+
+Tutti i servizi dovrebbero risultare `running` (healthy).
+
+> **Nota sul firewall cloud:** apri le porte **80** (app) e **9000** (MinIO —
+> il browser carica e recupera le immagini direttamente dall'object storage).
+> Senza la 9000, i caricamenti falliscono immediatamente.
+
+### 3. Crea un utente admin
+
+```bash
+docker compose exec api npm run create-admin -- \
+  --email=you@example.com \
+  --password=atleast12chars \
+  --name="Your Studio"
+```
+
+### 4. Accedi
+
+Nel tuo browser:
+
+→ **http://localhost** (login dello studio) — oppure, su un server remoto,
+semplicemente **http://\<server-ip\>** (digita esplicitamente `http://`; alcuni
+browser forzano `https://`, e per un IP nudo non esiste un certificato)
+
+> **Nota:** Accedi sempre a Lumio tramite la **porta 80** (il proxy Caddy) — instrada
+> `/api/*` verso l'API. Nessuna configurazione necessaria per l'accesso via IP; lascia `LUMIO_HOST`
+> vuoto. In alternativa, crea un tunnel sulla porta 80 (non 3000):
+> `ssh -L 8080:127.0.0.1:80 your-server` → poi apri `http://localhost:8080`.
+> (Dalla v0.49.1 anche la porta 3000 del frontend inoltra le chiamate API come fallback,
+> ma la porta 80 resta il punto di ingresso previsto.)
+
+Dopo aver effettuato l'accesso trovi la creazione della galleria in alto a sinistra. Carica una foto, condividi il link della galleria — fatto.
+
+---
+
+## È in esecuzione. E adesso?
+
+- **Aggiornare un'installazione esistente** → `git pull && docker compose up -d --build` —
+  il `--build` è importante: i fix spesso si trovano dentro le immagini (Caddy, API, frontend),
+  un semplice `up -d` continua a far girare quelle vecchie. Dettagli: [docs/SELFHOSTING.md](docs/SELFHOSTING.it.md#aggiornamenti)
+
+- **Collega il tuo dominio** → [docs/SELFHOSTING.md](docs/SELFHOSTING.it.md) (setup di 15 minuti con HTTPS)
+- **Le immagini spariscono al riavvio dei container?** → MinIO archivia i dati nel volume `minio_data`, che persiste. Assicurati solo di non eseguire accidentalmente `docker volume rm` su di esso.
+- **Configura i backup** → [docs/BACKUP.md](docs/BACKUP.it.md)
+- **Qualcosa non funziona?** → [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.it.md)
+
+---
+
+## Architettura
+
+```
+┌──────────┐    ┌──────────┐    ┌────────────────┐
+│ Frontend │◄──►│   API    │◄──►│ Postgres/Redis │
+│ Next.js  │    │ Fastify  │    │  + S3 Storage  │
+└──────────┘    └────┬─────┘    └────────────────┘
+                     │
+                     ▼
+                ┌─────────┐
+                │ Worker  │  RAW decode, thumbnails,
+                │ Python  │  video transcode, ZIP build
+                │ Celery  │
+                └─────────┘
+```
+
+- **`apps/frontend`** — Next.js 16 (App Router) + Tailwind
+- **`apps/api`** — Fastify + Prisma (Postgres) + BullMQ (Redis)
+- **`apps/worker`** — Python + Celery + rawpy/pyvips/ffmpeg
+- **`packages/shared`** — Tipi TypeScript condivisi + schemi Zod
+- **`infra/`** — Config Caddy, init Postgres
+
+---
+
+## Configurazioni avanzate
+
+Tutto opzionale. La Quick Start sopra è sufficiente per un singolo studio.
+
+| Scenario | Doc |
+|---|---|
+| Produzione dietro un dominio proprio con HTTPS | [docs/SELFHOSTING.md](docs/SELFHOSTING.it.md) |
+| Più studi su un'unica istanza | [docs/MULTI_TENANT.md](docs/MULTI_TENANT.it.md) |
+| Modalità SaaS con billing Stripe | [docs/SAAS_MODE.md](docs/SAAS_MODE.it.md) |
+| Accelerazione GPU (NVENC + tag IA) | [docs/GPU.md](docs/GPU.it.md) |
+| Auto-tagging IA (CLIP) | [docs/ML.md](docs/ML.it.md) |
+| Sottodomini per tenant tramite certificato wildcard | [docs/WILDCARD.md](docs/WILDCARD.it.md) |
+| Distribuire il carico su più server | [docs/SCALING.md](docs/SCALING.it.md) |
+| S3 esterno invece di MinIO (R2, B2, Hetzner, Wasabi) | [docs/STORAGE.md](docs/STORAGE.it.md) |
+| Backup, migrazioni, re-queue | [docs/OPERATIONS.md](docs/OPERATIONS.it.md) |
+| Contribuire / sviluppo | [docs/DEVELOPMENT.md](docs/DEVELOPMENT.it.md) |
+
+---
+
+## Licenza
+
+[Functional Source License 1.1 (FSL-1.1-ALv2)](LICENSE) — una licenza *source-available* (non open source OSI).
+
+**Permesso a chiunque:**
+- Privati, fotografi professionisti e studi: usare, self-hostare, modificare — anche commercialmente per la propria attività
+- Agenzie: gestire Lumio nell'ambito di servizi per i propri clienti
+
+**Non permesso:**
+- Costruire un'offerta SaaS/cloud ospitata concorrente, che fornisce a terzi come prodotto funzionalità uguali o sostanzialmente simili a Lumio (*Competing Use*)
+
+**A tempo limitato:** Ogni versione diventa automaticamente disponibile sotto [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0) due anni dopo il suo rilascio — poi senza restrizioni.
+
+Per un'offerta ospitata/concorrente, è disponibile una licenza commerciale su richiesta.
+
+---
+
+## Come contribuire
+
+Pull request benvenute. Vedi [CONTRIBUTING.md](CONTRIBUTING.it.md).
+
+Issue e discussioni: https://github.com/markusthiel/lumio/issues

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](README.de.md)
+**English** · [Deutsch](README.de.md) · [Italiano](README.it.md)
 
 <p align="center">
   <picture>

--- a/apps/capture-one-plugin/README.it.md
+++ b/apps/capture-one-plugin/README.it.md
@@ -1,0 +1,166 @@
+[Deutsch](README.md) · **Italiano**
+
+# Lumio Capture One Plugin
+
+Riflette la selezione del cliente di una galleria Lumio nel catalogo
+Capture One attualmente aperto o nella sessione corrente. Color tag,
+valutazioni a stelle e pick finiscono direttamente sulle Variant.
+
+## Prerequisiti
+
+- **macOS** — Capture One supporta gli script solo su macOS. Per
+  Windows non esiste un percorso di scripting ufficiale.
+- **Capture One Pro 14** o successivo. Le versioni precedenti hanno
+  librerie AppleScript più limitate e non sono state testate.
+- **Python 3** (installato di default su macOS 12.3 e successivi in
+  `/usr/bin/python3`). Se non presente: tramite Homebrew con
+  `brew install python3` oppure con il pacchetto di installazione
+  ufficiale di Python.
+- Un'istanza Lumio raggiungibile e un token API (vedi "Setup").
+
+## Installazione
+
+1. Scarica la cartella `apps/capture-one-plugin/` dal repo Lumio
+   (oppure clona il repo). Contenuto:
+   - `lumio-c1-sync.py` — lo script helper Python che comunica con Lumio
+   - `Lumio - Pull Selection.applescript` — l'AppleScript che appare
+     in C1
+   - questo README
+
+2. Apri una volta il file `.applescript` con l'**Editor script**
+   (`/System/Applications/Utilities/Script Editor.app`), verifica
+   che compili (menu "Script → Compila") e salvalo come **script
+   compilato** (`.scpt`).
+
+3. Copia i file — il `.scpt` + `lumio-c1-sync.py` — nella cartella
+   degli script di Capture One:
+
+   ```
+   ~/Library/Scripts/Capture One Scripts/
+   ```
+
+   Se la cartella non esiste, creala. I due file devono trovarsi
+   uno accanto all'altro — l'AppleScript si aspetta l'helper Python
+   nella stessa directory in cui si trova lui stesso.
+
+4. Assicurati che l'helper Python sia eseguibile:
+
+   ```bash
+   chmod +x ~/Library/Scripts/Capture\ One\ Scripts/lumio-c1-sync.py
+   ```
+
+5. Avvia Capture One (o riavvialo). Lo script compare sotto
+   **Scripts → Lumio - Pull Selection** nella barra dei menu.
+
+## Setup
+
+1. Genera un token API nello studio Lumio: **Impostazioni →
+   Token API → Crea token**, ad es. con nome
+   "Capture One @ Studio-Mac". COPIA il token — viene mostrato solo
+   una volta.
+
+2. Crea un file `~/.lumio-c1.json` con il seguente contenuto:
+
+   ```json
+   {
+     "host": "https://studio.lumio-cloud.de",
+     "token": "lum_xxxxxxxxxxxxxxxxxxxxxx"
+   }
+   ```
+
+   `host` è il tuo URL Lumio senza slash finale. Se fai self-hosting
+   su un dominio diverso, inseriscilo qui.
+
+3. Testa la connessione:
+
+   ```bash
+   ~/Library/Scripts/Capture\ One\ Scripts/lumio-c1-sync.py test
+   ```
+
+   Output atteso: `{"ok": true, "apiVersion": "1"}`.
+
+   In caso di `Lumio: API-Token ungültig oder abgelaufen`: crea un
+   nuovo token nello studio e aggiorna i valori `host`/`token` in
+   `.lumio-c1.json`.
+
+## Utilizzo
+
+1. In Capture One apri il catalogo o la sessione che contiene i file
+   RAW/JPEG originali.
+
+2. Seleziona **Scripts → Lumio - Pull Selection**.
+
+3. Dalla lista delle gallerie, scegli quella da sincronizzare.
+
+4. Lo script recupera tutti i file della galleria, li confronta per
+   nome file con il catalogo/sessione attualmente attivo e applica
+   quanto segue:
+
+   | Lumio | Capture One |
+   |---|---|
+   | Color "red" | Color-Tag 1 (Rosso) |
+   | Color "yellow" | Color-Tag 3 (Giallo) |
+   | Color "green" | Color-Tag 4 (Verde) |
+   | Rating 1–5 | Rating 1–5 |
+   | Pick (senza Color-Tag) | Color-Tag 5 (Blu) |
+   | Liked | Rating minimo 1 (marcatore più leggero) |
+
+5. Alla fine appare una finestra di dialogo con il numero di file
+   trovati in corrispondenza. Se in Lumio esistono file che non sono
+   presenti nel catalogo, la finestra ne elenca alcuni come esempio.
+
+## Logica di matching
+
+Come il plugin Lightroom, anche il plugin Capture One esegue il
+matching **per nome file** (minuscolo, senza percorso). Se lo stesso
+nome file esiste più volte nel catalogo (es. Variant duplicate o
+import multipli), la selezione viene applicata **a tutte le Variant
+con lo stesso nome**.
+
+**Cosa significa:**
+
+- Se in Lumio hai caricato più Variant RAW dello stesso scatto e il
+  cliente ne ha contrassegnata solo una, il plugin non riesce a
+  distinguerle — il contrassegno finisce su tutte.
+- Con i file rinominati (es. Variant di modifica con sidecar C1 e
+  suffisso) il plugin non trova corrispondenze. È voluto: non
+  vogliamo indovinare.
+
+## Limitazioni note
+
+- **Windows non è supportato.** Capture One mette a disposizione una
+  libreria AppleScript solo su macOS. Per i workflow su Windows al
+  momento è disponibile solo il plugin Lightroom Classic.
+- **La mappatura Pick → Color-Tag 5** è una convenzione, non un vero
+  concetto di C1. A differenza di Lightroom, C1 non ha un flag
+  Pick/Reject dedicato. Gli studio che usano Color-Tag 5 (Blu) per
+  altri scopi dovrebbero essere consapevoli di questa collisione.
+- **Nessuna sincronizzazione bidirezionale.** Il plugin scrive solo
+  Lumio → C1. Le modifiche fatte in C1 (es. valutare i pick in un
+  secondo momento) non tornano indietro verso la galleria.
+- **Catalogo grande = scansione più lenta.** L'indicizzazione dei
+  file è lineare su tutte le Variant. Con un catalogo di 50k+ file,
+  la prima scansione richiede qualche secondo. Eseguiamo la
+  scansione una sola volta per chiamata, non per ogni file.
+
+## Gestione degli errori
+
+| Messaggio | Causa | Soluzione |
+|---|---|---|
+| „Konfigurationsdatei fehlt: ~/.lumio-c1.json" | Passo 2 del setup saltato | Crea il file come descritto sopra |
+| „Lumio: API-Token ungültig oder abgelaufen" | Token revocato o scaduto nello studio | Genera un nuovo token, inseriscilo in `.lumio-c1.json` |
+| „Lumio: Verbindung fehlgeschlagen" | Host non raggiungibile (DNS/firewall) | Controlla il valore di `host`, testa con `curl` |
+| „Bitte zuerst einen Capture-One-Katalog oder eine Session öffnen" | Nessun documento attivo in C1 | Apri catalogo/sessione, riavvia lo script |
+| „N Files nicht im Katalog gefunden" | I nomi file nel catalogo non corrispondono a quelli in Lumio | Confronta i nomi file — di solito il problema riguarda rinomine o Variant di sola modifica |
+
+## Aggiornamenti
+
+Quando un aggiornamento del repo modifica il plugin:
+
+1. Scarica le nuove versioni dei tre file (`.scpt`, `.py`, README) da
+   `apps/capture-one-plugin/` nel repo.
+2. Sostituiscili in `~/Library/Scripts/Capture One Scripts/`.
+3. Riavvia Capture One una volta.
+
+Il file `~/.lumio-c1.json` resta invariato — l'aggiornamento non lo
+tocca mai.

--- a/apps/capture-one-plugin/README.md
+++ b/apps/capture-one-plugin/README.md
@@ -1,3 +1,5 @@
+**Deutsch** · [Italiano](README.it.md)
+
 # Lumio Capture One Plugin
 
 Spiegelt die Kunden-Auswahl einer Lumio-Galerie in den aktuell

--- a/apps/lightroom-plugin/README.it.md
+++ b/apps/lightroom-plugin/README.it.md
@@ -1,0 +1,161 @@
+[Deutsch](README.md) · **Italiano**
+
+# Lumio Lightroom Classic Plugin
+
+Ponte bidirezionale tra Lightroom Classic e Lumio:
+
+1. **Import selezione** (Lumio → LR): la selezione del cliente di
+   una galleria arriva nel catalogo Lightroom come flag Pick, stelle
+   e Color Label.
+2. **Servizio di pubblicazione** (LR → Lumio): carica le immagini da
+   LR direttamente in una galleria Lumio. Una raccolta pubblicata
+   per ogni galleria Lumio. Il contenuto è determinato da
+   drag-and-drop o da regole della smart collection.
+
+## Prerequisiti
+
+- Lightroom Classic 9.0 o successivo
+- Un'istanza Lumio attiva (self-hosted o hosted)
+- Un token API (vedi "Setup")
+
+## Installazione
+
+1. Copia questa cartella — `lumio.lrdevplugin/` — sul disco locale
+   (es. in `~/Documents/Lightroom Plugins/`).
+2. In Lightroom Classic:
+   **File → Gestione plug-in… → Aggiungi**
+3. Seleziona la cartella `lumio.lrdevplugin` → **Aggiungi plug-in**.
+4. Il plugin appare come "Lumio" nel gestore. Lo stato dovrebbe
+   essere "Installato e attivato".
+
+**Nota per macOS:** se il Finder mostra la cartella come "bundle" e
+non riesci ad aprirla — rinominala semplicemente da `.lrdevplugin` a
+`.lrplugin` (oppure fai clic destro → "Mostra contenuto pacchetto").
+
+## Setup
+
+1. Genera un token API nello studio Lumio:
+   **Impostazioni → Token API → Crea token**, ad es. con nome
+   "Lightroom @ Studio-Mac". COPIA il token — viene mostrato solo
+   una volta.
+2. Nel gestore plug-in seleziona il plugin Lumio, nel pannello a
+   destra "Connessione Lumio":
+   - **Server**: il tuo URL Lumio incluso `https://`, es.
+     `https://studio.lumio-cloud.de`
+   - **Token API**: incolla il token appena generato
+3. Clicca su **Verifica connessione**. Output atteso:
+   `✓ Verbunden (API v1)`.
+
+## Utilizzo: Import selezione (pick del cliente verso LR)
+
+1. In Lightroom: **Libreria → Opzioni plug-in → Importa selezione
+   Lumio…**
+2. Scegli la galleria dalla lista.
+3. Seleziona le opzioni:
+   - **Imposta i pick come flag Lightroom**: un pick del cliente
+     diventa un flag Pick nel catalogo.
+   - **Like come valutazione a 1 stella**: un like senza rating
+     esplicito diventa 1 stella. Le valutazioni più alte già
+     presenti restano invariate.
+   - **Applica le valutazioni**: le stelle da 1 a 5 vengono
+     riportate direttamente.
+   - **Applica i Color Label**: red/yellow/green diventano i
+     Red/Yellow/Green di Lightroom.
+4. **Ricerca per nome file**: nell'intero catalogo oppure solo
+   nella raccolta attiva. Quest'ultima opzione è più veloce con
+   cataloghi grandi.
+5. **OK** → il plugin trova le corrispondenze dei file in base al
+   nome file originale (case-insensitive) e scrive i metadati in
+   un'unica transazione, così puoi annullare completamente l'import
+   con Cmd/Ctrl-Z.
+
+## Utilizzo: servizio di pubblicazione (immagini LR verso Lumio)
+
+1. In Lightroom, a sinistra sotto "Servizi di pubblicazione" appare
+   **Lumio**. Clicca su **Configura** → salva il servizio.
+2. **Crea raccolta pubblicata** sotto il servizio Lumio.
+3. Nella finestra di dialogo:
+   - scegli una **galleria esistente** dalla lista, OPPURE
+   - **creane una nuova** con titolo + modalità (selezione/proofing
+     o presentazione).
+   - **Metti automaticamente 'live' dopo il caricamento**: se
+     attivo, la galleria diventa live subito dopo il primo
+     caricamento riuscito — i clienti possono aprire l'URL.
+4. **Salva** → la raccolta appare sotto Lumio.
+5. Trascina le immagini nella raccolta con drag-and-drop oppure
+   tramite smart collection → sotto la raccolta le immagini si
+   accumulano come "Pronte per la pubblicazione".
+6. Clicca su **Pubblica** → Lightroom renderizza le immagini come
+   JPEG (sRGB) e le carica su Lumio. Per ogni caricamento vengono
+   generate in background le varianti di anteprima, thumbnail ed
+   eventualmente watermark.
+7. **Mostra in Lumio** (clic destro sulla raccolta) apre la galleria
+   nel browser.
+
+### Ripubblicare
+
+Se modifichi un'immagine in LR, puoi impostarla manualmente su
+"Ripubblica" (clic destro → "Ripubblica"). Al successivo ciclo di
+caricamento, il file vecchio viene eliminato da Lumio e viene
+caricato quello nuovo.
+
+### Rimuovere le immagini
+
+Rimuovi la foto dalla raccolta oppure elimina la raccolta → Lumio
+elimina automaticamente i file corrispondenti.
+
+## Logica di aggregazione (import selezione)
+
+Quando più clienti nella galleria fanno selezioni diverse, i valori
+vengono aggregati lato server:
+
+| Lumio-Server | Lightroom |
+|---|---|
+| **picked**: almeno un cliente ha scelto `pick` | Flag Pick |
+| **liked**: almeno un cliente ha messo un cuore | Almeno 1 stella |
+| **color**: colore più frequente tra tutti i clienti | Color Label |
+| **rating**: stelle massime tra tutti i clienti | Rating a stelle |
+
+## Limitazioni note
+
+- **Matching per nome file (import selezione)**: se hai rinominato
+  i file in Lightroom, non li troviamo. Un matching basato su
+  SHA-256 è pianificato come miglioramento futuro.
+- **Nomi file duplicati**: se il tuo catalogo contiene più foto con
+  lo stesso nome file (es. due fotocamere), vengono aggiornate
+  tutte.
+- **Flag Reject**: al momento Lumio conosce solo "pick" e "none",
+  non "reject". Per questo, durante l'import nessun flag Reject
+  esistente viene sovrascritto.
+- **Pubblicazione: solo JPEG, sRGB**: renderizziamo in JPEG sRGB e
+  carichiamo solo quello. Gli originali (RAW) restano in locale.
+- **Pubblicazione: solo upload single-part**: i file > 100 MB
+  vengono attualmente rifiutati. Con i render JPEG non è un
+  problema; con gli export TIFF potrebbe servire ridurre
+  manualmente la qualità.
+- **Smart Preview / stack RAW+JPEG**: il matching avviene a livello
+  di nome file, la voce principale del catalogo riceve i metadati.
+
+## Struttura delle cartelle del plugin
+
+```
+lumio.lrdevplugin/
+├── Info.lua                       Manifest (Selection + Publish)
+├── PluginManager.lua              UI im Zusatzmodul-Manager (Host+Token)
+├── ImportSelectionDialog.lua      Galerie- + Optionen-Dialog (Import)
+├── ImportSelectionTask.lua        Eigentliche Import-Logik
+├── LumioPublishService.lua        Publish-Service-Provider (Upload)
+├── LumioApi.lua                   HTTP-Wrapper mit Bearer-Auth
+├── Json.lua                       JSON-Lib (MIT, rxi/json.lua)
+└── Logger.lua                     LrLogger-Wrapper
+```
+
+## Log
+
+I log del plugin si trovano in:
+- macOS: `~/Documents/LrClassicLogs/Lumio.log`
+- Windows: `%USERPROFILE%\Documents\LrClassicLogs\Lumio.log`
+
+## Licenza
+
+FSL-1.1-ALv2 (Functional Source License), come il resto di Lumio.

--- a/apps/lightroom-plugin/README.md
+++ b/apps/lightroom-plugin/README.md
@@ -1,3 +1,5 @@
+**Deutsch** · [Italiano](README.it.md)
+
 # Lumio Lightroom Classic Plugin
 
 Bidirektionale Brücke zwischen Lightroom Classic und Lumio:

--- a/bench/README.it.md
+++ b/bench/README.it.md
@@ -1,0 +1,64 @@
+[Deutsch](README.md) · **Italiano**
+
+# Benchmark delle performance del frontend
+
+Misurazione riproducibile delle performance di caricamento di una
+pagina galleria. Permette di verificare i numeri citati nel
+blog/marketing.
+
+## Setup
+
+```bash
+npm i playwright
+npx playwright install chromium
+```
+
+## Esecuzione
+
+```bash
+node frontend-perf.mjs "https://deine-galerie.example/g/..." --runs 5
+```
+
+Confrontare più URL in sequenza:
+
+```bash
+node frontend-perf.mjs "<url-a>" "<url-b>" --runs 5
+```
+
+## Profilo
+
+Misurato con un profilo mobile, in modo che i numeri si avvicinino a
+un dispositivo reale (non a una connessione da data center senza
+throttling):
+
+- Dispositivo: Pixel 5 (profilo dispositivo Playwright)
+- Rete: Lighthouse "Slow 4G" — 1,6 Mbit/s download, 0,675 Mbit/s
+  upload, 150 ms RTT
+- CPU: rallentata 4× (emula uno smartphone di fascia media)
+- Più run a freddo per ogni misurazione, viene valutata la mediana
+
+## Metriche rilevate
+
+- **FCP** — First Contentful Paint
+- **LCP** — Largest Contentful Paint (Web Vital, buono ≤ 2,5 s)
+- **CLS** — Cumulative Layout Shift (Web Vital, buono ≤ 0,1)
+- **TBT** — Total Blocking Time (proxy di laboratorio per
+  l'interattività)
+- **reqs** — numero di richieste di rete nella prima visualizzazione
+- **loadedImgs** — immagini effettivamente caricate nella prima
+  visualizzazione
+
+## Note importanti per l'interpretazione
+
+- I numeri assoluti **dipendono dalla posizione**: la latenza di
+  base verso il rispettivo server/CDN varia in base al luogo di
+  misurazione. Ciò su cui puoi fare affidamento è il confronto
+  **relativo** tra due pagine nelle stesse condizioni.
+- I **byte delle immagini** non vengono confrontati di proposito:
+  per le immagini servite cross-origin (S3/CDN senza
+  `Timing-Allow-Origin`), la Resource Timing API segnala
+  `transferSize = 0`. Per questo il focus è su LCP/FCP/CLS/TBT e sul
+  numero di richieste.
+- Una singola galleria è un punto campione, non un benchmark
+  completo. Lo stato della cache CDN e la dimensione della galleria
+  influenzano il risultato.

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,3 +1,5 @@
+**Deutsch** · [Italiano](README.it.md)
+
 # Frontend-Performance-Benchmark
 
 Reproduzierbarer Messlauf für die Ladeperformance einer Galerie-Seite.

--- a/brand/README.de.md
+++ b/brand/README.de.md
@@ -1,4 +1,4 @@
-[English](README.md) · **Deutsch**
+[English](README.md) · **Deutsch** · [Italiano](README.it.md)
 
 # brand/
 

--- a/brand/README.it.md
+++ b/brand/README.it.md
@@ -1,0 +1,109 @@
+[English](README.md) · [Deutsch](README.de.md) · **Italiano**
+
+# brand/
+
+Ogni versione della marca Lumio, più gli script che le generano.
+
+**Le regole e la logica dietro di esse non stanno qui** — vivono in
+[`../docs/BRAND.md`](../docs/BRAND.it.md). Questa cartella è il magazzino, quel
+documento è il regolamento.
+
+Panoramica più rapida: apri [`preview.html`](preview.html) in un browser. La
+pagina incorpora direttamente i file di questa cartella, quindi mostra lo stato
+reale invece di una ridisegnata — comprese le dimensioni reali in pixel a
+partire da 16 px.
+
+## Contenuto
+
+| Cartella | Cosa contiene |
+|---|---|
+| `logo/` | simbolo, wordmark e lockup come SVG, ciascuno normale e invertito |
+| `favicon/` | favicon SVG, fallback PNG, touch icon, web manifest |
+| `email/` | versioni PNG per le intestazioni email |
+| `readme/` | PNG dei lockup per l'intestazione del README, chiari e scuri |
+| `social/` | card di anteprima social per GitHub — **deve essere caricata lì manualmente**, vedi `social/README.md` |
+| `fonts/` | Quicksand e Inter con i relativi testi di licenza |
+| `src/` | gli script Python che generano tutto quanto sopra |
+
+### Quale file per cosa
+
+| File | Uso |
+|---|---|
+| `logo/mark.svg` | favicon, icona dell'app, ovunque si adatti solo il simbolo |
+| `logo/mark-inverse.svg` | lo stesso su sfondo scuro |
+| `logo/mark-mono.svg` | monocolore, per timbri e stampa a un colore |
+| `logo/mark-thin.svg` | taglio più stretto — alternativa se il taglio sembra troppo dominante |
+| `logo/logo.svg` | lockup orizzontale per intestazioni e firme |
+| `logo/logo-mono-light.svg` | lockup su superficie colorata, dove la tessera arancione sparirebbe |
+| `logo/logo-cloud.svg`, `logo/logo-selfhosted.svg` | impilati, con il descrittore di prodotto |
+| `logo/wordmark.svg` | solo la wordmark, quando il simbolo è già affiancato |
+| `email/logo-email*.png` | intestazioni email. PNG, perché Gmail e Outlook non renderizzano SVG |
+| `readme/logo-readme*.png` | intestazione del README, chiara e scura |
+
+Le copie distribuite vivono sotto `apps/frontend/public/`. Questa cartella è la
+fonte, non la destinazione — cambia le cose qui, poi copia.
+
+## Rigenerare
+
+Gli SVG sono generati, non disegnati a mano. La wordmark è **Quicksand
+SemiBold convertita in tracciati**, così i file del logo non caricano alcun
+webfont.
+
+```bash
+pip install fonttools cairosvg
+cd brand/src
+
+python3 build.py            # symbol, wordmark, all lockups
+python3 favicon-adaptive.py # favicon with prefers-color-scheme
+python3 og.py               # Open Graph images, 1200x630
+python3 github.py           # social preview + README logos
+```
+
+Gli script localizzano i font tramite un percorso relativo a se stessi, quindi
+la chiamata non dipende dalla working directory. Un'esecuzione da una copia
+pulita riproduce tutti e quattordici gli SVG **identici byte per byte** a
+quelli qui archiviati — se un file differisce, è un segnale, non rumore.
+
+## Font
+
+`fonts/` contiene i due caratteri usati, insieme ai relativi testi di licenza:
+
+| File | Uso |
+|---|---|
+| `Quicksand.ttf` | wordmark (istanza `wght 600`), descrittore (`wght 500`) |
+| `Inter.ttf` | titoli delle immagini Open Graph |
+| `Quicksand-OFL.txt`, `Inter-OFL.txt` | le relative licenze |
+
+Entrambi sono sotto la **SIL Open Font License 1.1**, che permette esplicitamente
+la ridistribuzione ma richiede che il testo della licenza viaggi insieme —
+da qui i file `OFL.txt` accanto a essi. Entrambe le famiglie portano un
+*Reserved Font Name*: una versione modificata non può mantenere il nome
+"Quicksand" o "Inter".
+
+La wordmark in `logo/` è già convertita in tracciati e non ha più bisogno del
+font — questi file servono solo per la rigenerazione.
+
+## Colori
+
+| Ruolo | Hex | Uso |
+|---|---|---|
+| Ink | `#12121A` | tessere, wordmark, superfici scure |
+| Accent | `#FF4D2E` | esattamente una tessera, il puntino della i, riempimenti, testo da 24 px |
+| Accent strong | `#C93214` | link e testo piccolo su sfondi chiari |
+| Paper | `#FAF8F5` | sfondo chiaro, etichette su riempimenti arancioni |
+
+## Usare questo altrove
+
+Il codice è concesso in licenza sotto FSL-1.1-ALv2. **Il nome e la marca non sono
+coperti da essa.** Se fai self-hosting di Lumio, lascia il branding così com'è —
+è proprio quello il punto. Se costruisci qualcosa di tuo sopra e lo distribuisci,
+per favore metti la tua marca: altrimenti sembra Lumio ufficiale e le richieste
+di supporto finiscono nella casella sbagliata. Tutto è sostituibile: i file
+sotto `apps/frontend/public/`, il componente `Logo`, e `--logo-accent` in
+`globals.css`.
+
+Per stampa, elenchi o newsletter, i file qui possono essere usati così come
+sono. `readme/logo-readme.png` (chiaro) e `readme/logo-readme-dark.png`
+(scuro) sono la scelta usuale, `favicon/icon-512.png` dove serve una tessera
+quadrata. Non serve chiedere — ma fai un fischio se manca qualcosa in un
+formato che ti serve.

--- a/brand/README.md
+++ b/brand/README.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](README.de.md)
+**English** · [Deutsch](README.de.md) · [Italiano](README.it.md)
 
 # brand/
 

--- a/brand/social/README.de.md
+++ b/brand/social/README.de.md
@@ -1,4 +1,4 @@
-[English](README.md) · **Deutsch**
+[English](README.md) · **Deutsch** · [Italiano](README.it.md)
 
 # social/
 

--- a/brand/social/README.it.md
+++ b/brand/social/README.it.md
@@ -1,0 +1,20 @@
+[English](README.md) · [Deutsch](README.de.md) · **Italiano**
+
+# social/
+
+`github-social.png` (1280×640) è la card che GitHub, Slack, Mastodon e altri
+mostrano quando qualcuno condivide il link del repository.
+
+**GitHub non la legge dal repository.** Deve essere caricata una volta:
+
+> Repo → **Settings** → sezione *Social preview* → **Edit** → `github-social.png`
+
+Dopodiché resta ferma e va toccata di nuovo solo quando cambia la marca. Per
+testarla, passa il link su <https://www.opengraph.xyz/> o incollalo in un
+canale Slack.
+
+Il testo è deliberatamente in **inglese** — il README è inglese-first e GitHub
+è la vetrina internazionale. Le versioni tedesche vivono con i siti marketing
+sotto il loro `brand/og-default.svg`.
+
+Rigenera con `python3 ../src/github.py`.

--- a/brand/social/README.md
+++ b/brand/social/README.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](README.de.md)
+**English** · [Deutsch](README.de.md) · [Italiano](README.it.md)
 
 # social/
 

--- a/docs/BACKUP.de.md
+++ b/docs/BACKUP.de.md
@@ -1,4 +1,4 @@
-[English](BACKUP.md) · **Deutsch**
+[English](BACKUP.md) · **Deutsch** · [Italiano](BACKUP.it.md)
 
 # Backup
 

--- a/docs/BACKUP.it.md
+++ b/docs/BACKUP.it.md
@@ -1,0 +1,278 @@
+[English](BACKUP.md) · [Deutsch](BACKUP.de.md) · **Italiano**
+
+# Backup
+
+> Un backup non testato non è un backup. **Esegui regolarmente test di
+> restore.**
+
+Lumio esegue il backup di due aree dati separate, gestite in modo diverso:
+
+1. **Postgres** – il database dell'applicazione (utenti, gallerie, permessi,
+   stato di abbonamenti/Stripe). Piccolo, di alto valore, cambia
+   continuamente → **giornaliero**.
+2. **Bucket S3** – i file immagine e video veri e propri. Grande, cambia
+   lentamente → **settimanale**.
+
+Principio ferreo: **i backup devono uscire dal server.** Un dump che resta
+sullo stesso server del DB non serve a nulla se il server si guasta. Questo
+setup segue quindi la **regola del 3-2-1**: i dati (1) più due copie (2)
+presso due provider diversi, una delle quali fuori sede (1).
+
+| Dati | Originale | Copia 1 | Copia 2 |
+|---|---|---|---|
+| Postgres | Volume del server | Hetzner Object Storage (secondo bucket) | Backblaze B2 |
+| Immagini/video | `lumio-prod` (Hetzner) | Versioning + Object Lock su `lumio-prod` | Backblaze B2 (rclone sync) |
+
+`redis_data` (coda dei job) e `caddy_data` (certificati TLS) **non**
+vengono sottoposti a backup — entrambi si rigenerano al riavvio. Dettagli
+sotto in "Cosa non serve backuppare".
+
+Questo repo include gli script già pronti:
+
+- `scripts/lumio-backup.sh` – dump giornaliero di Postgres in entrambi i
+  repo restic
+- `scripts/lumio-media-sync.sh` – sync rclone settimanale delle immagini
+  verso B2
+- `scripts/lumio-backup.env.example` – template di configurazione (secrets!)
+
+---
+
+## Panoramica: cosa viene configurato
+
+1. Installa gli strumenti: `restic`, `rclone`, `mc` (client MinIO, solo per
+   il versioning dei bucket)
+2. Crea un secondo bucket Hetzner `lumio-backups` (per il repo restic del DB)
+3. Crea i bucket Backblaze B2 (`lumio-db-backup`, `lumio-media-backup`)
+4. Inizializza i repo restic in entrambe le destinazioni
+5. Attiva versioning + Object Lock su `lumio-prod`
+6. Configura i remote rclone
+7. Compila il file di configurazione `/etc/lumio-backup.env`
+8. Aggiungi i cron job
+9. Collega un dead man's switch
+10. Esegui un **test di restore**
+
+---
+
+## 1. Installa gli strumenti
+
+```bash
+apt update && apt install -y restic rclone
+
+# mc (MinIO client) — only needed to toggle bucket versioning.
+# Architecture automatic (amd64 or arm64):
+curl -sSL https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/mc -o /usr/local/bin/mc
+chmod +x /usr/local/bin/mc
+```
+
+## 2. Secondo bucket Hetzner
+
+Nella Hetzner Cloud Console crea un **secondo** bucket, es.
+`lumio-backups` — **non** lo stesso di `lumio-prod`, altrimenti diventa un
+single point of failure. Poi genera una coppia di chiavi S3 (Console →
+Object Storage → Credentials). L'endpoint è `fsn1.your-objectstorage.com`.
+
+## 3. Bucket Backblaze B2
+
+Nell'account B2 crea due bucket privati:
+
+- `lumio-db-backup` (per il DB)
+- `lumio-media-backup` (per le immagini)
+
+Poi crea una **application key** con accesso a entrambi i bucket (B2 → App
+Keys). Ottieni un `keyID` e un `applicationKey` — quest'ultimo viene
+mostrato solo **una volta**, quindi salvalo subito.
+
+## 4. Inizializza i repo restic
+
+restic cripta tutto con una password. Generane una robusta e conservala —
+è l'**unico** modo per decrittare i backup:
+
+```bash
+openssl rand -base64 48 > /root/.lumio-restic-pwd
+chmod 600 /root/.lumio-restic-pwd
+```
+
+> **Conserva questa password anche in un password manager su un dispositivo
+> diverso.** Se la perdi INSIEME al server, i backup sono irrecuperabili.
+
+Inizializza entrambi i repo una volta sola (stessa password per entrambi):
+
+```bash
+export RESTIC_PASSWORD_FILE=/root/.lumio-restic-pwd
+
+# Hetzner (S3 backend)
+export AWS_ACCESS_KEY_ID="<hetzner-backup-key>"
+export AWS_SECRET_ACCESS_KEY="<hetzner-backup-secret>"
+restic -r s3:https://fsn1.your-objectstorage.com/lumio-backups/db init
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+
+# Backblaze B2 (B2 backend)
+export B2_ACCOUNT_ID="<b2-key-id>"
+export B2_ACCOUNT_KEY="<b2-app-key>"
+restic -r b2:lumio-db-backup:db init
+```
+
+## 5. Versioning + Object Lock su `lumio-prod`
+
+Protegge le immagini da cancellazioni accidentali/malevole prima ancora che
+parta il sync settimanale. Su Hetzner questo si attiva solo via CLI (non
+nella UI):
+
+```bash
+mc alias set lumio https://fsn1.your-objectstorage.com <prod-key> <prod-secret>
+mc version enable lumio/lumio-prod
+
+# Optional but recommended: expire old versions after 30 days (cost!)
+mc ilm rule add lumio/lumio-prod --noncurrent-expire-days 30
+```
+
+L'Object Lock (WORM, protezione ransomware) può essere attivato solo alla
+**creazione del bucket** — per un `lumio-prod` esistente, versioning +
+lifecycle è la via pragmatica. Per il massimo irrobustimento, crea un nuovo
+bucket con Object Lock e migra (un progetto a parte).
+
+## 6. Remote rclone
+
+```bash
+rclone config
+```
+
+Crea due remote:
+
+- **`hetzner`** — tipo `s3`, provider `Other`, endpoint
+  `fsn1.your-objectstorage.com`, le credenziali di `lumio-prod`.
+- **`b2`** — tipo `b2`, con `keyID` e `applicationKey`.
+
+Test:
+
+```bash
+rclone lsd hetzner:lumio-prod
+rclone lsd b2:
+```
+
+## 7. File di configurazione
+
+```bash
+cp /opt/docker/lumio/lumio/scripts/lumio-backup.env.example /etc/lumio-backup.env
+chmod 600 /etc/lumio-backup.env
+nano /etc/lumio-backup.env   # fill in all __PLACEHOLDERS__
+```
+
+Copia gli script in una posizione fissa e rendili eseguibili:
+
+```bash
+install -m 700 /opt/docker/lumio/lumio/scripts/lumio-backup.sh     /usr/local/bin/
+install -m 700 /opt/docker/lumio/lumio/scripts/lumio-media-sync.sh /usr/local/bin/
+```
+
+Testa manualmente la prima esecuzione:
+
+```bash
+/usr/local/bin/lumio-backup.sh
+restic -r b2:lumio-db-backup:db snapshots   # snapshot there?
+```
+
+## 8. Cron
+
+```cron
+# Postgres daily at 03:00
+0 3 * * * /usr/local/bin/lumio-backup.sh >> /var/log/lumio-backup.log 2>&1
+
+# Images/videos weekly, Sunday 03:30
+30 3 * * 0 /usr/local/bin/lumio-media-sync.sh >> /var/log/lumio-media-sync.log 2>&1
+```
+
+Per un'operatività SaaS molto attiva (molte transazioni Stripe), aumenta la
+frequenza di Postgres a ogni 6 o 12 ore.
+
+## 9. Dead man's switch
+
+Il guasto più pericoloso è quello **silenzioso** — il cron smette di girare
+e nessuno se ne accorge. Crea due check su
+[healthchecks.io](https://healthchecks.io) (gratuito) e inserisci gli URL di
+ping come `HEALTHCHECK_URL` e `MEDIA_HEALTHCHECK_URL` in
+`/etc/lumio-backup.env`. Gli script fanno ping a `/start`, successo e
+`/fail` automaticamente; se un job non gira entro il periodo previsto, il
+servizio ti avvisa via email/push.
+
+## 10. Semaforo di stato backup nel super admin (opzionale)
+
+Dopo ogni successo lo script scrive un file di stato (`STATUS_FILE`,
+default `/backup/lumio/status.txt`). Il semaforo di stato backup integrato
+di Lumio nell'area super admin può leggerlo e mostrare età/dimensione
+(verde < 24 h, giallo < 72 h, rosso oltre).
+
+Per questo il container API deve poter vedere il file. In
+`docker-compose.prod.yml` aggiungi al servizio `api`:
+
+```yaml
+    environment:
+      - BACKUP_STATUS_PATH=/backup-status/status.txt
+    volumes:
+      - /backup/lumio:/backup-status:ro
+```
+
+> Questa è una modifica a Compose/deploy (solo server principale,
+> `BACKUP_STATUS_PATH` è una env opzionale con un default). Senza questo
+> passaggio il backup funziona comunque al 100% — solo il semaforo resta su
+> "non attivo".
+
+---
+
+## Test di restore
+
+**Fallo una volta a trimestre**, idealmente su una VM usa e getta.
+
+### Restore di Postgres (in un DB di test)
+
+```bash
+export RESTIC_PASSWORD_FILE=/root/.lumio-restic-pwd
+export B2_ACCOUNT_ID="<b2-key-id>"; export B2_ACCOUNT_KEY="<b2-app-key>"
+
+restic -r b2:lumio-db-backup:db restore latest --target /tmp/restored
+cd /opt/docker/lumio/lumio
+docker compose exec -T postgres psql -U lumio -c "DROP DATABASE IF EXISTS lumio_test;"
+docker compose exec -T postgres psql -U lumio -c "CREATE DATABASE lumio_test;"
+docker compose exec -T postgres pg_restore -U lumio -d lumio_test < /tmp/restored/tmp/lumio-dump.*/lumio.dump
+
+# Sanity: tables + row counts
+docker compose exec -T postgres psql -U lumio -d lumio_test -c "\dt"
+```
+
+Tabelle presenti e row count plausibili → il backup di Postgres è OK.
+
+### Restore completo (una nuova istanza completa)
+
+1. Installa Lumio da zero su una nuova VM (vedi `SELFHOSTING.md`).
+2. Ferma i container: `docker compose stop`.
+3. Ripristina `.env` dallo snapshot restic (`env.backup`) — contiene
+   password + credenziali S3!
+4. Carica il dump di Postgres (come sopra, ma nel DB reale invece di
+   `lumio_test`).
+5. Sincronizza di nuovo le immagini dal bucket B2:
+   `rclone sync b2:lumio-media-backup hetzner:lumio-prod`.
+6. Avvia i container, testa il login + una galleria.
+
+Se funziona, in un disastro reale sei di nuovo online in ~1 ora.
+
+---
+
+## Cosa non serve backuppare
+
+- `redis_data` – solo la coda dei job. I job in corso vanno persi, il
+  sistema si avvia comunque pulito.
+- `caddy_data` – certificati TLS, Caddy li riscarica automaticamente
+  (attento solo al rate limit di Let's Encrypt).
+- `minio_data` – vuoto quando si usa S3 esterno.
+- Immagini dei container – arrivano dal registry.
+
+---
+
+## Frequenza dei backup (riepilogo)
+
+| Asset | Frequenza | Motivazione |
+|---|---|---|
+| Postgres | giornaliero (SaaS eventualmente 6–12 h) | Alto valore dei dati, dimensione ridotta |
+| Bucket S3 (immagini) | settimanale | Grande volume di dati, cambiamento lento |
+| `.env` | a ogni backup del DB | Un restore senza `.env` è doloroso (incluso nella directory del dump) |
+| Test di restore completo | trimestrale | Convalida l'integrità del backup |

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](BACKUP.de.md)
+**English** · [Deutsch](BACKUP.de.md) · [Italiano](BACKUP.it.md)
 
 # Backup
 

--- a/docs/BRAND.de.md
+++ b/docs/BRAND.de.md
@@ -1,4 +1,4 @@
-[English](BRAND.md) · **Deutsch**
+[English](BRAND.md) · **Deutsch** · [Italiano](BRAND.it.md)
 
 # Lumio — Marke
 

--- a/docs/BRAND.it.md
+++ b/docs/BRAND.it.md
@@ -1,0 +1,112 @@
+[English](BRAND.md) · [Deutsch](BRAND.de.md) · **Italiano**
+
+# Lumio — Brand
+
+## Il simbolo
+
+Quattro tessere di uguale dimensione su una griglia rigorosa 2×2, tagliate da
+un'unica linea retta a 45°. Un contact sheet con un tratto di selezione: la
+tessera arancione sta libera, due sono tagliate, una resta intatta.
+
+Una linea retta può tagliare al massimo due tessere in questa griglia — quindi
+la divisione non è arbitraria, è l'unica disposizione in cui la tessera
+arancione resta intera.
+
+## Colori
+
+| Ruolo  | Hex       | Uso                                             |
+|--------|-----------|--------------------------------------------------|
+| Ink    | `#12121A` | tessere, wordmark, superfici scure                |
+| Accent | `#FF4D2E` | esattamente una tessera, il puntino della i, il descrittore |
+| Paper  | `#FAF8F5` | sfondo chiaro, tessere su superfici scure         |
+
+Niente blu, niente violetto, niente gradiente dal blu al viola — quella è la
+divisa delle altre app foto self-hosted, ed è il motivo per cui la prima bozza
+è stata scartata.
+
+## Tipografia
+
+- **Wordmark: Quicksand SemiBold**, convertita in tracciati. I file del logo
+  quindi non caricano alcun webfont. Quicksand viene usata *solo* per la
+  wordmark, mai per il testo del corpo.
+- **UI e testo: Inter.** Invariata, già in uso in tutti i repo.
+
+## File
+
+`apps/frontend/public/`
+
+| File                   | Scopo                                             |
+|------------------------|----------------------------------------------------|
+| `favicon.svg`          | simbolo; l'ink segue `prefers-color-scheme`         |
+| `favicon-16/32.png`    | fallback per browser più vecchi                     |
+| `apple-touch-icon.png` | 180×180, sfondo opaco (iOS non gradisce l'alpha)    |
+| `icon-512.png`         | web manifest, PWA                                   |
+| `mark.svg`             | solo simbolo                                        |
+| `logo.svg`             | simbolo + wordmark, orizzontale                     |
+| `logo-inverse.svg`     | lo stesso per superfici scure                       |
+| `wordmark.svg`         | solo wordmark                                       |
+
+`brand/` — sorgenti, non serviti
+
+| File                   | Scopo                                        |
+|------------------------|-----------------------------------------------|
+| `logo-cloud.svg`       | lockup impilato con `CLOUD`                    |
+| `logo-selfhosted.svg`  | lockup impilato con `SELF-HOSTED`              |
+| `mark-mono.svg`        | monocolore, per timbri e usi a qualità fax    |
+| `mark-inverse.svg`     | tessere chiare                                 |
+
+## Nel codice
+
+`Logo` da `@/components/ui`, varianti `mark` e `full`:
+
+```tsx
+<Logo variant="full" className="h-6 w-auto" />
+```
+
+L'ink segue `currentColor`; l'accent segue `--logo-accent`, che è legato a
+`--brand-accent`. Quindi dove il simbolo sostituisce un logo di studio
+mancante, porta il colore di accento di quello studio. Su una superficie
+scura, basta impostare un colore di testo chiaro — nessun secondo file
+necessario.
+
+I file statici sotto `public/` (`favicon.svg`, `logo.svg`, le immagini OG)
+mantengono il vermiglio fisso. Quelli sono Lumio come prodotto, non del
+tenant.
+
+## Testo su superfici arancioni
+
+Le etichette su vermiglio sono **paper `#FAF8F5`**, non ink. Questa è una
+deviazione deliberata da WCAG 2, e nasce dalla misurazione:
+
+| Su `#FF4D2E` | WCAG 2 | APCA |
+|---|---|---|
+| Ink `#12121A` | 5.64 | Lc +44 — solo testo grande |
+| Paper `#FAF8F5` | 3.12 | Lc −60 — va bene per il testo del corpo |
+
+APCA è l'algoritmo successore a derivazione percettiva ed è notevolmente più
+accurato per colori saturi a luminosità media. WCAG 2 sovrastima
+sistematicamente il testo scuro su riempimenti saturi; su uno schermo reale,
+paper si legge chiaramente meglio.
+
+La regola che ne consegue: le etichette su superfici arancioni mai sotto i
+14 px e almeno `font-weight: 600`.
+
+**Se WCAG 2.1 AA deve essere formalmente dichiarato** — EN 301 549 e la
+normativa tedesca BFSG fanno riferimento a WCAG 2, non ad APCA — il rimedio è
+*un'unica* modifica in *un unico* punto: scurire l'accent a `#C93214`, incluso
+il simbolo, i favicon e le immagini OG. Questo mantiene un tono unico con
+entrambi gli algoritmi verdi. Due arance distinte sono state testate e
+respinte: simbolo e bottone affiancati nell'header si leggevano come un
+errore.
+
+## Regole
+
+- Esattamente **una** tessera porta l'accent. Mai due, mai tutte e quattro.
+- Il taglio resta un'unica linea retta continua. Non piegarlo, non
+  specchiarlo, non centrarlo.
+- L'interno delle tessere resta vuoto. Nessun simbolo, nessuna lettera lì
+  dentro.
+- Dimensione minima 16 px. Non usarlo sotto quella soglia.
+- Lascia almeno la larghezza di una tessera di spazio libero intorno al logo.
+- Su uno sfondo movimentato (una foto), posiziona il simbolo su un chip
+  opaco, altrimenti il taglio si riempie di immagine.

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](BRAND.de.md)
+**English** · [Deutsch](BRAND.de.md) · [Italiano](BRAND.it.md)
 
 # Lumio — Brand
 

--- a/docs/DEVELOPMENT.de.md
+++ b/docs/DEVELOPMENT.de.md
@@ -1,4 +1,4 @@
-[English](DEVELOPMENT.md) · **Deutsch**
+[English](DEVELOPMENT.md) · **Deutsch** · [Italiano](DEVELOPMENT.it.md)
 
 # Lumio — Development Guide
 

--- a/docs/DEVELOPMENT.it.md
+++ b/docs/DEVELOPMENT.it.md
@@ -1,0 +1,555 @@
+[English](DEVELOPMENT.md) · [Deutsch](DEVELOPMENT.de.md) · **Italiano**
+
+# Lumio — Development Guide
+
+## Requisiti
+
+- **Docker** + **Docker Compose v2** (funziona anche Compose v1, ma senza la CLI `docker compose`)
+- **Node.js 20+** (per API + frontend senza Docker)
+- **Python 3.12+** (per il worker senza Docker)
+- **pnpm** o **npm** (nel setup standard usiamo npm)
+- **git** e un client Forgejo/Git
+
+## Primo setup
+
+```bash
+git clone https://github.com/markusthiel/lumio.git
+cd lumio
+cp .env.example .env
+```
+
+**Importante:** cambia almeno questi valori in `.env`:
+
+- `POSTGRES_PASSWORD` — una stringa casuale lunga qualsiasi
+- `S3_ACCESS_KEY`, `S3_SECRET_KEY` — credenziali MinIO
+- `JWT_SECRET`, `SESSION_SECRET` — `openssl rand -base64 32`
+
+## Completamente in Docker
+
+```bash
+docker compose up -d --build
+```
+
+Al primo avvio succede quanto segue:
+
+1. Postgres si avvia, crea il DB, carica le estensioni
+2. MinIO si avvia, crea il bucket (tramite il servizio `minio_init`)
+3. L'API esegue la migrazione Prisma e si avvia sulla porta 3001
+4. Il frontend si compila e si avvia sulla porta 3000
+5. Caddy si aggancia a 80/443
+
+Raggiungibili:
+
+- Frontend: http://localhost:3000
+- API health: http://localhost:3001/health
+- Console MinIO: http://localhost:9001
+- (via Caddy sulla porta 80, routing unificato)
+
+Visualizza i log:
+
+```bash
+docker compose logs -f api
+docker compose logs -f worker
+```
+
+Ferma:
+
+```bash
+docker compose down              # keeps volumes
+docker compose down -v           # deletes everything incl. DB/storage
+```
+
+## Production deployment
+
+Il `docker-compose.yml` di default fa partire uno stack funzionante — ma per un deployment reale dietro un dominio pubblico ci sono alcune impostazioni che, se non le configuri correttamente fin dall'inizio, creeranno sicuramente problemi al primo bring-up. Questa checklist riassume tutto quello che un self-hoster dovrebbe sapere prima del primo `docker compose up`.
+
+### Tre topologie — quale fa per te?
+
+**A) Lumio gestisce il TLS da sé**
+- IP/VM proprio, il Caddy di Lumio si aggancia a 80+443
+- Caddy recupera automaticamente i certificati Let's Encrypt
+- La variante più semplice se l'host è dedicato esclusivamente a Lumio
+
+**B) Dietro un proxy TLS esterno** (es. Caddy/Nginx/Traefik nello stesso ambiente per più servizi)
+- Il proxy esterno gestisce la terminazione HTTPS
+- Il Caddy di Lumio ascolta internamente su HTTP, il proxy esterno fa da passthrough
+- Quello che usiamo in questo progetto
+
+**C) Setup locale / test**
+- Tutto su `localhost`, nessun hostname reale
+- Il `.env.example` di default è pensato per questo caso
+
+### Configurazione DNS
+
+Lumio ha bisogno di **due** hostname:
+
+1. **Dominio dell'app** (es. `galleries.example.com`) — frontend + API
+2. **Sottodominio S3** (es. `s3.galleries.example.com`) — MinIO/archiviazione oggetti
+
+Il sottodominio S3 non è opzionale. Abbiamo provato a farlo funzionare tramite un prefisso di percorso del dominio principale (`/s3/...`), ma MinIO non lo supporta — la firma V4 copre l'intero percorso, un rewrite del reverse proxy produce sempre `SignatureDoesNotMatch`. Un sottodominio separato è la via standard, anche nella documentazione ufficiale di MinIO.
+
+Entrambi i record A puntano allo stesso IP.
+
+### `.env` per ogni topologia
+
+**A) Lumio gestisce il TLS da sé:**
+```env
+LUMIO_HOST=galleries.example.com
+LUMIO_S3_HOST=s3.galleries.example.com
+PUBLIC_URL=https://galleries.example.com
+S3_PUBLIC_URL=https://s3.galleries.example.com
+CADDY_HTTP_PORT=80
+CADDY_HTTPS_PORT=443
+```
+
+Importante: NESSUN prefisso `http://` su `LUMIO_HOST`/`LUMIO_S3_HOST` — altrimenti Caddy pensa che tu voglia solo HTTP e non recupera nessun certificato.
+
+**B) Dietro un proxy TLS esterno:**
+```env
+LUMIO_HOST=http://galleries.example.com
+LUMIO_S3_HOST=http://s3.galleries.example.com
+PUBLIC_URL=https://galleries.example.com
+S3_PUBLIC_URL=https://s3.galleries.example.com
+CADDY_HTTP_PORT=32080
+CADDY_HTTPS_PORT=32443
+FRONTEND_PORT=33030
+API_PORT=33031
+MINIO_API_PORT=32091
+MINIO_CONSOLE_PORT=32092
+```
+
+Qui CON il prefisso `http://` — altrimenti il Caddy di Lumio prova a fare da sé Let's Encrypt per gli hostname e fallisce.
+
+Nel proxy esterno serve poi:
+
+```caddyfile
+galleries.example.com {
+    reverse_proxy <docker-host>:32080
+}
+s3.galleries.example.com {
+    reverse_proxy <docker-host>:32080
+}
+```
+
+Importante: **non sovrascrivere l'header Host** nel proxy esterno. Il comportamento di default in Caddy/Nginx è corretto, ma se qualcuno ci ha scritto `proxy_set_header Host $proxy_host` oppure `header_up Host {upstream_hostport}` di Caddy — toglilo. MinIO verifica la firma V4 tramite l'header Host della richiesta, che deve corrispondere a quello con cui l'API ha firmato l'URL (`S3_PUBLIC_URL`).
+
+**C) Setup locale:** i default di `.env.example` vanno bene, non cambiare nulla.
+
+### Controlla i conflitti di porta prima dell'avvio
+
+Prima di eseguire `docker compose up`, controlla per sicurezza che le porte siano libere:
+
+```bash
+ss -tlnp | grep -E ':(32080|32443|33030|33031|32091|32092)\s'
+```
+
+Nessun output = tutto libero. Importante: i mapping `127.0.0.1:3000` (binding su loopback) **non proteggono** da conflitti con listener su `0.0.0.0:3000` — il kernel riserva la porta indipendentemente dall'indirizzo.
+
+### Genera i secret
+
+```bash
+openssl rand -base64 32   # JWT_SECRET
+openssl rand -base64 32   # SESSION_SECRET
+openssl rand -base64 24   # POSTGRES_PASSWORD
+openssl rand -base64 24   # S3_ACCESS_KEY (shorter looks more like a real access key)
+openssl rand -base64 32   # S3_SECRET_KEY
+```
+
+Metti questi valori in `.env`.
+
+### Bring-up
+
+```bash
+docker compose up -d --build
+docker compose ps                    # all "Up" / "healthy"?
+docker compose logs --tail=30 api    # "Lumio API ready" visible?
+```
+
+Se i container partono ma poi si riavviano: `docker compose logs --tail=50 <service>` mostra il perché per ciascuno.
+
+### Crea un utente admin
+
+```bash
+docker compose exec api npm run create-admin -- \
+    --email=you@example.com --password=long_password --name="Your Studio"
+```
+
+In modalità multi-tenant serve inoltre `--tenant=<slug> --tenant-name="..."`.
+
+### Smoke test
+
+Dopo l'avvio, clicca sistematicamente in questo ordine:
+
+1. **Login** su `https://galleries.example.com/login` → studio
+2. **Crea un branding** → carica un logo (PNG ~200 KB) → il logo compare nell'editor
+3. **Crea una galleria** → collega il branding → stato su `live`
+4. **Carica un'immagine di test** nel dettaglio galleria dello studio → lo stato passa da `uploading → processing → ready`, appare una thumbnail
+5. **Opzionale: test video** (~30 s, MP4 H.264) → stesso flusso, il worker fa in più il transcoding HLS
+6. **Copia il link di condivisione** → aprilo in una scheda in incognito → le immagini sono visibili
+
+Se uno di questi passaggi va storto, `docker compose logs --tail=80 api worker` mostra la causa. Gli errori più comuni al primo deploy sono elencati più sotto in "Problemi comuni".
+
+### Backup
+
+Fai il backup almeno di questi due volume:
+
+- `postgres_data` — metadati (utenti, gallerie, record dei file, sessioni)
+- `minio_data` — tutti i file immagine/video
+
+Esempio con `restic` per un backup giornaliero di entrambi:
+
+```bash
+docker run --rm \
+    --volumes-from lumio_postgres \
+    --volumes-from lumio_minio \
+    -e RESTIC_REPOSITORY=... -e RESTIC_PASSWORD=... \
+    restic/restic backup /var/lib/postgresql/data /data
+```
+
+(Adatta al tuo stack di backup.)
+
+### Codifica video hardware (opzionale)
+
+Il transcoding HLS domina il carico del worker sulle gallerie grandi. Di default Lumio usa `libx264` (CPU) — portabile, funziona ovunque senza configurazione. Se hai una GPU, puoi passare il worker alla codifica hardware e transcodificare 5–10× più velocemente a seconda della sorgente.
+
+Si controlla tramite la variabile d'ambiente `LUMIO_HW_ENCODER` nel container worker:
+
+| Valore | Significato |
+|---|---|
+| `auto` (predefinito) | Prova NVENC → QSV → VAAPI, ripiega sul software |
+| `nvenc` | GPU NVIDIA (RTX/Quadro/ecc.) |
+| `qsv` | Intel QuickSync |
+| `vaapi` | VA-API (Intel/AMD su Linux) |
+| `software` | Forza `libx264`, nessuna verifica hardware |
+
+Con `auto` il worker proverà, al primo video, quali encoder il binario ffmpeg supporta davvero (`ffmpeg -encoders`), e metterà in cache il risultato.
+
+**Prerequisiti lato container:**
+
+- **VAAPI** (il più semplice — GPU Intel o GPU AMD su un host Linux):
+  ```yaml
+  worker:
+    devices:
+      - /dev/dri/renderD128:/dev/dri/renderD128
+    group_add:
+      - "render"   # GID of the render group on the host (cat /etc/group | grep render)
+    environment:
+      LUMIO_HW_ENCODER: "vaapi"
+  ```
+  Il pacchetto ffmpeg di Debian nell'immagine worker standard ha già VAAPI incluso.
+
+- **NVENC** (GPU NVIDIA): NVIDIA Container Toolkit installato + avvia il worker con `--gpus all`. Il ffmpeg standard dei repo Debian **non** ha NVENC compilato — serve un'immagine con `jellyfin/ffmpeg` o un ffmpeg auto-compilato con `--enable-nvenc`.
+
+- **QSV** (Intel): come VAAPI, più in aggiunta `intel-media-va-driver`.
+
+Senza questi passaggi di setup funziona solo `software`; `auto` lo rileva e ripiega di conseguenza, un avviso finisce nel log del worker (`encoder.requested_unavailable`).
+
+### Deployment dalla container registry
+
+> **Nota:** questo percorso è interno ai maintainer (registry privata). Self-hoster e collaboratori esterni compilano le immagini dal sorgente (`docker compose up -d --build`) e non hanno bisogno di accesso alla registry.
+
+La CI compila tre immagini container a ogni push su `main` e le pubblica sulla Forgejo container registry:
+
+```
+forgejo.thiel.tools/thiel/lumio-api:<tag>
+forgejo.thiel.tools/thiel/lumio-frontend:<tag>
+forgejo.thiel.tools/thiel/lumio-worker:<tag>
+```
+
+Schema dei tag:
+
+- `:latest` e `:main` — l'ultima build riuscita di `main`
+- `:v0.2.0` — i tag Git (`v*`) vengono ripresi 1:1 come tag dell'immagine
+- `:<short-sha>` — ogni build riceve in aggiunta il proprio commit SHA come tag, in modo da poter fissare esattamente una versione del codice
+
+Sull'host di produzione usi il `docker-compose.prod.yml` come override, che sostituisce i blocchi `build:` con riferimenti `image:`:
+
+```bash
+cd /opt/docker/lumio/lumio
+git pull   # only to keep docker-compose.* up to date
+
+docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.prod.yml \
+    pull
+
+docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.prod.yml \
+    up -d
+```
+
+Selezione del tag tramite la variabile d'ambiente `LUMIO_TAG`:
+
+```bash
+LUMIO_TAG=v0.2.0 docker compose \
+    -f docker-compose.yml \
+    -f docker-compose.prod.yml \
+    up -d
+```
+
+Se la tua registry Forgejo è privata (il default per repository non pubblici), serve un login di pull sul server:
+
+```bash
+docker login forgejo.thiel.tools
+# Username: your Forgejo name
+# Password: Forgejo personal access token with scope `read:package`
+```
+
+Il login viene salvato in `~/.docker/config.json` (o `/root/.docker/config.json` per il Compose eseguito come root) e basta per tutti i pull successivi.
+
+**Setup della CI:** il workflow di push sulla registry ha bisogno di due secret in Forgejo sotto `Settings → Actions → Secrets`:
+
+| Nome | Valore |
+|---|---|
+| `REGISTRY_USER` | Il tuo username Forgejo |
+| `REGISTRY_TOKEN` | Personal access token con scope `write:package` |
+
+**Pulizia della registry:** Forgejo ha regole di pulizia integrate sotto `User settings → Packages → Cleanup Rules`. Default sensati per Lumio:
+
+- Match: `lumio-*`
+- Keep the most recent: `5`
+- Keep versions matching: `^(latest|main|v.*)$` (mantiene i tag di branch e release)
+- Remove versions older than: `30 days`
+
+Questo mantiene le ultime 5 build SHA più tutti i tag di release e il puntatore di branch; i tag SHA più vecchi vengono rimossi automaticamente.
+
+### Webhook in uscita (studio → strumenti esterni)
+
+Per ogni tenant puoi configurare endpoint HTTPS che vengono chiamati con un POST firmato su determinati eventi. Configurazione nello studio sotto `/studio/webhooks`. L'attuale whitelist degli eventi (proviene da `apps/api/src/services/webhooks.ts`):
+
+| Evento | Quando |
+|---|---|
+| `gallery.created` | Creata una nuova galleria |
+| `gallery.live` | Lo stato della galleria passa a `live` |
+| `gallery.deleted` | Galleria eliminata definitivamente |
+| `selection.finalized` | Il cliente ha finalizzato la propria selezione |
+| `comment.posted` | Un commento su un file |
+| `file.uploaded` / `file.failed` | riservati, al momento non vengono generati |
+
+**Formato della richiesta:** corpo JSON
+`{ "event": "<type>", "timestamp": "<iso>", "data": { ... } }`
+Header:
+
+```
+Content-Type:      application/json
+X-Lumio-Event:     gallery.created
+X-Lumio-Timestamp: 1730000000
+X-Lumio-Signature: sha256=<hex>
+User-Agent:        Lumio-Webhook/1.0
+```
+
+**Firma:** HMAC-SHA256 su `<timestamp>.<body>` con il secret del webhook. Schema identico a GitHub/Stripe. Esempio di verifica lato ricevente:
+
+**Node/Express:**
+
+```js
+const crypto = require("node:crypto");
+const SECRET = process.env.LUMIO_WEBHOOK_SECRET;
+app.post("/lumio-hook",
+  express.raw({ type: "application/json" }),
+  (req, res) => {
+    const ts = req.header("X-Lumio-Timestamp");
+    const sig = req.header("X-Lumio-Signature");
+    const expected = "sha256=" + crypto
+      .createHmac("sha256", SECRET)
+      .update(`${ts}.${req.body.toString("utf-8")}`)
+      .digest("hex");
+    if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+      return res.status(401).end();
+    }
+    // Replay protection: check the timestamp (e.g. max 5 min old)
+    const age = Math.abs(Date.now() / 1000 - Number(ts));
+    if (age > 300) return res.status(401).end();
+
+    const event = JSON.parse(req.body);
+    // ... process ...
+    res.status(204).end();
+  });
+```
+
+**Python/Flask:**
+
+```python
+import hashlib, hmac, time
+from flask import request, abort
+
+SECRET = b"..."
+
+@app.post("/lumio-hook")
+def hook():
+    ts = request.headers["X-Lumio-Timestamp"]
+    sig = request.headers["X-Lumio-Signature"]
+    body = request.get_data()
+    expected = "sha256=" + hmac.new(
+        SECRET, f"{ts}.".encode() + body, hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        abort(401)
+    if abs(time.time() - int(ts)) > 300:
+        abort(401)
+    payload = request.get_json()
+    # ... process ...
+    return "", 204
+```
+
+**Comportamento dei retry:** con 2xx la consegna è completa. Con 4xx (eccetto 408/429) il worker rinuncia direttamente — il ricevente ha segnalato che la richiesta così com'è non va bene. Con 5xx, un timeout o un errore di rete, il worker ritenta con backoff esponenziale (5s, 25s, 2min, 10min, 1h, poi definitivamente morto). I riceventi quindi non devono garantire il 100% di uptime, ma la gestione dovrebbe essere idempotente — lo stesso evento può arrivare più volte se il primo tentativo era un 5xx e il retry è comunque andato a buon fine.
+
+**Audit:** nello studio sotto `/studio/webhooks` → seleziona un webhook → "Ultime consegne" elenca gli ultimi 50 tentativi con stato HTTP e testo dell'errore. Riuscito = verde, morto = rosso, in attesa = giallo. Tramite `POST /webhooks/:id/test` (il pulsante "Test" nella UI) puoi inviare subito un evento `test.ping` per verificare la validazione del ricevente, senza dover aspettare un trigger reale.
+
+**Ciclo di vita del secret:** alla creazione viene generato una volta sola e restituito nella risposta di creazione. Le GET successive non restituiscono più il secret. Se viene perso: elimina il webhook, creane uno nuovo.
+
+## Ibrido: infrastruttura in Docker, app in locale
+
+Per un hot reload veloce:
+
+```bash
+# 1. Only the infrastructure in Docker
+docker compose up -d postgres redis minio minio_init
+
+# 2. API locally
+cd apps/api
+npm install
+npx prisma migrate deploy
+npm run dev          # port 3001, watch mode
+
+# 3. Frontend locally
+cd apps/frontend
+npm install
+npm run dev          # port 3000, fast refresh
+
+# 4. Worker locally (in a venv)
+cd apps/worker
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+celery -A app worker -l info -c 2
+```
+
+`.env` viene letto in tutte e tre le app (dotenv). Per un setup locale adatta `DATABASE_URL` in modo che punti a `localhost:5432` invece di `postgres:5432` — per farlo, esponi la porta Postgres nel file Compose (vedi il commento in `docker-compose.yml`).
+
+## Crea un utente admin (dev)
+
+Nel setup di sviluppo (app in locale, nessun dominio di produzione):
+
+```bash
+# Via Docker
+docker compose exec api npm run create-admin -- --email=you@example.com --password=secret --name="Your Studio"
+
+# Locally (from source, without a build)
+cd apps/api && npm run create-admin:dev -- --email=you@example.com --password=secret
+```
+
+Nel container di produzione usa invece `create-admin` (senza il suffisso `:dev`), vedi la sezione "Production deployment" più sopra.
+
+## Migrazioni del database
+
+Usiamo Prisma:
+
+```bash
+# Change the schema in apps/api/prisma/schema.prisma, then:
+cd apps/api
+npx prisma migrate dev --name description_of_the_change
+
+# Roll out in the container:
+docker compose exec api npx prisma migrate deploy
+```
+
+## Test
+
+```bash
+cd apps/api && npm test         # Vitest
+cd apps/frontend && npm test    # not set up yet
+cd apps/worker && pytest        # not set up yet
+```
+
+## Code style
+
+- **TypeScript** strict mode, niente `any`
+- **Python** PEP 8 + type hints, `ruff` come linter (ancora da fare)
+- **Commit** secondo Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`
+- **PR** descrivono il cosa e il perché, non il come (quello sta nel codice)
+
+## Problemi comuni
+
+### Generale
+
+- **`pyvips` ha bisogno di libvips42 sul sistema.** Nell'immagine Docker c'è già; in locale `apt install libvips42` (Linux) o `brew install vips` (macOS).
+- **`rawpy` ha bisogno di libraw.** Nell'immagine Docker: `libraw-bin`. In locale: `apt install libraw-dev` e reinstalla.
+- **MinIO con `S3_FORCE_PATH_STYLE=true`** — AWS S3 invece vuole `false`.
+- **CORS con un frontend locale senza Caddy:** l'API deve conoscere `PUBLIC_URL=http://localhost:3000` e impostare CORS di conseguenza. MinIO permette upload dal browser tramite `MINIO_API_CORS_ALLOW_ORIGIN=*` (già impostato in `docker-compose.yml`).
+- **Dimenticato prisma generate:** dopo una modifica dello schema esegui `npx prisma generate`, altrimenti i tipi restano obsoleti.
+- **L'upload multipart ha bisogno dell'header ETag.** S3/MinIO devono **esporre** l'header di risposta `ETag` nelle richieste `UploadPart` (CORS `ExposeHeaders`). MinIO lo fa automaticamente con `MINIO_API_CORS_ALLOW_ORIGIN=*`; con AWS S3 il CORS del bucket deve impostare esplicitamente `<ExposeHeader>ETag</ExposeHeader>`.
+
+### Deployment
+
+Insidie che tipicamente colpiscono al PRIMO vero deploy:
+
+- **`ambiguous site definition: :80`** nel log di Caddy → sia `LUMIO_HOST` che `LUMIO_S3_HOST` risolvono allo stesso indirizzo. Soluzione: usa hostname reali, così Caddy fa routing basato sull'host sulla stessa porta.
+- **`Bind for 0.0.0.0:3000 failed: port is already allocated`** nonostante un binding su `127.0.0.1:` → un altro servizio sull'host è già in ascolto su `0.0.0.0:3000`. Loopback e 0.0.0.0 condividono la stessa riserva di porta nel kernel. Soluzione: scegli una porta libera in `.env` (`FRONTEND_PORT=33030` o simile).
+- **L'upload dal browser fallisce con "DNS error: minio"** → riguarda solo le versioni precedenti alla v0.51.0 (da allora, senza `S3_PUBLIC_URL` l'API firma automaticamente verso `http://<request-host>:9000`). Se succede comunque: `S3_PUBLIC_URL` punta all'hostname interno del container — impostalo sul sottodominio S3 pubblico (`https://s3.galleries.example.com`) o rimuovilo.
+- **L'upload dal browser riceve un 403 `SignatureDoesNotMatch`** → un proxy tra il browser e MinIO modifica l'header Host. MinIO verifica V4 tramite l'Host. Soluzione: `header_up Host {host}` nel Caddy di Lumio, e nel proxy esterno passa l'header Host **invariato** (il default in Caddy, in Nginx `proxy_set_header Host $host;`).
+- **Il logo del branding dello studio mostra un 404 in console** → l'API non è stata ricompilata dopo il fix di `serializeBranding`. `docker compose up -d --build api`.
+- **L'API si riavvia all'infinito con `Could not parse schema engine response`** → Prisma non trova libssl nell'immagine Alpine. Non dovrebbe succedere con il `Dockerfile` di default (installiamo `openssl3` e impostiamo `binaryTargets`), ma se succede: controlla se l'immagine attuale è stata effettivamente compilata.
+- **Il worker si riavvia all'infinito con `wait: Illegal option -n`** → `entrypoint.sh` gira nella shell sbagliata. Lo shebang è `#!/bin/bash`, che dovrebbe andare bene con l'immagine di default.
+- **`create-admin` segnala `tsx: not found`** → l'immagine di produzione include solo `node` + JS compilato. `npm run create-admin` ora chiama `node dist/scripts/create-admin.js`; in modalità dev `npm run create-admin:dev`.
+- **La galleria mostra i file con le thumbnail nello studio, ma la pagina cliente è vuota** → i file probabilmente sono a `status='failed'`. La pagina cliente nasconde i `failed`, lo studio mostra tutto. Controlla il log dell'API/worker per capire cosa è andato storto. Elimina i file e ricaricali — `failed` non riprova automaticamente.
+
+## Pipeline di caricamento (flusso dati)
+
+Ecco come un file scorre nel sistema durante il caricamento:
+
+```
+Browser (uploadFiles)
+   │
+   │ 1) POST /api/v1/uploads/init  (filenames + sizes)
+   ▼
+API
+   │ 1a) Check gallery ownership, check the size limit
+   │ 1b) Per file: file record (status=uploading) + generate a storage key
+   │ 1c) Return presigned PUT URLs (single or multipart parts)
+   ▼
+Browser
+   │ 2) PUT directly to S3/MinIO with progress
+   │ 3) POST /api/v1/uploads/complete  (with the ETag list for multipart)
+   ▼
+API
+   │ 3a) Multipart complete at S3 (if multipart)
+   │ 3b) files.status = "processing"
+   │ 3c) Push a job into the Redis stream "lumio:jobs:file_processing"
+   ▼
+Worker (stream consumer)
+   │ 4) xreadgroup → receives the job
+   │ 5) Celery send_task → process_file.generate_renditions
+   ▼
+Celery worker
+   │ 6) Load S3 → /tmp/source
+   │ 7) pyvips: autorotate → resize → WebP (thumb/preview/web)
+   │ 8) Upload renditions to S3, create DB records
+   │ 9) files.status = "ready"
+   ▼
+The frontend polls /api/v1/galleries/:id every 2s
+   → once ready, the thumb URL is visible in the grid
+```
+
+In fase 2 sostituiremo il polling con un push WebSocket.
+
+## Decisioni architetturali (ADR)
+
+Le decisioni architetturali più importanti sono documentate in `docs/adr/` come brevi record. Formato:
+
+```
+# ADR-NNNN: Title
+
+## Status
+accepted / proposed / superseded
+
+## Context
+Why was the decision due?
+
+## Decision
+What was decided?
+
+## Consequences
+What does that mean positively/negatively?
+```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](DEVELOPMENT.de.md)
+**English** · [Deutsch](DEVELOPMENT.de.md) · [Italiano](DEVELOPMENT.it.md)
 
 # Lumio — Development Guide
 

--- a/docs/GPU.de.md
+++ b/docs/GPU.de.md
@@ -1,4 +1,4 @@
-[English](GPU.md) · **Deutsch**
+[English](GPU.md) · **Deutsch** · [Italiano](GPU.it.md)
 
 # GPU-Beschleunigung (NVIDIA NVENC)
 

--- a/docs/GPU.it.md
+++ b/docs/GPU.it.md
@@ -1,0 +1,102 @@
+[English](GPU.md) · [Deutsch](GPU.de.md) · **Italiano**
+
+# Accelerazione GPU (NVIDIA NVENC)
+
+Per l'elaborazione video (transcodifica HLS di più livelli di qualità) Lumio può usare l'encoder NVENC di NVIDIA. Questo riduce il tempo di transcodifica di un video 1080p di 1 ora da **2-3 ore via software** a **10-20 minuti su una RTX consumer**.
+
+## Requisiti
+
+Questa lista deve essere soddisfatta sul server host prima di attivare la GPU:
+
+1. **Driver NVIDIA installato**
+
+   ```bash
+   nvidia-smi
+   ```
+
+   dovrebbe elencare la GPU più una versione del driver.
+
+2. **NVIDIA Container Toolkit installato**
+
+   Guida: [NVIDIA Docs](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+
+   Versione breve per Ubuntu/Debian:
+
+   ```bash
+   distribution=$(. /etc/os-release; echo $ID$VERSION_ID)
+   curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+     sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+   curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
+     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+     sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+   sudo apt update
+   sudo apt install -y nvidia-container-toolkit
+   sudo nvidia-ctk runtime configure --runtime=docker
+   sudo systemctl restart docker
+   ```
+
+3. **Test**
+
+   ```bash
+   docker run --rm --gpus all nvidia/cuda:12.3.1-base-ubuntu22.04 nvidia-smi
+   ```
+
+   Se questo stampa l'output di `nvidia-smi` da dentro il container → il toolkit funziona.
+
+## Avviare Lumio con GPU
+
+Una volta soddisfatti i requisiti, carichi in aggiunta l'overlay GPU:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.gpu.yml \
+  up -d
+```
+
+All'avvio del worker il log dovrebbe mostrare:
+
+```
+encoder.detected available=['nvenc', 'software']
+encoder.selected name=nvenc
+```
+
+Se invece ottieni `name=software`, è un segno che NVENC non era raggiungibile — di solito un problema di setup del toolkit. Controlla `docker compose logs worker` per la causa esatta.
+
+## GPU condivisa con Jellyfin / Immich / altri
+
+Una GPU consumer (serie RTX 20/30/40) ha ufficialmente un limite di **5 sessioni NVENC simultanee**. Se fai girare Jellyfin e Immich in parallelo sulla stessa GPU e ci attacchi anche Lumio, il limite può diventare stretto.
+
+Soluzione: [nvidia-patch](https://github.com/keylase/nvidia-patch) è una modifica open-source del driver che rimuove il limite. Ampiamente usata nei setup Jellyfin/Plex ed è stabile. Configurala sull'host (non nel container) — Lumio non se ne accorge.
+
+Cosa puoi aspettarti:
+
+- Un worker Lumio esegue **fino a 3 sessioni NVENC simultanee** per video (una per livello di qualità HLS: 480p/720p/1080p)
+- Con più video in coda il worker li elabora in sequenza, non in parallelo — quindi 3 sessioni occupate, non di più
+- Con WORKER_CONCURRENCY > 1 potresti entrare nella zona limite; il default è 1 per i job video
+
+## Girare senza GPU
+
+Basta omettere `-f docker-compose.gpu.yml`:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  up -d
+```
+
+La logica dell'encoder di Lumio (apps/worker/encoder_profile.py) verifica a runtime cosa è disponibile e ricade automaticamente su libx264 (CPU). Non c'è nessun crash e non serve nessun cambio di configurazione — lo stesso stack Compose funziona su server con e senza GPU.
+
+## Controllare l'encoder esplicitamente
+
+Imposta la variabile env `LUMIO_HW_ENCODER` nel container worker:
+
+- `auto` (default) — NVENC → QSV → VAAPI → libx264, in quest'ordine
+- `nvenc` — solo NVENC, ricade su software se la GPU non c'è
+- `qsv` — Intel QuickSync (non rilevante senza una GPU Intel)
+- `vaapi` — VA-API (AMD o Intel)
+- `software` — esplicitamente libx264, anche se una GPU è presente (es. per tenere la GPU libera per altri container)
+
+L'overlay imposta `nvenc` di default — se a volte vuoi far girare il tuo worker solo su CPU (es. perché altri container hanno bisogno della GPU), puoi sovrascriverlo nel tuo `.env`.

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](GPU.de.md)
+**English** · [Deutsch](GPU.de.md) · [Italiano](GPU.it.md)
 
 # GPU acceleration (NVIDIA NVENC)
 

--- a/docs/KONZEPT.de.md
+++ b/docs/KONZEPT.de.md
@@ -1,4 +1,4 @@
-[English](KONZEPT.md) · **Deutsch**
+[English](KONZEPT.md) · **Deutsch** · [Italiano](KONZEPT.it.md)
 
 # Lumio — Konzept & Architektur
 

--- a/docs/KONZEPT.it.md
+++ b/docs/KONZEPT.it.md
@@ -1,0 +1,616 @@
+[English](KONZEPT.md) · [Deutsch](KONZEPT.de.md) · **Italiano**
+
+# Lumio — Concept & Architecture
+
+**Nome del progetto:** Lumio
+**Tipo:** Piattaforma source-available, self-hosted per condividere, fare il proofing e consegnare shooting fotografici e video
+**Licenza:** FSL-1.1-ALv2 (Functional Source License — source-available, non open source secondo OSI)
+**Ispirazione:** Picdrop, Pixieset, Pic-Time, ShootProof
+**Aggiornato a:** giugno 2026
+**Stato:** In produzione. Questo documento descrive il sistema **effettivamente costruito e distribuito** (nato originariamente come documento di pianificazione a maggio 2026, da allora costantemente allineato alla realtà).
+**Repository (pubblico):** https://github.com/markusthiel/lumio — codice dell'app per studio + gallerie cliente. Mantenuto internamente principalmente via Forgejo e specchiato su GitHub; i due siti marketing in Astro vivono in repository separati e interni.
+
+---
+
+## 1. Visione & posizionamento
+
+Un'alternativa a Picdrop self-hosted, veloce e attenta alla privacy — costruita per fotografi e piccoli studi che vogliono mantenere il pieno controllo dei propri dati (GDPR, NDA, clienti aziendali). L'obiettivo **non** è "parità di funzionalità con Adobe Lightroom", ma: riprodurre in modo pulito, come stack Docker, ciò che Picdrop fa davvero bene.
+
+**Tre principi guida:**
+
+1. **Veloce.** Caricamenti, thumbnail, rendering della galleria devono sembrare app native. Niente scatti da lazy-loading, niente 5 secondi di attesa per una thumbnail da 12 MP.
+2. **Semplice per i clienti finali.** Nessun login. Nessun "crea un account". Apri il link — guarda, metti like, commenta, scarica. Mobile-first.
+3. **All'altezza dei professionisti.** RAW, video di grandi dimensioni, molte migliaia di file per galleria, un workflow Lightroom/Capture One, branding, condivisioni sicure.
+
+---
+
+## 2. Stack tecnologico
+
+Lo stack effettivamente in uso (dopo aver soppesato performance, elaborazione delle immagini, velocità di sviluppo ed ecosistema):
+
+| Livello                   | Tecnologia                                    | Motivazione                                                                                                                  |
+| ------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **Frontend**              | **Next.js 16 (App Router, Turbopack) + React 19 + TypeScript** | Server Components per un rendering iniziale veloce, una buona pipeline immagini, un ecosistema enorme. Siti marketing separati in Astro. |
+| **UI**                    | Tailwind CSS + shadcn/ui + Radix              | Componenti di alta qualità e personalizzabili senza appesantire. Adatto al whitelabel.                                                      |
+| **Visualizzatore immagini**           | PhotoSwipe v5 o OpenSeadragon              | Lo standard di settore per lightbox/deep zoom. Gesti touch, tastiera, schermo intero, pinch zoom.                                  |
+| **Player video**          | Video.js o Vidstack                        | Streaming HLS, bitrate adattivo, sottotitoli, immagini di anteprima durante lo scrubbing.                                                   |
+| **Backend API**           | **Node.js + Fastify + TypeScript + Prisma (PostgreSQL)** | Molto veloce, stesso linguaggio del frontend → tipi condivisi (`packages/shared`), schemi Zod. Prisma come ORM con migrazioni versionate. |
+| **Worker (elaborazione)** | **Python + Celery** (container separato)     | Per l'elaborazione RAW/video l'ecosistema Python (rawpy, Pillow, OpenCV, PyAV) batte chiaramente Node. Una netta separazione API ↔ CPU. |
+| **Coda / cache**         | Redis (ioredis nell'API per rate limiting/sessioni, il broker Celery per i job del worker) | Coda di job per thumbnail/transcodifica/tagging, rate limiting, sessioni. Redis è protetto da password. |
+| **Database**             | **PostgreSQL 16**                              | JSONB per metadati flessibili (EXIF), ricerca full-text, maturo, transazionalmente sicuro.                                         |
+| **Archiviazione oggetti**        | **Compatibile S3**, liberamente selezionabile via `STORAGE_PROVIDER` (MinIO incluso di serie; in produzione su lumio-cloud.de: **Hetzner Object Storage**) | Scala orizzontalmente, backup semplici, URL presigned per il caricamento diretto dal browser (alleggerisce il backend). |
+| **Reverse proxy**         | Caddy o Traefik                            | Let's Encrypt automatico, HTTP/3, integrazione Compose semplice.                                                          |
+| **Auth (lato studio)**   | Auth di sessione propria (hashing argon2id, sessioni su Redis) | Cookie HTTP-only, TOTP 2FA, passkey/WebAuthn, token API per i plugin.                                            |
+| **Auth (lato galleria)**  | Token URL firmati (JWT) + password opzionale   | Stile Picdrop: nessun account per i clienti.                                                                                      |
+
+### Scelta del provider di archiviazione
+
+Poiché la condivisione di foto è **poco scrittura, molta lettura** (caricato una volta, scaricato molte volte), vale la pena guardare i prezzi di egress. Lumio supporta tutti i provider compatibili S3 tramite un unico interruttore `STORAGE_PROVIDER`:
+
+| Provider           | Prezzo storage  | Egress         | Quando ha senso                                                |
+| ------------------ | -------------- | -------------- | ------------------------------------------------------------ |
+| **MinIO** (locale)  | costo hardware | solo banda | Self-hosting sul proprio server, massima sovranità dei dati       |
+| **Cloudflare R2**  | molto economico    | **0 €**         | Consigliato per il modo hosted — i download non costano nulla        |
+| **Backblaze B2**   | molto economico    | economico         | Una buona alternativa, ampia scelta di regioni                      |
+| **AWS S3**         | medio          | costoso           | Se l'ecosistema AWS è comunque già presente                     |
+| **Wasabi**         | economico         | incl.           | Modello "tutto incluso", nessuna commissione di egress nascosta    |
+| **Hetzner Object Storage** | economico | incl. (in DE)   | GDPR-friendly, provider europeo                      |
+
+I prezzi concreti oscillano — verifica presso il provider. Per setup puramente self-hosted, **MinIO nello stesso Compose** è la via più semplice (default). L'istanza SaaS di produzione **lumio-cloud.de** gira volutamente su **Hetzner Object Storage** (UE/GDPR, egress incluso). Per setup ad alto traffico senza vincoli GDPR, **Cloudflare R2** (egress a 0 €) resta economicamente interessante.
+
+Il passaggio tra provider è possibile (`rclone sync s3-old:bucket s3-new:bucket` più il cambio di `S3_ENDPOINT`) — tutte le renditions sono reperibili tramite chiavi deterministiche.
+
+### Perché non fare tutto in un solo linguaggio?
+
+Avevo considerato di costruire il backend interamente in Python (FastAPI) — RAW/video ci si sarebbero adattati in modo nativo. Tuttavia:
+
+- Fastify è chiaramente più veloce nel livello API a elevato I/O (coordinamento upload, WebSocket per la collaborazione live, URL presigned) e lavora meglio con gli stream S3.
+- La separazione del worker è comunque necessaria (non vuoi una conversione RAW da 30 secondi nel processo API), quindi il worker può tranquillamente essere Python.
+- I tipi TypeScript condivisi tra frontend e API fanno risparmiare un numero enorme di bug.
+
+L'unico confine tra linguaggi è API ↔ worker via la coda Redis con payload JSON — pulito e stabile.
+
+### Alternative (se vuoi fare diversamente)
+
+- **TypeScript puro:** backend + worker entrambi in Node. Sharp per JPEG/PNG/TIFF/WebP è eccellente, `libraw` è raggiungibile via FFI, ma la gestione dei RAW diventa complicata. Le chiamate a ffmpeg sono indipendenti dal linguaggio.
+- **Python puro:** FastAPI + Celery + SSR Jinja o HTMX. Uno stack snello, ottimo per sviluppatori solo, ma il frontend diventa più faticoso per le interazioni impegnative della galleria.
+- **Go:** massime prestazioni, ma l'ecosistema immagini/video è più sottile; molto dovrebbe passare per CGO/sottoprocessi.
+
+---
+
+## 3. Architettura dei componenti
+
+```
+                                  ┌──────────────────┐
+                                  │   Reverse proxy  │
+                                  │  (Caddy/Traefik) │
+                                  │   TLS, HTTP/3    │
+                                  └────────┬─────────┘
+                                           │
+              ┌────────────────────────────┼────────────────────────────┐
+              │                            │                            │
+        ┌─────▼─────┐              ┌───────▼────────┐           ┌──────▼──────┐
+        │ Frontend  │              │   API server   │           │  MinIO/S3   │
+        │ Next.js   │◄────────────►│ Fastify (Node) │           │  Object     │
+        │           │   REST/WS    │                │           │  storage    │
+        └───────────┘              └───┬────────┬───┘           └──────▲──────┘
+                                       │        │                      │
+                                       │        │  Presigned PUT/GET   │
+                                       │        └──────────────────────┘
+                                       │
+                          ┌────────────┼────────────┐
+                          │            │            │
+                    ┌─────▼─────┐ ┌────▼────┐ ┌────▼──────────┐
+                    │ Postgres  │ │  Redis  │ │ Worker pool   │
+                    │ (metadata)│ │ (queue) │ │ Python+Celery │
+                    └───────────┘ └─────────┘ │ - thumbnails  │
+                                              │ - RAW decode  │
+                                              │ - video trans │
+                                              │ - ZIP build   │
+                                              └───────────────┘
+```
+
+### Componenti nel dettaglio
+
+**1. Reverse proxy** — TLS, routing HTTP, caching degli asset statici, opzionalmente Brotli/Zstd.
+
+**2. Frontend (Next.js)** — due aree:
+
+- **Studio** (`/studio/*`): la dashboard per il fotografo. Creazione gallerie, caricamento, statistiche, impostazioni, branding.
+- **Galleria** (`/g/[slug]`): quello che vedono i clienti. Veloce, focalizzata, ottimizzata per mobile. I Server Components per le parti irrilevanti per SEO/anteprima vanno bene qui, ma il vero e proprio visualizzatore è un Client Component per l'interattività.
+
+**3. Server API (Fastify)** — endpoint REST + un server WebSocket per la collaborazione live. Gestisce le sessioni, valida i token, firma gli URL S3, coordina i job del worker. **Non** fa mai passare le immagini attraverso di sé — sempre URL presigned.
+
+**4. Worker (Python/Celery)** — il livello ad alto uso di CPU. Modello pull: job dalla coda Redis, altamente scalabile (più repliche possibili, worker GPU possibili per ffmpeg+NVENC).
+
+**5. PostgreSQL** — metadati (utenti, gallerie, file, commenti, valutazioni, audit log).
+
+**6. Redis** — coda dei job, rate limiting, session store opzionale, pub/sub per il fanout WebSocket.
+
+**7. Archiviazione oggetti (compatibile S3)** — originali + renditions derivate (thumbnail, preview, web, con watermark). Nessun filesystem diretto — evita problemi di scalabilità. MinIO è incluso di serie per il self-hosting; l'istanza SaaS usa Hetzner Object Storage.
+
+---
+
+## 4. Modello dati (PostgreSQL)
+
+Le tabelle essenziali (semplificate, senza il boilerplate `created_at`/`updated_at`/`id`):
+
+```sql
+tenants                -- Multi-tenancy: one or many studios per instance
+  slug, name, status, custom_domain, branding_id
+
+users                  -- Studio owners and team members
+  tenant_id, email, password_hash, role, totp_secret, totp_enabled, status
+
+teams                  -- Optional: multi-user studios (within a tenant)
+  name, owner_id
+
+galleries              -- One gallery per shoot/delivery
+  tenant_id, slug, title, owner_id, branding_id, cover_file_id
+  mode               -- 'collaboration' | 'presentation'
+  status             -- 'draft' | 'live' | 'archived'
+  password_hash      -- optional
+  expires_at         -- optional
+  download_enabled, watermark_enabled, comments_enabled
+  selection_limit    -- max number the customer may select
+  settings_jsonb     -- flexible: sorting, layout, background color
+
+gallery_access        -- Who has access via a link
+  gallery_id, token, label (e.g. "couple", "agency")
+  permissions_jsonb  -- {can_download, can_comment, can_select, can_invite}
+
+files                  -- Every upload
+  gallery_id, original_filename, storage_key
+  mime_type, size_bytes, sha256
+  width, height, duration_ms
+  exif_jsonb, taken_at
+  status             -- 'uploading' | 'processing' | 'ready' | 'failed'
+  sort_index
+
+renditions             -- Derived variants per file
+  file_id, kind        -- 'thumb' | 'preview' | 'web' | 'watermarked' | 'hls'
+  storage_key, width, height, size_bytes
+
+selections             -- Customer selection
+  file_id, access_token_id, color, rating, status
+  -- color: 'red' | 'yellow' | 'green' (Picdrop-style)
+  -- rating: 1-5 stars
+  -- status: 'like' | 'pick' | 'reject'
+
+comments               -- Comments/annotations
+  file_id, access_token_id, author_label
+  body_text, annotation_jsonb  -- for scribbles: paths as SVG coords
+  parent_id           -- for threads
+
+team_votes             -- Several members of a customer team vote
+  file_id, voter_label, value
+
+download_log           -- Audit
+  gallery_id, file_id, ip, user_agent, kind
+
+events                 -- Generic audit log (login, share link, delete)
+  tenant_id, actor_type, actor_id, action, target_type, target_id, payload_jsonb
+
+brandings              -- Whitelabel per studio (or per gallery)
+  tenant_id, logo_url, primary_color, font, favicon_url
+  custom_domain, intro_text, footer_text, css_overrides
+
+billing_plans          -- Plan definitions (only active in hosted mode)
+  slug, name, storage_gib, galleries_max, files_per_gallery, users_max
+  bandwidth_gib_per_month, custom_domain, white_label, watermarking, analytics
+  stripe_price_id_monthly, stripe_price_id_yearly, price_monthly_cents, currency
+
+billing_subscriptions  -- One subscription per tenant
+  tenant_id (unique), plan_id, status, billing_interval
+  stripe_customer_id, stripe_subscription_id
+  current_period_start, current_period_end, trial_ends_at
+  storage_bytes_used, bandwidth_bytes_used, galleries_count
+
+billing_usage_records  -- Usage-based additional line items (phase 2)
+  tenant_id, kind, quantity, unit_price_cents, period_start, period_end
+```
+
+**Nota sulla multi-tenancy:** tutte le tabelle eccetto `tenants` e `billing_plans` hanno `tenant_id` come FK. L'API impone questo filtro centralmente.
+
+**Indici su:** `galleries(slug)`, `files(gallery_id, sort_index)`, `selections(file_id, access_token_id)`, `gallery_access(token)`.
+
+---
+
+## 5. Workflow principali
+
+### 5.1 Caricamento (studio → server)
+
+I "crazy fast uploads" di Picdrop non sono un trucco magico, ma un caricamento diretto browser→S3 con chunk paralleli. È esattamente quello che facciamo:
+
+1. Il browser chiede all'API: "voglio caricare N file" + metadati (nome, dimensione, MIME).
+2. L'API crea le voci `files` con stato `uploading`, genera **URL PUT presigned** (con multipart per file >100 MB).
+3. Il browser esegue `Promise.allSettled` con ad es. 6 caricamenti paralleli direttamente verso S3/MinIO (il backend **non** diventa il collo di bottiglia).
+4. Per ogni caricamento completato: il browser lo comunica all'API → l'API imposta lo stato su `processing` e lancia un job in Redis.
+5. Il worker recupera il job, genera le renditions, scrive lo stato `ready` nel DB.
+6. Il frontend riceve un aggiornamento di stato via WebSocket → la thumbnail appare live nella vista dello studio.
+
+**Vantaggio:** il backend può girare su 0.5 vCPU, il throughput scala con l'archiviazione oggetti.
+
+### 5.2 Elaborazione RAW
+
+Per ogni file RAW (CR2, CR3, NEF, ARW, RAF, DNG, ORF, PEF, RW2…) nel worker:
+
+```python
+import rawpy
+from PIL import Image
+
+with rawpy.imread(path) as raw:
+    # 1. Use the fast embedded preview JPEG (contained in the RAW,
+    #    created in-camera — looks like on the camera display)
+    try:
+        thumb = raw.extract_thumb()
+        if thumb.format == rawpy.ThumbFormat.JPEG:
+            preview_bytes = thumb.data
+        else:
+            preview_bytes = encode_jpeg(thumb.data)
+    except rawpy.LibRawNoThumbnailError:
+        # 2. Fallback: demosaic from RAW (slow, but reliable)
+        rgb = raw.postprocess(use_camera_wb=True, no_auto_bright=False)
+        preview_bytes = encode_jpeg(rgb, quality=92)
+
+# From the preview then derive the web renditions with Pillow/libvips
+```
+
+La documentazione di LibRaw lo conferma: la preview incorporata è la via veloce alla thumbnail, che copre quasi ogni formato RAW. Per le gallerie questo basta nel 99% dei casi — i clienti vogliono vedere cosa stanno selezionando, non la massima qualità RAW possibile.
+
+**Importante:** il **RAW originale resta intatto** nell'archiviazione. Le renditions sono solo JPEG/WebP derivati.
+
+### 5.3 Pipeline delle renditions
+
+Per ogni foto generiamo diverse varianti — **con libvips** (tramite `pyvips`), che è 4–8× più veloce di ImageMagick e richiede meno RAM:
+
+| Rendition          | Scopo                              | Dimensioni          | Formato              |
+| ------------------ | ---------------------------------- | ------------- | ------------------- |
+| `thumb`            | Vista a griglia nella galleria       | 400 px lato lungo | WebP, qualità 75 |
+| `preview`          | Lightbox / mobile                  | 1600 px       | WebP/AVIF, qual. 82 |
+| `web`              | Lightbox su schermi grandi      | 2560 px       | WebP/AVIF, qual. 85 |
+| `watermarked`      | Quando il download è disattivato         | come `web`     | JPEG + watermark    |
+| `download` (opz.)  | Variante di download "risoluzione web" | 2048 px       | JPEG, qual. 92      |
+| Originale           | Download completo (RAW o JPEG completo) | invariato   | formato originale      |
+
+### 5.4 Elaborazione video
+
+Per i video (MP4, MOV, AVI, MKV, HEVC, ProRes) nel worker tramite **ffmpeg**:
+
+1. **Poster** — un frame al 10% della durata come JPEG.
+2. **Stream web (HLS)** — bitrate adattivi: 480p, 720p, 1080p (4K opzionale). Codice: `ffmpeg -i input.mov -filter:v ... -hls_time 6 -hls_playlist_type vod ...`. Offre uno streaming fluidissimo invece di un download da 2 GB nel browser.
+3. **Thumbnail di scrubbing** — uno sprite sheet (un'immagine ogni 10 sec, come un unico grande JPEG) per l'anteprima del player durante lo scrubbing.
+4. **Originale** — resta nell'archiviazione per il download.
+
+**Accelerazione GPU** opzionale (NVENC/QSV) se l'host ha una GPU — drasticamente più veloce con materiale 4K.
+
+### 5.5 Vista galleria (esperienza cliente)
+
+Cosa vede il cliente tramite il link `https://photos.studio.de/g/abc123`:
+
+1. **Copertina** — una grande hero image + titolo della galleria + branding dello studio.
+2. **Opzionale:** inserimento password / raccolta email (per la lead generation, disattivabile).
+3. **Griglia** — un layout masonry virtualizzato (ad es. `react-photo-album` con `react-window`). Con 5.000 immagini si carica **solo** quello visibile. Le thumbnail vengono fornite tramite `<img loading="lazy">` + `srcset`.
+4. **Lightbox** — PhotoSwipe v5, tastiera, touch, pinch zoom, schermo intero, slideshow.
+5. **Per ogni immagine:** like, tag colore (rosso/giallo/verde), commento, strumento scribble (su dispositivi touch con pennino), valutazione a stelle.
+6. **Filtro** — "mostra solo i selezionati", "solo commentati", "per colore".
+7. **Download** — download singolo o ZIP (vedi sotto).
+
+### 5.6 Download ZIP (un grande punto dolente fatto bene)
+
+L'approccio ingenuo sarebbe: "impacchetta tutto in un unico ZIP e consegnalo" — a 10 GB il server muore. Fatto bene:
+
+- **ZIP in streaming**: il worker costruisce lo stream ZIP al volo e lo passa direttamente alla risposta HTTP (`archiver` in Node o `zipstream-ng` in Python). Nessun file temporaneo, nessuna esplosione di RAM.
+- Per i download **ripetibili** (ad es. dopo una selezione): lo ZIP viene messo in cache una volta su S3 e il link viene restituito per 7 giorni.
+- **Ripristinabile** via HTTP Range, per quanto lo stream lo consenta — in alternativa a blocchi (più ZIP da 5 GB ciascuno).
+
+### 5.7 Workflow Lightroom / Capture One
+
+La funzionalità killer di Picdrop: la selezione del cliente torna in Lightroom. Offriamo:
+
+1. **File di esportazione** — download di un `.txt`/`.csv` con i nomi dei file selezionati.
+2. **Sidecar XMP** — per ogni foto selezionata un file `.xmp` con `xmp:Rating` o `xmp:Label` che Lightroom/Capture One riconoscono direttamente quando li posizioni accanto ai RAW originali.
+3. **Plugin Lightroom** (fase 2) — un plugin Lua che recupera la selezione tramite un token API e contrassegna le immagini corrispondenti in Lightroom.
+
+---
+
+## 6. Matrice delle funzionalità
+
+Lumio è andato oltre l'MVP originale. Lo stato seguente riflette il sistema **effettivamente distribuito**.
+
+### Costruito & in produzione
+
+| Area | Funzionalità |
+| ------- | -------- |
+| **Gallerie** | Creazione, caricamento (browser→S3, chunk paralleli), draft/live/archiviata, protezione con password, data di scadenza, copertina, tag della galleria, capitoli, template/preset di galleria |
+| **Media** | RAW (CR2/CR3/NEF/ARW/RAF/DNG/ORF/PEF/RW2/X3F), JPEG/PNG/WebP/AVIF/TIFF/HEIC, video (MP4/MOV/AVI/MKV/HEVC/ProRes), transcoding HLS, slideshow |
+| **Esperienza cliente** | Galleria senza login, lightbox (tastiera/touch/pinch), like / tag colore / valutazione a stelle, commenti, annotazioni scribble direttamente sull'immagine, limite di selezione, download ZIP in streaming, mobile-first |
+| **Branding** | Branding per studio e per galleria (logo, colori, font, footer), domini personalizzati, testi hero/di benvenuto, livelli di animazione |
+| **Studio** | Membri del team + ruoli (Owner/Member), accesso team granulare per galleria, azioni bulk, tagging manuale + assistito da IA, rilevamento duplicati, audit log, statistiche/analytics, token API |
+| **Sicurezza** | TOTP 2FA, passkey/WebAuthn, argon2id, URL firmati, rate limiting, esportazione dati GDPR (per galleria come ZIP), scadenze automatiche di eliminazione/archiviazione |
+| **Print shop** | Vendita di stampe dalla galleria (prodotti/varianti/spedizione/provider), ritaglio, carrello, checkout con Stripe, conferma d'ordine & tracciamento |
+| **Plugin** | Plugin Lightroom Classic (publish service), plugin Capture One, webhook |
+| **Multilingua** | Interfaccia studio in tedesco + inglese (i18n completo, commutabile) |
+| **Multi-tenancy & billing** | Modo single/multi, self-service signup, abbonamenti Stripe + trial + livelli read-only, limiti di piano, banner |
+| **Operazioni** | Stack Docker Compose, scalabilità orizzontale dei worker su più nodi (Hetzner Private Network), TLS wildcard via acme-dns, analytics Umami (senza cookie, opzionale) |
+
+### Tagging AI (deliberatamente opt-in)
+
+Picdrop è volutamente privo di IA. Lumio offre il tagging automatico come **opt-in disattivabile** tramite un'immagine worker ML separata (`docker-compose.ml.yml`, CPU; GPU opzionale). I suggerimenti vengono mostrati allo studio per la conferma, nulla viene applicato senza essere richiesto.
+
+### Pianificato / aperto
+
+| Funzionalità |
+| ------- |
+| Altre lingue (FR, ES, IT) |
+| Fatturazione aggiuntiva basata sull'utilizzo (add-on di archiviazione via Stripe Metered) |
+| Ricerca globale su tutte le gallerie ("DAM-light") |
+| API pubblica + OAuth |
+| App mobile (caricamento dall'iPhone) |
+| Collaborazione live con cursori in tempo reale di altri visualizzatori |
+
+## 7. Multi-tenancy — un'istanza per uno o più studi
+
+> ⚠️ **Nota sulla licenza:** l'uso interno/agenzia del multi-tenant è illimitato; offrirlo come SaaS commerciale a terzi è *Competing Use* secondo la FSL-1.1-ALv2 e richiede una licenza commerciale. Vedi [LICENSE](../LICENSE).
+
+Lumio può fare entrambe le cose: **un'installazione per un singolo studio** (self-hosting classico) **oppure un'istanza multi-tenant** per provider SaaS, agenzie con più brand o hosted provider. La modalità si sceglie tramite un'unica variabile d'ambiente:
+
+```
+DEPLOYMENT_MODE=single   # exactly one tenant, created automatically at start
+DEPLOYMENT_MODE=multi    # any number of tenants, each with its own domain
+```
+
+### 7.1 Come funziona tecnicamente la separazione
+
+Usiamo la **multi-tenancy logica con `tenant_id` su ogni tabella protetta** (database condiviso, schema condiviso). È la via più pragmatica:
+
+- **Un** database PostgreSQL, **uno** schema, **un** bucket S3.
+- Ogni tabella (eccetto `tenants` stessa e `billing_plans`) ha una colonna `tenant_id`.
+- L'API impone un filtro su `tenant_id` su **ogni** query (un livello middleware, non un WHERE "dimenticabile").
+- Le chiavi di archiviazione in S3 hanno un prefisso per tenant: `t/<tenant_uuid>/files/<file_id>/...`. In questo modo un tenant può essere completamente eliminato con `aws s3 rm --recursive` se necessario.
+
+**Vantaggio rispetto a "schema per tenant" o "DB per tenant":** migrazioni semplici, un solo connection pool, gestione operativa semplice. **Svantaggio:** nessun isolamento rigido a livello di DB — da qui il rigoroso middleware API. Per clienti con requisiti di compliance estremi, un'istanza dedicata per tenant resta comunque la risposta giusta.
+
+### 7.2 Risoluzione del tenant per richiesta
+
+Quale tenant è attivo in un dato momento risulta dalla richiesta (in quest'ordine):
+
+1. **Dominio personalizzato** — `studio-mueller.de` → lookup in `tenants.custom_domain`.
+2. **Sottodominio** — `studio-mueller.lumio.example.com` → lookup in `tenants.slug`.
+3. **Link galleria** — `/g/<slug>` → la galleria conosce il proprio tenant.
+4. **Login studio** — l'ID di sessione è associato a `tenant_id`.
+5. **Fallback modo single** — l'unico tenant esistente viene usato automaticamente.
+
+Caddy lo fa in modo trasparente: un certificato wildcard (`LUMIO_WILDCARD_HOST=*.lumio-cloud.de`) tramite il metodo **acme-dns** (un container acme-dns proprio come mediatore DNS, nessuna API key del provider DNS necessaria) più ACME per-dominio per i domini personalizzati. La wildcard è opt-in tramite il profilo Compose `wildcard`.
+
+### 7.3 Isolamento del branding
+
+Ogni tenant ha il proprio profilo `branding` (logo, colori, font, testo del footer, CSS personalizzato opzionale), che può essere ulteriormente sovrascritto per galleria. Nel modo hosted il branding di Lumio può essere mostrato o nascosto in base al piano (piano Free: "Powered by Lumio" visibile, piano Pro: completamente whitelabel).
+
+### 7.4 Passaggio tra modalità
+
+`single` → `multi` è possibile in qualsiasi momento impostando `DEPLOYMENT_MODE=multi` e rifacendo il deploy. Il tenant singolo esistente viene preservato e può continuare a essere usato; i tenant aggiuntivi vengono creati tramite l'interfaccia admin o la CLI.
+
+`multi` → `single` ha senso solo se esiste esattamente un tenant.
+
+---
+
+## 8. Modo hosted — offrire Lumio come servizio
+
+> ⚠️ **Nota sulla licenza:** offrire Lumio come SaaS commerciale a terzi è *Competing Use* secondo la FSL-1.1-ALv2 e richiede una licenza commerciale — farlo girare per la propria organizzazione/agenzia no. Vedi [LICENSE](../LICENSE).
+
+Il modo hosted combina `DEPLOYMENT_MODE=multi` con `BILLING_ENABLED=true`. Con questo puoi gestire Lumio come servizio SaaS autonomo e offrire ai tuoi clienti una variante cloud a pagamento — loro prenotano un piano, tu gestisci l'infrastruttura, loro pagano mensilmente o annualmente.
+
+### 8.1 Sistema dei piani
+
+I piani sono definiti nella tabella `billing_plans`. Ogni piano imposta dei limiti e sblocca funzionalità:
+
+| Campo                | Significato                                                     |
+| ------------------- | ------------------------------------------------------------- |
+| `storage_gib`       | Archiviazione massima in GiB (NULL = illimitata)                |
+| `galleries_max`     | Numero massimo di gallerie attive                              |
+| `files_per_gallery` | Numero massimo di file per galleria                             |
+| `users_max`         | Numero massimo di membri dello studio                             |
+| `bandwidth_gib_per_month` | Limite di traffico, azzerato mensilmente              |
+| `custom_domain`     | Booleano — domini personalizzati consentiti?                             |
+| `white_label`       | Booleano — il branding Lumio può essere nascosto?                        |
+| `watermarking`      | Booleano — funzione watermark                              |
+| `analytics`         | Booleano — statistiche dettagliate                            |
+| `price_monthly_cents`, `price_yearly_cents`, `currency` | Prezzo                |
+| `stripe_price_id_monthly`, `stripe_price_id_yearly`     | Integrazione Stripe      |
+
+I piani effettivamente implementati (fonte: `apps/api/src/services/plans.ts`):
+
+| Piano   | Archiviazione | Gallerie attive | Profili branding | Dominio personalizzato | Team  | Watermark | Prezzo/mese |
+| ------ | -------- | --------------- | ---------------- | ------------- | ----- | --------- | ----------- |
+| Start  | 150 GB   | 5               | –                | no          | 1     | no      | 9 €         |
+| Solo   | 500 GB   | 10              | –                | no          | 1     | no      | 19 €        |
+| Studio | 1.000 GB | 50              | 1                | 1             | 1     | sì      | 39 €         |
+| Pro    | 3.000 GB | illimitate      | 5                | illimitati    | fino a 3 | sì      | 89 €        |
+
+In più un **trial di 14 giorni** (100 GB, 10 gallerie, accesso completo) e un **add-on di archiviazione** (+50 GB per +9 €/mese). Il pagamento annuale è ~17% più economico (2 mesi gratis).
+
+### 8.2 Integrazione Stripe
+
+Le route di `apps/api` sotto `/api/v1/billing/*` comunicano con Stripe:
+
+- **Sessione di checkout** per i nuovi abbonamenti (carta, SEPA, Apple Pay configurati automaticamente).
+- **Customer Portal** per cambio piano, cancellazione, download fatture — Stripe ospita l'interfaccia, noi ci limitiamo a linkarla.
+- **Ricevitore webhook** sotto `/api/v1/billing/webhook` elabora `checkout.session.completed`, `invoice.paid`, `customer.subscription.updated`, `customer.subscription.deleted`. In questo modo lo stato locale di `billing_subscriptions` si sincronizza con Stripe.
+
+Le tasse (DE: 19% IVA, UE: reverse charge, paesi terzi: nessuna IVA) sono gestite interamente tramite Stripe Tax — nessuna logica fiscale propria necessaria.
+
+### 8.3 Applicazione dei limiti
+
+Un job worker periodico (`tasks.billing.update_tenant_usage`, eseguito ogni ora) aggrega l'utilizzo effettivo per tenant e lo scrive in `billing_subscriptions.storage_bytes_used` e `bandwidth_bytes_used`.
+
+Prima di ogni **init di caricamento** l'API verifica se `storage_bytes_used + sum(nuovi file) > plan.storage_gib`. In caso affermativo: HTTP 402 (Payment Required) con un suggerimento di upgrade.
+
+In caso di **superamento della banda** il tenant non viene bloccato duramente (sarebbe ostile verso il cliente se proprio in quel momento è in corso uno shooting), ma gli owner vengono informati via email. Il provider può opzionalmente configurare un throttling a partire dal giorno X in caso di superamento persistente.
+
+In caso di **pagamento fallito** (`status=past_due`) il tenant resta pienamente funzionante per 7 giorni, poi le gallerie vengono impostate su "expired" per i clienti finali (il login dello studio viene preservato in modo che nessuno perda dati). Dopo 30 giorni `unpaid`: sospensione forzata, dopo 90 giorni un avviso di eliminazione imminente.
+
+### 8.4 Add-on basati sull'utilizzo (fase 2)
+
+Tramite la tabella `billing_usage_records` si può aggiungere in seguito una **fatturazione aggiuntiva basata sull'utilizzo** — ad esempio "5 € per ogni 100 GiB aggiuntivi di archiviazione". Stripe Metered Billing accetta i record mensilmente.
+
+### 8.5 Flusso di onboarding in modo multi
+
+Ci sono tre percorsi di onboarding, a seconda della modalità:
+
+1. **Self-host, modo single** (`DEPLOYMENT_MODE=single`, senza Stripe): il tenant di default viene creato automaticamente al primo avvio; serve solo una chiamata `create-admin` per il primo utente.
+2. **Self-host, modo multi** (un'agenzia senza billing): il super admin crea i tenant manualmente.
+3. **Modo SaaS** (`multi` + `BILLING_ENABLED=true` + Stripe): self-service signup tramite il sito marketing (lumio-cloud.de) — email + password + nome dello studio + sottodominio desiderato, trial di 14 giorni, poi scelta del piano o read-only.
+
+### 8.6 Temi operativi
+
+- I **backup** nel modo hosted sono obbligatori: `pg_dump` giornaliero, il bucket S3 con versioning degli oggetti e replicazione cross-region.
+- **Monitoraggio**: analytics **Umami** senza cookie (lo stack incluso sotto `infra/umami`, opt-in via `LUMIO_UMAMI_HOST`); metriche di errori/infrastruttura in base alle necessità (ad es. Sentry/Prometheus).
+- **Canale di supporto**: Helpscout, Crisp o semplicemente email. Invia il tenant ID insieme a ogni richiesta.
+- **SLA**: per i clienti paganti prometti almeno il 99,5% di uptime; le interruzioni vengono tracciate in `events` e specchiate su una status page.
+
+### 8.7 Quando lasciare disattivato il modo hosted?
+
+Se **fai solo self-hosting** del software (modo single o multi senza vendita): `BILLING_ENABLED=false`. In questo caso le tabelle di billing esistono, ma nessun limite viene applicato e nessun webhook Stripe è attivo. Tutte le funzionalità sono sbloccate per tutti i tenant.
+
+---
+
+## 9. Sicurezza & privacy
+
+Poiché il gruppo target è composto da professionisti con NDA, questo non è un "extra", ma il nucleo.
+
+- I **token della galleria** sono crittograficamente casuali (32 byte) e non indovinabili.
+- **Protezione con password** con Argon2id.
+- **URL firmati** per ogni accesso S3, con validità breve (ad es. 60 minuti).
+- **Rate limiting** su login, accesso alla galleria, commenti (ad es. via `@fastify/rate-limit`).
+- **HTTPS ovunque** — Caddy lo fa automaticamente.
+- Cookie di sessione **HTTPOnly + SameSite=Strict**.
+- Header **CSP** per il frontend.
+- **Rimozione EXIF** per le renditions web opzionale (dati GPS fuori).
+- **Modo watermark** quando i download sono bloccati — anche l'elemento del browser è protetto da "salva immagine" con `pointer-events` e un overlay CSS (non una vera protezione DRM, ma un ostacolo).
+- **Audit log** per: login, creazione galleria, link di condivisione generato, file eliminato, download.
+- **Strumenti GDPR**: "elimina automaticamente una galleria dopo X giorni", "esporta tutti i commenti dei clienti", "diritto alla cancellazione" implementabile.
+- **Residenza dei dati**: self-hosted — decidi tu dove vivono i dati (server proprio, Hetzner, AWS Francoforte, Wasabi…).
+
+---
+
+## 10. Deployment — Docker Compose
+
+Lo stack viene eseguito tramite **più file Compose componibili**. La base (`docker-compose.yml`) compila le immagini in locale; gli override attivano i mattoncini di produzione o opzionali:
+
+| File | Scopo |
+| ----- | ----- |
+| `docker-compose.yml` | Base: caddy, frontend, api, worker, postgres, redis, minio (build locale) |
+| `docker-compose.prod.yml` | Sostituisce i blocchi `build:` con immagini precompilate dalla **Forgejo container registry** (`forgejo.thiel.tools/thiel/lumio-{api,frontend,worker}:${LUMIO_TAG}`) |
+| `docker-compose.ml.yml` | Un worker ML aggiuntivo per il tagging AI (CPU) |
+| `docker-compose.gpu.yml` | Accelerazione GPU (NVIDIA) per transcoding/ML |
+| `docker-compose.worker.yml` | Un nodo worker puro per la scalabilità orizzontale (server proprio) |
+
+**Self-hosting (modo single), il caso più semplice:**
+
+```bash
+cp .env.example .env      # set secrets (S3 keys, DB password, JWT_SECRET …)
+docker compose up -d      # acme-dns is profile-gated and stays off
+```
+
+Questo fa girare tutto su un unico host incluso MinIO; `DEPLOYMENT_MODE=single` crea il tenant di default al primo avvio.
+
+**Operatività SaaS in produzione (riferimento: lumio-cloud.de):** il TLS wildcard per i sottodomini dei tenant richiede il profilo `wildcard` (altrimenti acme-dns non si avvia e il certificato wildcard si rompe):
+
+```bash
+cd /opt/docker/lumio/lumio && git pull && \
+  docker compose --profile wildcard \
+    -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.ml.yml \
+    up -d --build
+```
+
+**Scalabilità orizzontale:** i worker possono essere scaricati su nodi aggiuntivi. Il server principale e i nodi worker si trovano in una rete privata (Hetzner Private Network); Redis è protetto da password e si aggancia solo all'IP interno. Un nodo worker si distribuisce con `docker-compose.worker.yml` + un proprio `.env.worker`; Celery si mette in cluster automaticamente. Importante: `apps/frontend` e `apps/api` riguardano solo il server principale, le modifiche ad `apps/worker` riguardano tutti i nodi (i nodi sempre **dopo** il server principale a causa delle migrazioni DB). Dettagli: `docs/SCALING.md`.
+
+**Reverse proxy:** Caddy serve i domini dell'app (studio + wildcard) e i siti marketing tramite blocchi separati (configurazione sotto `infra/caddy/Caddyfile`, controllata via `LUMIO_WILDCARD_HOST`).
+
+**Hardware di riferimento (prod):** Hetzner CCX a Falkenstein (fsn1), 12 vCPU / 24 GB RAM / 480 GB, Hetzner Object Storage al posto di MinIO.
+
+**Hardware minimo consigliato (self-host):**
+- 4 vCPU, 8 GB RAM (un piccolo studio, ~50 GB/mese di traffico)
+- 8 vCPU, 16 GB RAM (più caricamenti paralleli, tagging AI attivo)
+- GPU opzionale, un'accelerazione significativa per video 4K e tagging ML
+
+## 11. Ottimizzazioni delle prestazioni
+
+Dove Picdrop sembra "veloce" — e come lo riproduciamo:
+
+| Leva                              | Implementazione                                                             |
+| ---------------------------------- | --------------------------------------------------------------------------- |
+| Caricamento diretto verso S3                | URL presigned, il backend non nel flusso dati                                 |
+| Griglia virtualizzata               | Vengono renderizzate solo le thumbnail visibili (`react-window`)                  |
+| `srcset` / immagini responsive        | Il browser recupera la dimensione adatta al viewport                                     |
+| AVIF/WebP invece di JPEG               | File 30–50% più piccoli a parità di qualità                              |
+| HTTP/3 (QUIC)                      | Più stream paralleli senza head-of-line blocking                        |
+| Caching HTTP aggressivo            | `Cache-Control: public, immutable, max-age=31536000` per le renditions (hash nel percorso) |
+| Pronto per CDN                          | Asset statici + renditions sono cacheable; è possibile anteporre una CDN Cloudflare/Bunny |
+| Prefetching                        | Le immagini successive/precedenti nella lightbox vengono precaricate                       |
+| libvips invece di ImageMagick          | 4–8× più veloce sulle thumbnail                                               |
+| Multi-worker                       | Worker Celery scalabili orizzontalmente                                         |
+| Connection pooling                 | pgBouncer opzionale con molte visualizzazioni simultanee della galleria               |
+
+---
+
+## 12. Repo, release & licenza
+
+- **Struttura del repo**: monorepo (pnpm workspaces) — `apps/frontend`, `apps/api`, `apps/worker` (Python/Celery), `apps/lightroom-plugin`, `apps/capture-one-plugin`, `packages/shared` (tipi condivisi).
+- **Tre repository**: codice dell'app (`lumio.git`) più due siti marketing in Astro — `lumio-cloud-de.git` (SaaS + sign-up + Stripe) e `lumio-app-de.git` (il pitch per il self-host).
+- **Hosting**: **Forgejo** (`forgejo.thiel.tools/thiel/*`) è primario; **GitHub** funge da mirror pubblico in push.
+- **Licenza**: **FSL-1.1-ALv2** (Functional Source License) — source-available. Vieta l'hosting SaaS concorrente (*Competing Use*), ma si converte automaticamente in Apache 2.0 due anni dopo ogni release. Licenza commerciale per offerte hosted/concorrenti su richiesta.
+- **Immagini/CI**: le immagini container vivono nella **Forgejo container registry**; deployment tramite `git pull` + `docker compose … up -d --build`.
+- **Documentazione**: nel repo sotto `docs/` (tra gli altri `STORAGE.md`, `SCALING.md`, `SAAS_MODE.md`).
+- **Demo/lancio**: prima il self-host (r/selfhosted, awesome-selfhosted, Hacker News, Mastodon) — comunicato come *source-available*, non "open source". GDPR / "i dati restano in Germania" come differenziatore centrale.
+
+## 13. Cosa sa fare Picdrop che deliberatamente tralasciamo (almeno all'inizio)
+
+- Ricerca globale su tutte le gallerie di un'agenzia ("DAM-light") — fase 2/3.
+- Integrazione con storage cloud (Dropbox, Drive) — il self-hosted non ne ha bisogno con la stessa urgenza.
+- La logica di abbonamento a pagamento è disattivata in modo self-host (`BILLING_ENABLED=false`); attiva via Stripe per la propria variante cloud. (Il **print shop** per la vendita di immagini è stato nel frattempo costruito e non è più escluso.)
+- Gestione dei permessi complessa con un centinaio di ruoli — restiamo a: owner, membro del team, ospite della galleria.
+
+---
+
+## 14. Rischi & domande aperte
+
+1. **Compatibilità RAW delle nuove fotocamere.** LibRaw è mantenuto attivamente, ma le fotocamere nuovissime (ad es. la Sony α1 II appena uscita) a volte richiedono aggiornamenti. Strategia: ricompilare regolarmente l'immagine worker, estrarre automaticamente CR3/ecc. con `exiftool` come anteprima di fallback.
+2. **Situazione brevettuale HEIC/HEIF** — libheif è OSS, ma l'encoder/decoder HEVC può essere nascosto in alcune distribuzioni. Testare nell'immagine Docker prima del rilascio.
+3. **Casi speciali Adobe DNG** — LibRaw gestisce il bilanciamento del bianco DNG diversamente da dcraw, il che può portare ad anteprime visibilmente diverse — di solito accettabile per le gallerie, ma va documentato.
+4. **Caricamento mobile di RAW di grandi dimensioni da iPhone** — Safari ha limiti di caricamento, eventualmente considerare il protocollo Tus (upload ripristinabili) invece del multipart semplice.
+5. **Scalabilità con gallerie enormi (10.000+ immagini)** — paginazione + scrolling virtuale sono pianificati, ma devono seguire test di carico.
+6. **L'angolo "concorrenza con Picdrop"** — Picdrop è uno strumento affermato. Differenziazione: self-hosted, source-available, i dati restano in Germania/UE, nessun lock-in, adatto a NDA. Non "uccidere Picdrop", ma colmare una lacuna.
+
+---
+
+## 15. Stato & prossimi passi
+
+L'MVP originale (le sezioni sottostanti) è completamente distribuito e in produzione, così come gran parte delle ex funzionalità di fase 2/3 (multi-tenancy, billing, 2FA/passkey, print shop, tagging AI, plugin, i18n DE/EN, scalabilità multi-nodo).
+
+**Punti aperti:**
+
+1. Mantenere pulito il **mirror GitHub** (si sincronizza da Forgejo).
+2. **Bootstrap Stripe** per i nuovi piani SaaS (`docker compose exec api npm run stripe-bootstrap`) — solo modo SaaS.
+3. Far revisionare da un legale i **testi legali** (DPA/Art. 28 GDPR, termini, privacy); impostare gli URL di impronta/privacy nell'env di lumio-cloud.de.
+4. Attivare **Umami analytics** (record A `stats.lumio-cloud.de`, `LUMIO_UMAMI_HOST`).
+5. Finalizzare il **plugin Capture One**.
+6. **Altre lingue** (FR/ES/IT) secondo necessità.
+7. **Lancio** della variante self-host (community) + un'istanza demo pubblica.
+
+## Appendice: librerie & strumenti importanti
+
+- **Elaborazione immagini**: libvips (via pyvips), Pillow, libheif; imageio come ponte
+- **RAW**: rawpy (wrapper LibRaw), exiftool (metadati)
+- **Video**: ffmpeg (HLS/transcoding)
+- **Backend**: Fastify, Zod, **Prisma** (PostgreSQL), ioredis, Stripe, argon2 (auth propria per sessioni/2FA/passkey)
+- **Worker**: Python, **Celery** (broker Redis), boto3, un'immagine ML separata per il tagging AI
+- **Frontend**: **Next.js 16**, **React 19**, Tailwind CSS, TanStack Query; siti marketing in **Astro**
+- **DevOps**: Docker Compose, Caddy (+ acme-dns per il TLS wildcard), Forgejo (codice + container registry, mirror GitHub), **Umami** (analytics senza cookie)
+- **i18n**: un sistema di dizionario leggero proprio (`apps/frontend/src/lib/i18n`, DE/EN)
+- **Testing**: Vitest, Playwright (E2E), pytest (worker)
+
+---
+
+*Fine del concetto.*

--- a/docs/KONZEPT.md
+++ b/docs/KONZEPT.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](KONZEPT.de.md)
+**English** · [Deutsch](KONZEPT.de.md) · [Italiano](KONZEPT.it.md)
 
 # Lumio — Concept & Architecture
 

--- a/docs/ML.de.md
+++ b/docs/ML.de.md
@@ -1,4 +1,4 @@
-[English](ML.md) · **Deutsch**
+[English](ML.md) · **Deutsch** · [Italiano](ML.it.md)
 
 # KI-Auto-Tagging (CLIP)
 

--- a/docs/ML.it.md
+++ b/docs/ML.it.md
@@ -1,0 +1,192 @@
+[English](ML.md) · [Deutsch](ML.de.md) · **Italiano**
+
+# Auto-tagging IA (CLIP)
+
+Lumio può taggare le immagini automaticamente al caricamento – ad es. riconosce spiaggia, matrimonio, ritratto, set in studio, tramonto. I tag vengono aggiunti ai record della foto e sono ricercabili.
+
+Questo è **opzionale**. Se non ti serve l'auto-tagging, non c'è nulla da fare – il worker standard ha la funzione disabilitata.
+
+---
+
+## Cosa fa
+
+Lumio usa **OpenAI CLIP** (Contrastive Language-Image Pretraining) localmente sul tuo server. Nessuna chiamata API esterna, tutto sul tuo hardware. Il modello è aperto, gira offline, non costa alcuna commissione API.
+
+Ad ogni caricamento immagine:
+
+1. Il worker recupera l'immagine da S3
+2. CLIP calcola un embedding (vettore)
+3. L'embedding viene confrontato con un elenco di tag candidati
+4. I tag con una confidenza superiore a `LUMIO_CLIP_THRESHOLD` vengono salvati
+
+I tag candidati sono configurabili in una word list (`apps/worker/lumio/clip_labels.py` se presente – altrimenti hardcoded).
+
+---
+
+## CPU vs GPU
+
+| | CPU | GPU |
+|---|---|---|
+| **Per immagine** | 1–3 secondi | 50–200 ms |
+| **Fabbisogno RAM** | ~3 GB | ~3 GB + ~2 GB VRAM |
+| **Hardware** | qualsiasi server amd64 o arm64 | GPU NVIDIA con Compute Capability 5.0+ (solo amd64) |
+| **Setup** | solo `docker-compose.ml.yml` | in aggiunta `docker-compose.gpu.yml` + NVIDIA Container Toolkit |
+| **Quando ha senso** | pochi caricamenti, elaborazione in background | throughput elevato, più utenti in parallelo |
+
+Per uno studio solo con 100 immagini al giorno: la CPU basta e avanza. Per un SaaS con 1000+ caricamenti all'ora: la GPU ha senso.
+
+---
+
+## Setup CPU (semplice)
+
+Basta aggiungere `docker-compose.ml.yml` allo stack:
+
+```bash
+cd /opt/docker/lumio/lumio
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.ml.yml \
+  up -d --build worker
+```
+
+Questo sostituisce il worker standard con uno con PyTorch + open_clip_torch. Al primo avvio il worker scarica il modello CLIP da HuggingFace (~150 MB), che viene messo in cache in `lumio_model_cache`.
+
+Verifica lo stato:
+
+```bash
+docker compose logs worker --tail=30 | grep -i clip
+```
+
+Dovrebbe mostrare qualcosa come `CLIP model loaded: ViT-B-32 (openai)` e, per le immagini, `tagged image with N labels`.
+
+### Ottimizzare le performance CPU
+
+- **Scaling del worker:** più worker paralleli permettono più inferenze concorrenti. Ma ogni worker tiene il modello CLIP in RAM (~2 GB), quindi non scalarlo all'infinito.
+  ```bash
+  docker compose up -d --scale worker=2
+  ```
+- **Regola la soglia:** in `.env` `LUMIO_CLIP_THRESHOLD=0.15` (default 0.08). Più alto = meno tag ma più affidabili.
+
+---
+
+## Setup GPU (per throughput elevato)
+
+### Requisiti
+
+1. GPU NVIDIA nel server (serie RTX 20/30/40 o Tesla/serie A)
+2. Driver NVIDIA installato (`nvidia-smi` deve funzionare)
+3. NVIDIA Container Toolkit installato ([Guida all'installazione](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html))
+4. Docker configurato con il runtime nvidia (`docker info | grep -i nvidia`)
+
+### Installazione rapida del Container Toolkit
+
+```bash
+# NVIDIA repo
+curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+apt update
+apt install -y nvidia-container-toolkit
+nvidia-ctk runtime configure --runtime=docker
+systemctl restart docker
+
+# Test
+docker run --rm --gpus all nvidia/cuda:12.2-base-ubuntu22.04 nvidia-smi
+```
+
+Se il test mostra l'output di `nvidia-smi`: il toolkit va bene.
+
+### Avviare Lumio con GPU
+
+```bash
+cd /opt/docker/lumio/lumio
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.ml.yml \
+  -f docker-compose.gpu.yml \
+  up -d --build worker
+```
+
+Nei log del worker:
+
+```bash
+docker compose logs worker | grep -i -E "cuda|gpu"
+```
+
+Dovrebbe mostrare `CUDA available: True, device=cuda:0`. Se `CUDA available: False`: il container non riesce a raggiungere la GPU, controlla il setup del toolkit o il flag compose.
+
+### GPU per più che il solo CLIP
+
+`docker-compose.gpu.yml` attiva anche **NVENC** nel worker – ffmpeg usa quindi la GPU per la transcodifica video invece della CPU. È enorme per le gallerie video:
+
+- CPU (libx264): 1080p ~1x tempo reale, 4K ~0.1x tempo reale
+- GPU (NVENC): 1080p ~8x tempo reale, 4K ~2x tempo reale
+
+Quindi se hai molti video di matrimoni, una GPU ripaga anche senza tagging IA.
+
+---
+
+## Configurazione
+
+In `.env` (tutte opzionali):
+
+```bash
+# CLIP fully on/off (overrides what docker-compose.ml.yml sets)
+LUMIO_CLIP_ENABLED=1
+
+# Model choice. Default: ViT-B-32 (small, fast, OK quality).
+# Alternatives: ViT-L-14 (better, much slower), ViT-B-16
+LUMIO_CLIP_MODEL=ViT-B-32
+
+# Pretraining dataset. Default: openai. Alternative: laion2b_s34b_b79k
+# (often better for photo content)
+LUMIO_CLIP_PRETRAINED=openai
+
+# Threshold for tag suggestions (0..1). Default: 0.08.
+# Higher = fewer but more confident tags. 0.15 is conservative, 0.05 generous.
+LUMIO_CLIP_THRESHOLD=0.08
+```
+
+Dopo una modifica, riavvia il worker:
+
+```bash
+docker compose restart worker
+```
+
+---
+
+## Personalizzare la word list dei tag
+
+La word list di default copre gli scenari fotografici tipici (matrimonio, ritratto, paesaggio, studio, ...). Se ti servono tag specifici per il tuo dominio (es. "evento sportivo", "shoot industriale"):
+
+Modifica la word list in `apps/worker/lumio/clip_labels.py` (o equivalente), rebuilda il worker.
+
+CLIP capisce **descrizioni**, non solo parole chiave. "Una foto di una festa di matrimonio in spiaggia" funziona meglio di solo "matrimonio".
+
+---
+
+## Quando l'auto-tagging NON vale la pena
+
+- Hai già un tuo sistema di workflow con keyword di Lightroom
+- Contenuti sensibili dal punto di vista della privacy (nudità, riservati) – anche se CLIP gira localmente, una classificazione ML è un flusso di dati aggiuntivo
+- L'hardware del worker è già al limite
+
+---
+
+## Errori comuni
+
+**Il worker si blocca al primo avvio:** il modello CLIP è in fase di download (~150 MB). I log mostrano `Downloading ...`. Alla prima immagine potrebbe scaricare ulteriori componenti del modello. Abbi pazienza, al secondo avvio è in cache.
+
+**`CUDA available: False` nonostante la GPU:** il container non ha accesso alla GPU. Controlli:
+1. `nvidia-smi` funziona sull'host?
+2. `docker info | grep -i nvidia` mostra `Runtimes: ... nvidia ...`?
+3. `docker-compose.gpu.yml` è incluso nel comando `up`?
+4. Il worker è stato ricostruito (`--build`)?
+
+**I tag non vengono mostrati:** cache del frontend. `Ctrl+Shift+R` nel browser, oppure riapri la galleria. Se ancora non compare: controlla i log del worker per le righe `tagged image`.
+
+**Carico CPU/RAM elevato:** normale per l'inferenza su CPU. Se il server è molto carico, abbassa la concorrenza del worker in `.env` (`WORKER_CONCURRENCY=2`) oppure usa una GPU.

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](ML.de.md)
+**English** · [Deutsch](ML.de.md) · [Italiano](ML.it.md)
 
 # AI auto-tagging (CLIP)
 

--- a/docs/MULTI_TENANT.de.md
+++ b/docs/MULTI_TENANT.de.md
@@ -1,4 +1,4 @@
-[English](MULTI_TENANT.md) · **Deutsch**
+[English](MULTI_TENANT.md) · **Deutsch** · [Italiano](MULTI_TENANT.it.md)
 
 # Multi-Tenant-Setup
 

--- a/docs/MULTI_TENANT.it.md
+++ b/docs/MULTI_TENANT.it.md
@@ -1,0 +1,121 @@
+[English](MULTI_TENANT.md) · [Deutsch](MULTI_TENANT.de.md) · **Italiano**
+
+# Setup multi-tenant
+
+> ⚠️ **Nota sulla licenza:** Far girare Lumio in multi-tenant per **la tua organizzazione o un'agenzia** (più brand/clienti che gestisci tu stesso) non è soggetto a restrizioni. Offrire Lumio come **SaaS commerciale a terzi** che compete con il servizio ospitato del maintainer è *Competing Use* e **non** è consentito liberamente sotto la FSL-1.1-ALv2 — per questo serve una licenza commerciale. Vedi [LICENSE](../LICENSE).
+
+Lumio può gestire più tenant (studi/clienti fotografi) sulla stessa installazione. Questo documento descrive come un nuovo tenant diventa raggiungibile — il DB + l'UI lo creano, ma perché l'URL giusto arrivi al tenant giusto ti serve uno dei tre metodi di routing qui sotto.
+
+Se stai costruendo un SaaS e hai meno di 20 clienti, il **metodo B (domini personalizzati per cliente)** è il percorso consigliato. I wildcard ripagano solo una volta che modificare il Caddyfile manualmente per ogni cliente diventa tedioso.
+
+## Come funziona la risoluzione del tenant
+
+Quando arriva una richiesta API, la risoluzione del tenant gira in questo ordine (vedi `apps/api/src/plugins/auth.ts:resolveTenant`):
+
+1. **Utente loggato** (cookie) — la sessione sa quale tenant
+2. **Header `X-Lumio-Tenant`** — per l'app mobile e i client API
+3. **Dominio personalizzato** — `studio-mueller.de` confrontato con `tenants.customDomain`
+4. **Sottodominio** — `studio-mueller.lumio-cloud.de` confrontato con `tenants.slug`, a condizione che `LUMIO_DOMAIN_BASE` sia impostato
+5. **Fallback single-mode** — se esiste solo un tenant, viene usato quello
+
+Non appena crei il secondo tenant, il passaggio 5 decade — devi usare 2, 3 o 4.
+
+---
+
+## Metodo B: domini personalizzati per cliente (consigliato per i primi clienti)
+
+Ogni cliente riceve un proprio dominio come `studio-mueller.de` o un bel sottodominio come `mueller.lumio.app`. Un blocco Caddyfile per dominio (sul Caddy esterno), il certificato viene ottenuto automaticamente tramite HTTP challenge — nessun plugin DNS necessario, funziona con il Caddy standard.
+
+### Passaggi per un nuovo cliente
+
+1. **Record DNS** — il cliente (o tu) punta il proprio dominio al tuo IP:
+   ```
+   studio-mueller.de    A    <IP dell'host Caddy esterno>
+   ```
+
+2. **Caddy esterno** — aggiungi un blocco:
+   ```caddyfile
+   studio-mueller.de {
+       reverse_proxy 192.168.178.90:32080
+   }
+   ```
+   Poi `caddy reload` (o riavvia il container Caddy). Il certificato viene ottenuto automaticamente tramite HTTP challenge non appena il dominio risolve.
+
+3. **Nel super admin** su `https://studio.lumio-cloud.de/super/login`:
+   - "+ Nuovo tenant"
+   - Inserisci slug, nome, **dominio personalizzato `studio-mueller.de`**
+   - Nome + email del proprietario
+   - "Crea + invita"
+
+4. **Il proprietario** clicca il link di setup nell'email, imposta la propria password, è loggato. Da quel momento `https://studio-mueller.de` è il suo studio.
+
+I link della galleria sono indipendenti da questo — usano lo slug della galleria, non lo slug del tenant, e funzionano sul rispettivo dominio del tenant (`studio-mueller.de/g/<gallery-slug>`).
+
+### Importante: il Caddy interno ha un catch-all
+
+Il Caddy interno (`infra/caddy/Caddyfile`) è configurato per contenere un blocco catch-all `http://` che si applica a **qualsiasi host** che non venga abbinato in modo più specifico. È esattamente ciò di cui hanno bisogno i domini personalizzati — altrimenti Caddy invierebbe un 308 verso `https://` per host sconosciuti e produrrebbe così (in combinazione con il Caddy esterno) un `ERR_TOO_MANY_REDIRECTS`.
+
+**Non devi cambiare nulla per cliente sul Caddy interno.** Il codice di risoluzione del tenant in `apps/api/src/plugins/auth.ts` confronta tramite l'header Host con `tenants.customDomain`. Se il dominio è inserito lì, tutto gira automaticamente.
+
+### Se non hai ancora un dominio personalizzato
+
+Va bene anche un bel sottodominio sotto il tuo brand per ogni cliente — es. `mueller.lumio-cloud.de` come "interim" finché il cliente non decide per un dominio personalizzato. Ogni sottodominio del genere è un proprio blocco Caddyfile con un proprio certificato. Con 5-10 clienti va benissimo.
+
+---
+
+## Metodo A: sottodominio wildcard (`*.lumio-cloud.de`)
+
+Una volta che hai molti clienti in stile SaaS e modificare il Caddyfile manualmente per cliente diventa fastidioso, il salto ai wildcard ripaga. Allora `<slug>.lumio-cloud.de` è automaticamente l'URL dello studio per ogni tenant, senza reload di Caddy per ogni nuovo cliente.
+
+**Ma**: i certificati wildcard richiedono la DNS challenge, perché la HTTP challenge non può validare `*.domain`. Ti serve o un plugin DNS (per il reselling United Domains c'è [`KlettIT/caddy-autodns`](https://github.com/KlettIT/caddy-autodns) come plugin di terze parti, che andrebbe compilato dentro Caddy tramite xcaddy), oppure usi la delega CNAME acme-dns.
+
+Se percorri questa strada, i passaggi sono:
+
+1. **DNS** — record A wildcard `*.lumio-cloud.de` → IP
+2. **Caddy a monte** — blocco wildcard con DNS challenge
+3. **Caddy interno di Lumio** — imposta `LUMIO_WILDCARD_HOST=*.lumio-cloud.de:80` in `.env` (il blocco Caddyfile è già preparato, vedi `infra/caddy/Caddyfile`)
+4. **Env dell'API** — `LUMIO_DOMAIN_BASE=lumio-cloud.de`
+
+Il walkthrough completo è in [WILDCARD.md](WILDCARD.it.md). Per il primissimo onboarding non ne vale ancora la pena — torna a questa sezione quando sei pronto, o chiedi.
+
+---
+
+## Metodo C: header `X-Lumio-Tenant` (per client API)
+
+Usato soprattutto dall'app mobile. Invece di passare tramite dominio/sottodominio, il client parla direttamente con l'URL dell'API e invia un header:
+
+```
+GET /api/v1/galleries HTTP/1.1
+Host: studio.lumio-cloud.de
+X-Lumio-Tenant: studio-mueller
+```
+
+Proprietà di sicurezza importante: se è presente un cookie di sessione, **vince il tenant della sessione**, non l'header. Altrimenti un utente con un cookie per il tenant A potrebbe semplicemente accedere al tenant B tramite manipolazione dell'header.
+
+Quindi l'header ha effetto solo sulle richieste non loggate (login dell'app mobile, autenticazione via token API).
+
+---
+
+## Rinominare il tenant di default
+
+Il primo tenant, creato tramite `npm run create-admin`, ha slug=`default`. Se gestisci una vera piattaforma multi-tenant, vorrai rinominarlo:
+
+- Super admin → Tenant → clicca sul tenant default → Modifica
+- Cambia lo slug (viene mostrato un avviso)
+- Salva
+
+⚠ Gli URL dei sottodomini esistenti sotto `default.lumio-cloud.de` si rompono immediatamente (se il metodo A è attivo). I link di condivisione della galleria **non** sono interessati — usano lo slug della galleria, non lo slug del tenant. Le sessioni studio loggate del tenant restano valide (il cookie porta il tenantId, non lo slug).
+
+---
+
+## Quale metodo per cosa
+
+| Per cosa                            | Metodo                            |
+|----------------------------------|--------------------------------------|
+| I primi 1-20 clienti, ognuno con il proprio dominio brand | B (dominio personalizzato) |
+| 20+ clienti, non vuoi più modificare Caddy per cliente | A (wildcard) |
+| App mobile                       | C (header)                           |
+| Studio nel browser                   | risolto automaticamente via cookie dopo il primo login |
+| Link della galleria per il cliente           | funziona su qualsiasi dominio tenant |
+
+I metodi sono combinabili — un tenant può avere contemporaneamente un dominio personalizzato E un sottodominio wildcard E un header mobile.

--- a/docs/MULTI_TENANT.md
+++ b/docs/MULTI_TENANT.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](MULTI_TENANT.de.md)
+**English** · [Deutsch](MULTI_TENANT.de.md) · [Italiano](MULTI_TENANT.it.md)
 
 # Multi-tenant setup
 

--- a/docs/OPERATIONS.de.md
+++ b/docs/OPERATIONS.de.md
@@ -1,4 +1,4 @@
-[English](OPERATIONS.md) · **Deutsch**
+[English](OPERATIONS.md) · **Deutsch** · [Italiano](OPERATIONS.it.md)
 
 # Lumio — Operations Cookbook
 

--- a/docs/OPERATIONS.it.md
+++ b/docs/OPERATIONS.it.md
@@ -1,0 +1,961 @@
+[English](OPERATIONS.md) · [Deutsch](OPERATIONS.de.md) · **Italiano**
+
+# Lumio — Operations Cookbook
+
+Attività quotidiane per gestire un'istanza Lumio in produzione. Pensato per chi fa self-hosting e ha già un setup funzionante (vedi [DEVELOPMENT.md](./DEVELOPMENT.it.md) per la prima installazione).
+
+Tutti i comandi di questo documento presuppongono che la directory corrente sia la root del repo Lumio:
+
+```bash
+cd /opt/docker/lumio/lumio   # or wherever your clone lives
+```
+
+Se il tuo setup richiede Compose file diversi (GPU, proxy esterno, ecc.), sostituiscili di conseguenza in ogni chiamata a `docker compose`. La maggior parte degli esempi usa il set completo che hai anche nel setup di produzione:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.gpu.yml \
+  <subcommand>
+```
+
+Per leggibilità, nel cookbook lo abbreviamo come `docker compose <subcommand>` — non dimenticare i flag nella pratica.
+
+---
+
+## Indice
+
+1. [Deploy](#deploy)
+2. [Ciclo di vita dei servizi](#ciclo-di-vita-dei-servizi)
+3. [Modificare una variabile ENV e ricaricare](#modificare-una-variabile-env-e-ricaricare)
+4. [Ruotare secret e password](#ruotare-secret-e-password)
+5. [Visualizzare i log](#visualizzare-i-log)
+6. [Accesso al database](#accesso-al-database)
+7. [Redis / stream dei job](#redis--stream-dei-job)
+8. [Rimettere in coda i file falliti](#rimettere-in-coda-i-file-falliti)
+9. [Backfill del worker](#backfill-del-worker)
+10. [Ispezione dell'archiviazione (S3 / MinIO)](#ispezione-dellarchiviazione-s3--minio)
+11. [Gestione dei tenant](#gestione-dei-tenant)
+12. [Diagnosi: è davvero rotto?](#diagnosi-è-davvero-rotto)
+13. [Backup e ripristino](#backup-e-ripristino)
+14. [Pulizia dell'archiviazione](#pulizia-dellarchiviazione)
+15. [Problemi comuni](#problemi-comuni)
+
+---
+
+## Deploy
+
+### Aggiornare il codice
+
+```bash
+git pull
+docker compose up -d --build api frontend worker
+```
+
+`--build` è importante: senza, continua a girare la vecchia immagine, anche se hai fatto il pull. `up -d` senza `--build` fa un nuovo pull **solo se** il tag dell'immagine è cambiato (Compose non si accorge dei cambiamenti ai file).
+
+**Fai il deploy selettivamente per servizio** se, ad esempio, hai avuto solo modifiche al frontend:
+
+```bash
+docker compose up -d --build frontend
+```
+
+Nomi dei servizi: `api`, `frontend`, `worker`, `caddy`, `postgres`, `redis`, `minio`. Questi ultimi tre quasi non vengono mai ricostruiti — usano immagini precostituite.
+
+### Ricostruire senza cache (in caso di problemi di build)
+
+```bash
+docker compose build --no-cache worker
+docker compose up -d worker
+```
+
+Aiuta con bug strani tipo "il file è nel repo ma manca nel container", normalmente non serve.
+
+### Hard reload del frontend per gli utenti
+
+Dopo modifiche a CSS o JS, i clienti potrebbero dover fare Ctrl+F5, perché Next.js mette in cache gli asset statici. Per modifiche critiche puoi riavviare il container del frontend, che invalida gli hash di build:
+
+```bash
+docker compose restart frontend
+```
+
+---
+
+## Ciclo di vita dei servizi
+
+### Avviare tutti i servizi
+
+```bash
+docker compose up -d
+```
+
+### Fermare tutto
+
+```bash
+docker compose stop
+```
+
+`stop` vs `down`: `stop` mantiene i container, `down` li rimuove (i volumi restano). Nell'uso normale usa `stop`.
+
+### Riavvio di un singolo servizio
+
+```bash
+docker compose restart api
+```
+
+Utile ad esempio dopo una modifica a `.env` — il container rilegge l'ENV all'avvio, non serve ricostruire l'immagine.
+
+### Stato dei container
+
+```bash
+docker compose ps
+```
+
+Mostra quali servizi sono in esecuzione, quali porte sono mappate, se qualcuno è unhealthy.
+
+---
+
+## Modificare una variabile ENV e ricaricare
+
+Le modifiche a `.env` hanno effetto solo con un **riavvio del container**, non automaticamente nel processo in esecuzione. Workflow:
+
+```bash
+cd /opt/docker/lumio/lumio
+
+# 1) Edit the ENV
+nano .env
+
+# 2) Restart the service (no --build needed, no git pull needed)
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.gpu.yml \
+  restart api
+
+# 3) Verify the new value really made it in
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.gpu.yml \
+  exec api env | grep <YOUR_KEY>
+
+# 4) Optional: follow the logs while it comes up
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.gpu.yml \
+  logs -f api
+```
+
+**Quale servizio deve riavviarsi?** Le variabili ENV sono legate all'immagine del container per ogni servizio in `docker-compose.yml`; il servizio da riavviare dipende da cosa cambi:
+
+| Variabile ENV | Riavvio |
+|---|---|
+| `MAX_FILE_SIZE_MIB`, `MAX_UPLOAD_HARD_CAP_MIB` | `api` |
+| `BILLING_ENABLED`, `STRIPE_*` | `api` |
+| `LUMIO_DOMAIN_BASE`, `PUBLIC_URL` | `api`, `frontend` |
+| Configurazione dominio Caddy | `caddy` |
+| `S3_*`, `MINIO_*` | `api`, `worker` |
+| Tuning del worker (concorrenza ecc.) | `worker` |
+| Credenziali Postgres | `api`, `worker`, `postgres` |
+| In caso di dubbio | tutti: `docker compose restart` |
+
+**Perché non `docker compose up -d`?** Funziona anche quello — ma `up` ricostruisce solo se l'immagine è cambiata. Per modifiche pure a `.env`, `restart` è più veloce (nessun controllo dell'immagine) ed è più esplicito ("volevo davvero solo ricaricare l'ENV").
+
+**Perché non `kill -HUP`?** Le app Node non hanno un reload SIGHUP. Per Caddy funzionerebbe, ma usiamo lo stesso pattern per tutti i servizi perché è più facile da ricordare.
+
+---
+
+## Ruotare secret e password
+
+> ⚠️ Qui ci sono due trappole, ognuna delle quali causa un'interruzione di servizio se "cambi semplicemente il `.env`". Leggi per intero la sezione pertinente prima di cambiare qualcosa.
+
+### Boot guard: i secret placeholder bloccano l'avvio
+
+L'API **rifiuta di avviarsi** se `JWT_SECRET` o `SESSION_SECRET` sono ancora i placeholder pubblicamente noti di `.env.example`:
+
+```
+[lumio:api] Refusing to start: insecure secret(s) detected: JWT_SECRET, SESSION_SECRET.
+```
+
+È voluto — questi valori sono visibili nel repo, chiunque potrebbe falsificare token con essi. Imposta valori robusti:
+
+```
+openssl rand -base64 32   # → JWT_SECRET
+openssl rand -base64 32   # → SESSION_SECRET
+```
+
+### Ruotare i secret dell'app (`JWT_SECRET` / `SESSION_SECRET`)
+
+Le sessioni e i token API sono **hashati lato DB** e NON dipendono da questi secret. Significa che una rotazione **non disconnette nessuno**, gli utenti già loggati restano dentro. Cosa invece influisce davvero `SESSION_SECRET` (è la base HMAC/di derivazione):
+
+- **I cookie dei visitatori della galleria** sono firmati con HMAC tramite `SESSION_SECRET`. Dopo una rotazione, i visitatori attivi della galleria devono reinserire una volta la password della galleria. I link condivisi restano validi — non c'è nulla da rigenerare.
+- **Le credenziali del laboratorio di stampa** sono cifrate con una chiave derivata da `SESSION_SECRET` via HKDF. Dopo una rotazione, le credenziali del laboratorio salvate in precedenza non possono più essere decifrate → vanno reinserite una volta. (Se non usi la funzione di stampa: irrilevante.)
+- I token di login challenge sono di breve durata → non critici.
+
+`JWT_SECRET` è obbligatorio ma nel codice attuale non firma nulla da cui dipendano sessioni o token esistenti → rotazione senza impatto per l'utente. Tienilo comunque robusto.
+
+Procedura (nessuna build, nessun `git pull`):
+
+```
+# Adjust .env on the main server, then:
+docker compose --profile wildcard \
+  -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.ml.yml \
+  up -d --force-recreate api
+```
+
+### Ruotare la password del DB (`POSTGRES_PASSWORD`) — la trappola più grande
+
+L'immagine Postgres legge `POSTGRES_PASSWORD` **solo al primissimo init** di una directory dati vuota. Con un volume esistente la variabile viene **ignorata** al riavvio — la password reale del ruolo vive nel DB. Se cambi solo il `.env` e riavvii, l'API si connette con la nuova password a un DB che ha ancora quella vecchia → errore di autenticazione → API giù.
+
+Quindi la password va cambiata **prima in Postgres stesso**:
+
+```
+# 1) Backup as a safety net (main server)
+docker exec lumio_postgres pg_dump -U lumio lumio | gzip > ~/lumio-db-$(date +%F).sql.gz
+
+# 2) New password WITHOUT special characters (otherwise the DATABASE_URL syntax breaks)
+openssl rand -hex 24        # → referred to below as NEWPW
+
+# 3) Change the password in Postgres (changes only the password, no data)
+docker exec -it lumio_postgres psql -U lumio -d lumio
+#   at the psql prompt:  \password lumio   (asks twice, no echo)  →  \q
+```
+
+Poi propaga la nuova password ovunque **venga usato il ruolo `lumio`**:
+
+- **Server principale** `.env`: `POSTGRES_PASSWORD=NEWPW`
+- **Ogni worker node** `.env.worker`:
+  `DATABASE_URL=postgres://lumio:NEWPW@10.0.0.2:5432/lumio`
+
+E ricrea:
+
+```
+# Main server
+cd /opt/docker/lumio/lumio && docker compose --profile wildcard \
+  -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.ml.yml up -d
+
+# then every worker node
+cd /opt/docker/lumio/lumio && docker compose \
+  -f docker-compose.worker.yml --env-file .env.worker up -d
+```
+
+Postgres viene ricreato nel processo ma **non** rilancia l'init (il volume è pieno) — la password del passo 3 resta valida. Verifica: `curl -s https://<your-domain>/health` → `status: ok` significa che l'API si è connessa con la nuova password.
+
+**Non interessati** da questa rotazione: Umami (una propria istanza Postgres con un proprio `UMAMI_DB_PASSWORD`) e acme-dns (un proprio ruolo DB).
+
+---
+
+## Visualizzare i log
+
+### Log live di un servizio
+
+```bash
+docker compose logs -f worker
+```
+
+`-f` è follow (Ctrl+C per uscire). Senza `-f` un dump una tantum.
+
+### Ultime N righe
+
+```bash
+docker compose logs --tail=200 worker
+```
+
+### Log di più servizi combinati
+
+```bash
+docker compose logs -f api worker
+```
+
+### Filtro per finestra temporale
+
+```bash
+docker compose logs --since 10m worker
+docker compose logs --since 2026-05-21T15:00:00 worker
+```
+
+### Salvare i log su file
+
+```bash
+docker compose logs --tail=500 worker > /tmp/worker.log
+```
+
+### Cercare nei log JSON strutturati
+
+I log di worker e API sono JSON (via structlog/pino). Filtra con `jq`:
+
+```bash
+docker compose logs --no-log-prefix --tail=1000 worker | \
+  grep -oE '\{.*\}' | jq -r 'select(.level == "error") | .event'
+```
+
+---
+
+## Accesso al database
+
+### Aprire una shell psql
+
+```bash
+docker compose exec postgres psql -U lumio lumio
+```
+
+`-U lumio` è l'utente DB, il secondo `lumio` è il nome del DB. Entrambi di default. Se hai credenziali tue (`.env`), usa quelle.
+
+### Una singola query senza shell interattiva
+
+```bash
+docker compose exec postgres psql -U lumio lumio -c \
+  "SELECT id, name, status FROM tenants;"
+```
+
+### Escaping delle colonne con lettere maiuscole
+
+Prisma genera tabelle in camelCase e richiede virgolette doppie attorno ad esse. Vanno escapate nella chiamata da shell:
+
+```bash
+docker compose exec postgres psql -U lumio lumio -c \
+  "SELECT id, status, \"errorMessage\" FROM files WHERE status = 'failed';"
+```
+
+### Query utili
+
+**Controllare lo stato di un file:**
+```sql
+SELECT id, "originalFilename", status, "errorMessage",
+       "sizeBytes"/1024/1024 AS mb
+FROM files
+WHERE id = '<file-id>';
+```
+
+**File falliti nell'ultima ora:**
+```sql
+SELECT id, "originalFilename", "errorMessage", "updatedAt"
+FROM files
+WHERE status = 'failed'
+  AND "updatedAt" > NOW() - INTERVAL '1 hour'
+ORDER BY "updatedAt" DESC;
+```
+
+**Panoramica dell'archiviazione per tenant:**
+```sql
+SELECT t.slug, t.name,
+       COUNT(DISTINCT g.id) AS galleries,
+       COUNT(f.id) AS files,
+       pg_size_pretty(SUM(f."sizeBytes")) AS storage
+FROM tenants t
+LEFT JOIN galleries g ON g."tenantId" = t.id
+LEFT JOIN files f ON f."galleryId" = g.id AND f.status = 'ready'
+GROUP BY t.id, t.slug, t.name
+ORDER BY SUM(f."sizeBytes") DESC NULLS LAST;
+```
+
+**Guardare le renditions di un file** (quali esistono, quanto sono grandi):
+```sql
+SELECT kind, format, "sizeBytes"/1024/1024 AS mb, "storageKey"
+FROM renditions
+WHERE "fileId" = '<file-id>'
+ORDER BY kind;
+```
+
+**Trovare il proprietario di un tenant** (es. per contatto di supporto):
+```sql
+SELECT t.slug, u.email, u.role
+FROM tenants t
+JOIN users u ON u."tenantId" = t.id
+WHERE u.role = 'owner';
+```
+
+### Creare un dump
+
+```bash
+docker compose exec postgres pg_dump -U lumio lumio > /backup/lumio-$(date +%F).sql
+```
+
+### Ripristinare da un dump
+
+```bash
+cat /backup/lumio-2026-05-21.sql | \
+  docker compose exec -T postgres psql -U lumio lumio
+```
+
+`-T` disabilita l'allocazione TTY, altrimenti la pipe del cat resta bloccata.
+
+---
+
+## Redis / stream dei job
+
+Lumio usa Redis come coda dei job tra API e worker. Stream:
+
+| Stream | Contenuto |
+|---|---|
+| `lumio:jobs:file_processing` | Elaborazione immagini (renditions) |
+| `lumio:jobs:video_processing` | Video (HLS + MP4 + sprite) |
+| `lumio:jobs:zip_build` | Creazione ZIP |
+| `lumio:jobs:webhook_delivery` | Webhook in uscita |
+
+Consumer group: `lumio_workers` (tutti i container worker lo condividono).
+
+### Redis CLI
+
+```bash
+docker compose exec redis redis-cli
+```
+
+### Stato dello stream
+
+**Quanti messaggi ci sono in totale nello stream:**
+```bash
+docker compose exec redis redis-cli XLEN lumio:jobs:video_processing
+```
+
+**Pending = presi in carico ma non confermati (acked)** (il worker li ha ancora in corso oppure è crashato):
+```bash
+docker compose exec redis redis-cli XPENDING lumio:jobs:video_processing lumio_workers
+```
+
+Formato di output: `[count, min-id, max-id, [[consumer, count], ...]]`. Se qualcosa resta lì appeso per minuti, un worker ha preso in carico un job ma non l'ha finito (il reclaim stale avviene automaticamente dopo `CLAIM_MIN_IDLE_MS` = 60s, poi un altro consumer se ne fa carico).
+
+**Mostrare le ultime 5 voci nello stream** (per il debug):
+```bash
+docker compose exec redis redis-cli XREVRANGE lumio:jobs:video_processing + - COUNT 5
+```
+
+### Inserire manualmente un job nello stream
+
+Formato: un singolo campo `payload` con un body JSON. Questo è importante — il consumer dello stream nel worker legge `fields.get("payload")` e lo fa passare per JSON.parse, **non** più campi separati.
+
+```bash
+docker compose exec redis redis-cli XADD lumio:jobs:video_processing '*' \
+  payload '{"type":"process_video","fileId":"<uuid>"}'
+```
+
+Per altri tipi di job vedi `consumer.py` nel codice del worker — ad es.:
+- `{"type":"process_file","fileId":"..."}` → renditions immagine
+- `{"type":"process_raw","fileId":"..."}` → anteprima RAW
+- `{"type":"process_watermark","fileId":"..."}` → applicazione watermark
+
+---
+
+## Rimettere in coda i file falliti
+
+Se l'elaborazione di un file è fallita (`status = 'failed'`) e vuoi che venga ritentata:
+
+```bash
+# 1. Reset the status
+docker compose exec postgres psql -U lumio lumio -c \
+  "UPDATE files SET status='processing', \"errorMessage\"=NULL \
+   WHERE id = '<file-id>';"
+
+# 2. Push the matching job into the Redis stream
+docker compose exec redis redis-cli XADD lumio:jobs:video_processing '*' \
+  payload '{"type":"process_video","fileId":"<file-id>"}'
+
+# 3. Follow the logs
+docker compose logs -f worker
+```
+
+Tipo di job in base a `files.kind`:
+- `image` → `lumio:jobs:file_processing`, type=`process_file`
+- `heic` → `lumio:jobs:file_processing`, type=`process_file`
+- `raw` → `lumio:jobs:file_processing`, type=`process_raw`
+- `video` → `lumio:jobs:video_processing`, type=`process_video`
+
+### Più file falliti in una volta
+
+```sql
+-- First check via SQL which ones they are
+SELECT id, "originalFilename", kind, "errorMessage"
+FROM files
+WHERE status = 'failed'
+  AND "galleryId" = '<gallery-id>'
+ORDER BY "updatedAt" DESC;
+```
+
+Poi un loop bash:
+
+```bash
+# Restart all failed video files of a gallery
+docker compose exec postgres psql -U lumio lumio -At -c \
+  "SELECT id FROM files WHERE status='failed' AND kind='video' AND \"galleryId\"='<gallery-id>'" | \
+while read FILE_ID; do
+  echo "Re-queueing $FILE_ID"
+  docker compose exec postgres psql -U lumio lumio -c \
+    "UPDATE files SET status='processing', \"errorMessage\"=NULL WHERE id='$FILE_ID';" > /dev/null
+  docker compose exec redis redis-cli XADD lumio:jobs:video_processing '*' \
+    payload "{\"type\":\"process_video\",\"fileId\":\"$FILE_ID\"}" > /dev/null
+done
+```
+
+`-At` rende l'output pulito (`A` = unaligned, `t` = tuples only).
+
+---
+
+## Backfill del worker
+
+Quando il codice del worker aggiunge nuove renditions (es. `web_jpeg` o `video_mp4`), queste naturalmente non esistono per i file caricati prima dello sprint. È a questo che servono i task di backfill.
+
+### video_mp4 (variante MP4 web per il download del cliente)
+
+Per galleria:
+
+```bash
+docker compose exec worker celery -A app call \
+  tasks.backfill_video_mp4.run_for_gallery --args='["<gallery-id>"]'
+```
+
+Globalmente con un limite (idempotente, può girare più volte):
+
+```bash
+# 5 videos to try it out
+docker compose exec worker celery -A app call \
+  tasks.backfill_video_mp4.run_global --args='[5]'
+
+# Larger batch when the test is OK
+docker compose exec worker celery -A app call \
+  tasks.backfill_video_mp4.run_global --args='[200]'
+```
+
+Effetto: circa il 5-15% della dimensione originale in più su S3 per video. Con NVENC un video 1080p di 5 minuti viene elaborato in ~30 secondi, senza GPU in 2-5 minuti. Per backfill grandi, tieni il log del worker aperto:
+
+```bash
+docker compose logs -f worker
+```
+
+### web_jpeg (versione JPEG per il download immagini del cliente)
+
+Per galleria:
+
+```bash
+docker compose exec worker celery -A app call \
+  tasks.backfill_web_jpeg.run_for_gallery --args='["<gallery-id>"]'
+```
+
+Per tenant (tutte le gallerie del tenant):
+
+```bash
+docker compose exec worker celery -A app call \
+  tasks.backfill_web_jpeg.run_for_tenant --args='["<tenant-id>"]'
+```
+
+### Monitorare l'avanzamento del backfill
+
+```sql
+-- How many files (still) have no video_mp4 rendition?
+SELECT COUNT(*)
+FROM files f
+WHERE f.kind = 'video' AND f.status = 'ready'
+  AND NOT EXISTS (
+    SELECT 1 FROM renditions r
+    WHERE r."fileId" = f.id AND r.kind = 'video_mp4'
+  );
+```
+
+---
+
+## Ispezione dell'archiviazione (S3 / MinIO)
+
+### UI console di MinIO
+
+```
+http://docker5.lan:32092
+```
+
+Accedi con `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` da `.env`.
+
+### CLI mc (client MinIO) — dall'esterno
+
+```bash
+# Set up the alias (once)
+mc alias set lumio http://localhost:32091 <root-user> <root-password>
+
+# Count bucket contents
+mc ls --recursive lumio/lumio-bucket/ | wc -l
+
+# Storage usage
+mc du lumio/lumio-bucket/
+
+# Per tenant
+mc du lumio/lumio-bucket/t/<tenant-id>/
+```
+
+### Trovare la chiave di archiviazione di un file nel DB
+
+```sql
+SELECT "storageKey" FROM files WHERE id = '<file-id>';
+SELECT "storageKey", kind FROM renditions WHERE "fileId" = '<file-id>';
+```
+
+Le chiavi tipicamente iniziano con `t/<tenant-id>/galleries/<gallery-id>/...`.
+
+### Recuperare un oggetto da MinIO (per debug)
+
+```bash
+mc cp lumio/lumio-bucket/t/.../source /tmp/test.jpg
+```
+
+---
+
+## Gestione dei tenant
+
+### Mostrare tutti i tenant
+
+```sql
+SELECT id, slug, name, status, plan, "createdAt"
+FROM tenants
+ORDER BY "createdAt" DESC;
+```
+
+### Gestire un tenant tramite la UI super admin
+
+```
+https://studio.lumio-cloud.de/super/login
+```
+
+Accedi con le credenziali super admin (vedi `.env` o i tuoi appunti).
+
+### Creare un tenant manualmente
+
+Funziona nel super admin tramite la UI. Via CLI solo tramite l'API di Prisma — più semplice tramite la UI dello studio.
+
+### Sospendere un tenant
+
+```sql
+UPDATE tenants SET status = 'suspended' WHERE slug = '<slug>';
+```
+
+`active` / `suspended` / `archived`. Con suspended, non entrano né i clienti né gli utenti dello studio.
+
+### Abilitare un sottodominio personalizzato per un tenant
+
+Tre cose devono essere corrette:
+
+1. **Record DNS**: `mueller.lumio-cloud.de A <server-ip>` (oppure wildcard `*.lumio-cloud.de`)
+2. **Blocco Caddy esterno**:
+   ```caddyfile
+   mueller.lumio-cloud.de {
+       reverse_proxy 192.168.178.90:32080
+   }
+   ```
+   Oppure con un blocco wildcard:
+   ```caddyfile
+   *.lumio-cloud.de {
+       reverse_proxy 192.168.178.90:32080
+   }
+   ```
+3. **Lato app**: `LUMIO_DOMAIN_BASE=lumio-cloud.de` deve essere impostato in `.env`. L'app estrae il sottodominio e lo mappa su `tenants.slug`.
+
+Ricarica Caddy dopo le modifiche:
+
+```bash
+sudo systemctl reload caddy   # or docker exec caddy ...
+```
+
+### Dominio personalizzato del tenant (full custom invece di sottodominio)
+
+Nello studio, in Impostazioni → Dominio personalizzato, inserisci un hostname (es. `gallery.studio-mueller.de`). Anche qui, in più: DNS + Caddy esterni.
+
+---
+
+## Diagnosi: è davvero rotto?
+
+### Guardare dentro il container worker
+
+```bash
+# What processes are running?
+docker compose exec worker ps auxf
+
+# Specifically ffmpeg subprocesses
+docker compose exec worker pgrep -af ffmpeg
+
+# GPU utilization (if the GPU compose overlay is active)
+docker compose exec worker nvidia-smi
+
+# Temp directory (processing in progress)
+docker compose exec worker ls -lh /tmp/lumio_vid_* 2>/dev/null
+docker compose exec worker du -sh /tmp/lumio_vid_* 2>/dev/null
+```
+
+### Memoria / disco
+
+```bash
+# Container RAM
+docker stats --no-stream
+
+# Host disk
+df -h
+
+# Container disk (image + overlay)
+docker system df
+```
+
+### Endpoint di healthcheck
+
+L'API ha un endpoint di health:
+
+```bash
+curl -s http://localhost:33031/api/v1/health
+# {"status":"ok","db":"ok","redis":"ok","storage":"ok"}
+```
+
+Se uno passa a `error`/`down` → è quello il problema.
+
+### Testare gli import nel worker
+
+Se i task del worker falliscono con un ModuleNotFoundError, verifica rapidamente:
+
+```bash
+docker compose exec worker python -c \
+  "from encoder_profile import profile_for; print(profile_for(1080))"
+
+docker compose exec worker env | grep PYTHONPATH
+# expected: PYTHONPATH=/app
+```
+
+### Guardare l'ultima esecuzione di un task
+
+```sql
+-- Failed jobs in the last 24h
+SELECT id, "originalFilename", kind, "errorMessage", "updatedAt"
+FROM files
+WHERE status = 'failed' AND "updatedAt" > NOW() - INTERVAL '24 hour'
+ORDER BY "updatedAt" DESC;
+```
+
+`errorMessage` contiene lo `str(err)` dell'eccezione. Per i traceback completi guarda nei log del worker — dal commit `d590520` gli stack trace vengono loggati correttamente con `format_exc_info` nella pipeline structlog.
+
+---
+
+## Backup e ripristino
+
+### Cosa va incluso nel backup
+
+Tre cose:
+1. **DB Postgres** — tutti i tenant, le gallerie, i file, le selezioni, ecc.
+2. **Bucket S3/MinIO** — i file veri e propri
+3. **File `.env`** — credenziali, secret
+
+Cosa **non** serve includere nel backup:
+- Redis (coda dei job, stato effimero)
+- Immagini Docker (costruite localmente, ricostruibili in qualsiasi momento)
+
+### Dump di Postgres (manuale)
+
+```bash
+docker compose exec postgres pg_dump -U lumio lumio \
+  | gzip > /backup/lumio-db-$(date +%F).sql.gz
+```
+
+### Mirror di MinIO su archiviazione esterna
+
+```bash
+# Initial setup
+mc alias set backup s3.backup-provider.example <key> <secret>
+
+# Sync (idempotent, copies only new/changed objects)
+mc mirror lumio/lumio-bucket/ backup/lumio-backup/
+```
+
+### Script di backup via cron (esempio)
+
+```bash
+#!/bin/bash
+set -e
+DATE=$(date +%F)
+DEST=/backup/lumio
+mkdir -p $DEST
+
+cd /opt/docker/lumio/lumio
+docker compose exec -T postgres pg_dump -U lumio lumio \
+  | gzip > $DEST/db-$DATE.sql.gz
+
+mc mirror lumio/lumio-bucket/ $DEST/storage/
+
+# 14 days retention for DB dumps
+find $DEST -name "db-*.sql.gz" -mtime +14 -delete
+```
+
+Crontab:
+```
+0 3 * * * /opt/scripts/lumio-backup.sh >> /var/log/lumio-backup.log 2>&1
+```
+
+### Ripristino (DB)
+
+```bash
+# The container must be running and the DB empty (or dropdb first)
+gunzip -c /backup/lumio-db-2026-05-21.sql.gz | \
+  docker compose exec -T postgres psql -U lumio lumio
+```
+
+### Ripristino (archiviazione)
+
+```bash
+mc mirror /backup/lumio/storage/ lumio/lumio-bucket/
+```
+
+---
+
+## Pulizia dell'archiviazione
+
+### Identificare oggetti S3 orfani
+
+Orfano = si trova nel bucket, ma nessuna voce del DB lo referenzia. Può succedere se i file sono stati eliminati ma il job di pulizia non è stato eseguito.
+
+Una pulizia integrata non esiste ancora (roadmap). Rilevamento manuale:
+
+```bash
+# All storage keys from the DB
+docker compose exec postgres psql -U lumio lumio -At -c \
+  "SELECT \"storageKey\" FROM files
+   UNION SELECT \"storageKey\" FROM renditions
+   UNION SELECT \"storageKey\" FROM zip_downloads
+   WHERE \"storageKey\" IS NOT NULL" > /tmp/db-keys.txt
+
+# All storage keys from MinIO
+mc ls --recursive lumio/lumio-bucket/ \
+  | awk '{print $NF}' > /tmp/minio-keys.txt
+
+# Difference
+comm -23 <(sort /tmp/minio-keys.txt) <(sort /tmp/db-keys.txt) > /tmp/orphans.txt
+wc -l /tmp/orphans.txt
+```
+
+**Prima di eliminare:** guarda un campione e controlla che siano davvero file orfani. Fai attenzione ai caricamenti in corso — hanno brevemente un oggetto S3 senza una voce nel DB.
+
+### Ripulire i download ZIP scaduti
+
+```sql
+SELECT COUNT(*) FROM zip_downloads
+WHERE "expiresAt" < NOW();
+```
+
+```sql
+DELETE FROM zip_downloads
+WHERE "expiresAt" < NOW() - INTERVAL '7 day';
+```
+
+(Gli oggetti S3 restano — a meno che non vengano rimossi tramite il job di pulizia. Voce dello sprint-2.)
+
+### Eliminare un file completamente (studio + S3)
+
+Nello studio tramite la UI. Programmaticamente senza la UI:
+
+```sql
+-- Note the file ID
+SELECT id, "storageKey" FROM files WHERE id = '<file-id>';
+
+-- Delete the renditions (CASCADE would do this too, here explicitly)
+DELETE FROM renditions WHERE "fileId" = '<file-id>';
+
+-- Delete the file row
+DELETE FROM files WHERE id = '<file-id>';
+```
+
+Poi rimuovi gli oggetti S3 manualmente (chiavi dalla query SELECT precedente).
+
+---
+
+## Problemi comuni
+
+### "No module named 'encoder_profile'" nel worker
+
+**Sintomo:** `process_video.failed` con `errorMessage = "No module named 'encoder_profile'"`.
+
+**Causa:** l'immagine del worker non è stata ricostruita dopo un aggiornamento del codice, oppure `PYTHONPATH=/app` non è impostato.
+
+**Soluzione:**
+```bash
+git pull
+docker compose up -d --build worker
+
+# Verify
+docker compose exec worker env | grep PYTHONPATH
+docker compose exec worker python -c "from encoder_profile import profile_for; print('ok')"
+```
+
+### "column f.tenantId does not exist" in un task di backfill
+
+**Sintomo:** errore SQL quando viene chiamato `backfill_video_mp4.run_global`.
+
+**Causa:** un vecchio bug, dovrebbe essere risolto dal commit `74fcb50`. Se persiste: non è l'immagine attuale.
+
+**Soluzione:** `git pull && docker compose up -d --build worker`.
+
+### Sottodominio del tenant non raggiungibile
+
+**Sintomo:** `mueller.lumio-cloud.de` non si carica, il login funziona solo tramite il dominio principale dell'app.
+
+**Causa:** manca il blocco Caddy esterno oppure manca il record DNS.
+
+**Soluzione:** controlla entrambi, vedi la sezione [Gestione dei tenant > Abilitare un sottodominio personalizzato](#abilitare-un-sottodominio-personalizzato-per-un-tenant).
+
+### Il web MP4 è più grande dell'originale
+
+**Sintomo:** il download cliente "versione web" fornisce un file più grande dell'originale.
+
+**Causa:** il video sorgente è già fortemente compresso (es. 720p a 1300 kbps), il nostro target di re-encoding di 2800 kbps in quel caso è controproducente.
+
+**Soluzione:** dal commit `36146f8` la generazione del web MP4 viene saltata se il bitrate sorgente è ≤ target. Per i file vecchi, ripulisci manualmente (vedi [Pulizia dell'archiviazione](#pulizia-dellarchiviazione)) oppure via SQL:
+
+```sql
+DELETE FROM renditions r
+USING files f
+WHERE r."fileId" = f.id
+  AND r.kind = 'video_mp4'
+  AND r."sizeBytes" >= f."sizeBytes";
+```
+
+Più eliminare manualmente gli oggetti S3.
+
+### I campi di input nello studio sono bianchi / illeggibili
+
+**Sintomo:** nel tema scuro dello studio, i campi input sono bianchi con testo illeggibile.
+
+**Causa:** prima del commit `2b20607` questo interessava alcune pagine dello studio con tag `<input>` grezzi senza `bg-`/`text-` espliciti. Dal fix in poi dovrebbe funzionare tutto.
+
+**Soluzione:** ricostruisci il frontend con il codice attuale:
+```bash
+docker compose up -d --build frontend
+```
+
+### "Processing failed" — dov'è lo stack trace?
+
+**Prima del commit `d590520`:** la pipeline structlog non includeva `format_exc_info`, quindi i traceback venivano scartati su `log.exception()` e `exc_info=True`. Nel log restava solo `"exc_info": true` senza lo stack effettivo.
+
+**Dal commit `d590520`:** il traceback completo è nel log del worker sotto la chiave `"exception"`. Inoltre la colonna `errorMessage` in `files` contiene la forma breve.
+
+### Il worker interrompe ogni job dopo poco tempo
+
+**Possibile causa:** disco pieno, OOM killer attivo, oppure connessione Redis persa. Controlla:
+
+```bash
+df -h
+docker stats --no-stream
+dmesg | tail -50 | grep -i "oom\|kill"
+docker compose logs --tail=100 redis
+```
+
+---
+
+## Commit importanti di riferimento
+
+Questi commit sono dietro a bug/migrazioni menzionati nel cookbook. Quando appare un sintomo, `git log --oneline | grep <key>` aiuta:
+
+- `0d8ba99` — migrazione del dominio dell'app a studio.lumio-cloud.de
+- `62921b8` — introdotta la rendition MP4 web
+- `74fcb50` — `tenantId` nel backfill SQL joinato da galleries
+- `d590520` — structlog format_exc_info
+- `6085c58` — import top-of-module di encoder_profile + PYTHONPATH
+- `88b6fe0` — procps nell'immagine del worker (pgrep/ps/watch)
+- `36146f8` — web MP4 saltato quando la sorgente è già piccola
+- `2b20607` — fix globale del tema scuro per i campi form
+- `4a7625f` — toolbar sticky theme-aware
+- `7509cc6` — fix del contrasto degli accenti
+- `867edb1` — modalità selezione cliente con localStorage
+- `7cbbc37` — leggibilità dei commenti nella lightbox
+- `e3e50fd` — MVP dei link di caricamento (backend + studio + drop zone pubblica)
+- `3fbb24d` — link di caricamento: approvazione bulk, filtro pending, contatore in header
+- `16221bb` — link di caricamento per singolo file + rifiuto bulk con motivazione
+- `0dd5c7b` — limite di caricamento per file configurabile per tenant + link

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](OPERATIONS.de.md)
+**English** · [Deutsch](OPERATIONS.de.md) · [Italiano](OPERATIONS.it.md)
 
 # Lumio — Operations Cookbook
 

--- a/docs/PRINT_SHOP.de.md
+++ b/docs/PRINT_SHOP.de.md
@@ -1,4 +1,4 @@
-[English](PRINT_SHOP.md) · **Deutsch**
+[English](PRINT_SHOP.md) · **Deutsch** · [Italiano](PRINT_SHOP.it.md)
 
 # Print-Shop — Provider & Adapter
 

--- a/docs/PRINT_SHOP.it.md
+++ b/docs/PRINT_SHOP.it.md
@@ -1,0 +1,68 @@
+[English](PRINT_SHOP.md) · [Deutsch](PRINT_SHOP.de.md) · **Italiano**
+
+# Print shop — provider e adapter
+
+Aggiornato al: 2026-06-04
+
+Questo documento registra lo stato reale del print shop nonché i punti deliberatamente rimandati. Sostituisce la precedente nota generica (e fuorviante) "12 print provider sono NotImplemented".
+
+## Architettura
+
+Il print shop separa in modo netto la logica di Lumio dall'integrazione specifica del laboratorio:
+
+- **Interfaccia adapter** (`apps/api/src/services/print/adapters/base.ts`): ogni provider implementa `validateCredentials`, `fetchCatalog`, `submitOrder`, `getOrderStatus`. Gli adapter sono **stateless** — ricevono credenziali + un oggetto ordine passati come parametro e non hanno accesso proprio al DB. Il livello di servizio verifica accesso/tenant prima che un adapter venga chiamato.
+- **Registry dei provider** (`apps/api/src/services/print/providers.ts`): la definizione centrale nel codice di tutti i provider (etichetta, mercato, campi credenziali, stage, istanza adapter). Una voce nel registry **non** significa che il provider sia attivo — lo decide il super admin.
+- **Stage**: `production` (live), `beta` (l'API funziona, non ancora rilasciata a tutti), `planned` (stub via `NotImplementedAdapter`), `self_print` (caso speciale).
+- **Livello service/order**: `shop.ts`, `orders.ts`, `payment.ts`, `stripe-connect.ts`, `credentials.ts`. Route: `routes/print-shop.ts` (studio) e `routes/print-shop-public.ts` (cliente).
+
+## Stato attuale dei provider
+
+| Provider | Stage | Adapter | Stato |
+|---|---|---|---|
+| Self print (`manual_self_print`) | self_print | `ManualSelfPrintAdapter` | **Pienamente funzionale.** Gli ordini vengono inoltrati allo studio con l'indirizzo di consegna. Sempre disponibile, nessuna attivazione da super admin necessaria. |
+| Prodigi (`prodigi`) | beta | `ProdigiAdapter` | **Completamente implementato** contro Print API v4.0 (creazione ordine, stato/tracking, toggle sandbox). Pronto per la produzione, ma non ancora passato a `production`. |
+| Gelato (`gelato`) | beta | `GelatoAdapter` | **Completamente implementato** contro Order Flow API v4 (creazione ordine, stato/tracking; nessuna URL sandbox separata). Pronto per la produzione, ma `beta`. |
+| WhiteWall, Saal Digital, CEWE Pro, ProfiLab, myposter, Pixum, Posterlounge, Albelli, Lalalab, MPIX, Bonusprint | planned | `NotImplementedAdapter` | Stub. Vedi "Perché i lab planned sono bloccati". |
+
+Insieme, Gelato e Prodigi coprono la gamma rilevante (stampe, poster, tele, cornici, fotolibri) con una produzione densa in ambito EU/DE. Per un'offerta di stampa funzionante questi due più self print sono sufficienti.
+
+## Perché i lab `planned` sono bloccati
+
+I laboratori consumer tedeschi/UE/USA (WhiteWall, Saal, CEWE, Pixum, myposter, ecc.) quasi tutti **non hanno un'API di ordinazione self-service aperta**. Un'integrazione reale richiede:
+
+1. Un account partner/B2B presso il rispettivo laboratorio (attivazione, talvolta un NDA).
+2. La loro documentazione API effettiva (di solito dietro un login partner/NDA).
+3. Credenziali sandbox per i test.
+
+Questo è un **passaggio di onboarding di business, non una pura questione di coding**. Costruire un adapter contro endpoint indovinati sarebbe codice privo di valore che si rompe in produzione. Questi provider quindi restano deliberatamente come stub finché non è disponibile un accesso partner concreto, documentazione inclusa.
+
+## Attivazione (SaaS vs. self-hosted)
+
+Ci sono **due livelli**:
+
+1. **Feature flag `print_shop`** — sblocca l'area print shop per un tenant.
+2. **Attivazione del provider** — quali laboratori vengono offerti a livello di piattaforma.
+
+| | SaaS / multi mode | Self-hosted (single mode) |
+|---|---|---|
+| Feature flag | UI super admin, per tenant | `FEATURES_ENABLED=print_shop` in `.env` |
+| Provider | UI super admin (`/super/print-providers`) | `PRINT_PROVIDERS_ENABLED=prodigi,gelato` in `.env` |
+
+Self print (`manual_self_print`) è sempre disponibile su entrambi i percorsi. Una
+voce DB impostata tramite l'UI del super admin ha la precedenza sulle variabili
+env — anche per la disattivazione. Dopo aver modificato `.env`: `docker compose up -d api`.
+Ogni studio inserisce le proprie credenziali API del laboratorio sotto Print shop → Providers.
+
+## Aggiungere un nuovo provider
+
+1. Una voce nel registry (`providers.ts`): `key`, `label`, `market`, `credentialFields`, `categories`, inizialmente `stage: "planned"` con `new NotImplementedAdapter("<key>")`.
+2. Implementa l'adapter sotto `services/print/adapters/<key>.ts` (modello: `prodigi.ts` / `gelato.ts`).
+3. Nel registry, sostituisci il `NotImplementedAdapter` con l'adapter reale e imposta lo stage su `beta`.
+4. L'attivazione avviene per piattaforma tramite il super admin (`/super/print-providers`); il tenant inserisce le proprie credenziali nello studio.
+
+## Rimandato (TODO, deliberatamente non ora)
+
+- **Gelato/Prodigi `beta` → `production`**: dopo un test con chiavi sandbox/live reali, aumentare lo stage. Una pura modifica al registry.
+- **Pre-rendering del crop**: un crop libero impostato dal cliente (`order.items[].crop`) attualmente non viene passato al laboratorio (Gelato/Prodigi ricevono il file completo, Prodigi usa `sizing: "fillPrintArea"`). Più pulito sarebbe: il worker crea una rendition high-res ritagliata a partire dal crop e l'adapter invia la sua URL firmata. La leva di qualità più grande.
+- **Import dinamico del catalogo** (`fetchCatalog`): Gelato/Prodigi indirizzano i prodotti tramite SKU/productUid che il fotografo attualmente inserisce manualmente come `providerVariantRef`. Un import automatico è opzionale.
+- **Ulteriori laboratori concreti**: solo una volta disponibile l'accesso API partner (account + documentazione + chiave sandbox) per un laboratorio specifico — allora si costruisce in modo mirato quel singolo adapter.

--- a/docs/PRINT_SHOP.md
+++ b/docs/PRINT_SHOP.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](PRINT_SHOP.de.md)
+**English** · [Deutsch](PRINT_SHOP.de.md) · [Italiano](PRINT_SHOP.it.md)
 
 # Print shop — providers & adapters
 

--- a/docs/REQUIREMENTS.de.md
+++ b/docs/REQUIREMENTS.de.md
@@ -1,4 +1,4 @@
-[English](REQUIREMENTS.md) · **Deutsch**
+[English](REQUIREMENTS.md) · **Deutsch** · [Italiano](REQUIREMENTS.it.md)
 
 # Voraussetzungen / System Requirements
 

--- a/docs/REQUIREMENTS.it.md
+++ b/docs/REQUIREMENTS.it.md
@@ -1,0 +1,83 @@
+[English](REQUIREMENTS.md) · [Deutsch](REQUIREMENTS.de.md) · **Italiano**
+
+# Requisiti / System Requirements
+
+Cosa deve avere il tuo server prima di installare Lumio. Per il vero e proprio
+flusso di installazione vedi [SELFHOSTING.md](SELFHOSTING.it.md), per lo scaling
+[SCALING.md](SCALING.it.md).
+
+## Sistema operativo & Docker
+
+- **Linux** (testato su Ubuntu 22.04/24.04 e Debian 12). Altre distribuzioni
+  funzionano finché Docker gira.
+- **Docker Engine ≥ 24** e **Docker Compose v2** (`docker compose`, non il
+  vecchio `docker-compose`). Verifica: `docker compose version`.
+- Compose v2 usa BuildKit di default — importante per il `--build`.
+
+## Architettura CPU — amd64 **e** arm64
+
+Lumio gira su entrambe le architetture server comuni. Costruisci le immagini
+con `--build` nativamente sulla tua macchina; la variante giusta viene
+selezionata automaticamente, nulla da configurare.
+
+| Architettura | Esempi | Stato |
+|---|---|---|
+| **amd64** (x86-64) | Intel/AMD, la maggior parte delle VM cloud (Hetzner CX/CPX, …) | Pienamente supportata, target di test primario |
+| **arm64** (aarch64) | Ampere (Hetzner CAX), AWS Graviton, Apple Silicon via Docker, Raspberry Pi 5 | Pienamente supportata |
+
+**Un limite su ARM:** l'accelerazione GPU per l'auto-tagging IA
+([GPU.md](GPU.it.md)) richiede **NVIDIA/CUDA** ed è quindi disponibile solo su amd64. Su
+ARM il tagging gira sulla CPU — funzionalmente identico, solo più lento per
+immagine. Tutte le altre funzionalità (gallerie, caricamento, RAW/HEIC,
+transcodifica video, proofing, ZIP, print shop) sono completamente identiche
+su entrambe le architetture.
+
+> Nota su Apple Silicon: Docker Desktop su un Mac serie M esegue container
+> `linux/arm64` — ottimo per i test locali. Per la produzione un vero server
+> Linux (amd64 o arm64) resta la raccomandazione.
+
+## Memoria & CPU
+
+Indicazioni di massima. Il maggiore consumatore è la transcodifica video
+(libx264 su CPU); il funzionamento solo foto/RAW è molto più leggero.
+
+| Setup | CPU | RAM | Nota |
+|---|---|---|---|
+| **Singolo studio, solo foto** | 2 vCPU | 4 GB | Livello base, gallerie piccole |
+| **Singolo studio con video** | 4 vCPU | 8 GB | La transcodifica ha bisogno di margine |
+| **+ Auto-tagging IA (worker ML)** | +2 vCPU | **+4 GB** | Inferenza CLIP; immagine ~2,5 GB invece di ~1 GB |
+| **Multi-tenant / SaaS** | 8 vCPU | 16 GB | + [nodi worker](SCALING.it.md) separati se necessario |
+
+Il worker ML serve solo se vuoi l'auto-tagging — senza di esso il supplemento
+di RAM non si applica. I worker possono essere spostati su nodi dedicati non
+appena un server non basta più (vedi [SCALING.md](SCALING.it.md)).
+
+## Disco
+
+- **Sistema + immagini:** ~5 GB (con worker ML ~7 GB).
+- **Database:** piccolo (metadati, nessuna immagine) — cresce lentamente.
+- **Immagini/video:** il vero fabbisogno di spazio.
+  - Con **MinIO** (locale) i file vivono sul volume del server — dimensiona il
+    disco in base al volume atteso di foto/video. Regola pratica: sensato fino
+    a ~500 GB, oltre usa S3 esterno.
+  - Con **S3 esterno** (Hetzner Object Storage, R2, B2, Wasabi) il server
+    stesso non ha quasi bisogno di storage. Setup: [STORAGE.md](STORAGE.it.md).
+
+## Rete
+
+- Un **IPv4** pubblico (e opzionalmente IPv6) con le porte **80** + **443**
+  aperte (Caddy ottiene il certificato Let's Encrypt tramite queste).
+- **Porta 9000** aperta anche se giri SENZA una subdomain S3
+  (Quick Start / test via IP): il browser carica e recupera le immagini
+  direttamente da MinIO su quella porta. Con `S3_PUBLIC_URL` impostato
+  (setup con dominio secondo SELFHOSTING.md), la 9000 resta interna.
+- Un **dominio** che punta all'IP del server.
+- Per il multi-tenant con sottodomini wildcard vedi anche [WILDCARD.md](WILDCARD.it.md).
+
+## Checklist rapida
+
+- [ ] Server Linux, amd64 **o** arm64
+- [ ] Docker ≥ 24 + Compose v2
+- [ ] Dominio + IP pubblico, porte 80/443 aperte (firewall del SO **e** del cloud); senza subdomain S3 anche la 9000
+- [ ] RAM/CPU secondo la tabella (considera video & tagging ML)
+- [ ] Strategia di storage decisa (MinIO locale vs. S3 esterno)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](REQUIREMENTS.de.md)
+**English** · [Deutsch](REQUIREMENTS.de.md) · [Italiano](REQUIREMENTS.it.md)
 
 # Requirements / System Requirements
 

--- a/docs/ROADMAP.de.md
+++ b/docs/ROADMAP.de.md
@@ -1,4 +1,4 @@
-[English](ROADMAP.md) · **Deutsch**
+[English](ROADMAP.md) · **Deutsch** · [Italiano](ROADMAP.it.md)
 
 # Lumio — Roadmap
 

--- a/docs/ROADMAP.it.md
+++ b/docs/ROADMAP.it.md
@@ -1,0 +1,255 @@
+[English](ROADMAP.md) · [Deutsch](ROADMAP.de.md) · **Italiano**
+
+# Lumio — Roadmap
+
+Aggiornato a: giugno 2026. Un documento vivo — le priorità possono cambiare. Il nucleo dell'app è pronto ed è in produzione; la variante SaaS è live su lumio-cloud.de.
+
+---
+
+## Fase 0 — Skeleton & infrastruttura ✅
+
+- [x] Struttura monorepo (apps/api, apps/frontend, apps/worker, packages/shared)
+- [x] Stack Docker Compose con Postgres, Redis, MinIO, Caddy
+- [x] Schema Prisma (modello dati completo incl. multi-tenancy + billing)
+- [x] API skeleton con Fastify + endpoint di health
+- [x] Worker skeleton con Celery + helper di archiviazione
+- [x] Frontend skeleton con Next.js + Tailwind
+- [x] Documento di concept
+- [x] Pipeline CI (Forgejo Actions) — lint, build, test
+- [x] Immagini container automaticamente nel container registry (Forgejo, con override `docker-compose.prod.yml` e pin `LUMIO_TAG`)
+- [x] TLS wildcard per i sottodomini dei tenant via acme-dns (profilo Compose `wildcard`; vedi docs/WILDCARD.md)
+- [x] Scalabilità orizzontale dei worker su più nodi (Hetzner Private Network, Redis protetto da password; vedi docs/SCALING.md)
+
+---
+
+## Fase 1 — MVP (sprint 1–4)
+
+**Obiettivo:** un'applicazione di gallerie funzionante con caricamento, visualizzazione, like, download.
+
+### Sprint 1 — Auth & tenancy
+
+- [x] Auto-bootstrap del tenant in modalità single (il primo avvio crea un tenant predefinito)
+- [x] Registrazione utente + login (email + password, Argon2)
+- [x] Gestione delle sessioni con cookie HTTPOnly
+- [x] CLI: `npm run create-admin`
+- [x] Middleware di risoluzione del tenant (dominio/sottodominio/slug)
+
+### Sprint 2 — Pipeline di caricamento ✅ (per lo più)
+
+- [x] Creazione di una galleria via API
+- [x] Browser → S3 presigned PUT con supporto multipart
+- [x] Worker: process_file per JPEG/PNG/WebP/TIFF/HEIC (rendition thumb/preview/web con libvips)
+- [x] Studio UI: elenco gallerie, dialog di creazione, pagina di dettaglio con caricamento drag & drop
+- [x] Coda dei job basata su stream (Redis streams) tra API e worker
+- [x] Aggiornamento di stato basato su polling nel frontend (ogni 2s durante l'elaborazione)
+- [x] Push WebSocket per lo stato dei file (sostituisce il polling a 2s nello studio con /ws/galleries/:id; il polling resta come fallback a 10s)
+- [x] Test worker: far passare realmente un'immagine end-to-end
+      (test di integrazione con testcontainers, viene eseguito in CI con i servizi Postgres+MinIO)
+
+### Sprint 3 — Galleria cliente ✅ (per lo più)
+
+- [x] Route slug della galleria `/g/[slug]` con branding
+- [x] Protezione con password
+- [x] Vista a griglia (griglia standard, masonry virtualizzato arriva nella fase 2)
+- [x] Lightbox con navigazione da tastiera + touch + filtri
+- [x] Like / tag colore (UI di valutazione a stelle arriva nella fase 2)
+- [x] Ottimizzazione touch mobile (tutti i tap target ≥36px)
+- [x] Gestione dei link di condivisione nello studio incl. token e permessi
+- [x] Sessione visitatore tramite cookie HMAC invece di un token in ogni URL
+
+### Sprint 4 — Download & proofing ✅
+
+- [x] Download di singolo file via URL presigned
+- [x] Commenti per immagine
+- [x] Panoramica studio: quali file sono stati selezionati? (`/galleries/:id/proofing/summary`)
+- [x] Builder ZIP in streaming (task worker build_zip con S3 multipart)
+- [x] Rendition con watermark (quando il download è disattivato)
+- [x] Export CSV della selezione
+- [x] **Export XMP sidecar per Lightroom Classic / Capture One**
+- [x] Studio UI per il riepilogo proofing con statistiche + tabella per-accesso + elenco file
+- [x] Notifiche email (nuovo commento)
+- [x] Pulsante di completamento selezione per il cliente con notifica email
+- [x] Notifica ZIP della selezione al cliente (notifica lazy al primo poll pronto)
+- [x] UI di caricamento immagine watermark nello studio (PUT presigned direttamente su S3)
+
+---
+
+## Fase 2 — Funzionalità Pro (sprint 5–8)
+
+### RAW & video ✅ (per lo più)
+
+- [x] Worker: process_raw con rawpy — anteprima JPEG incorporata come fast path,
+      fallback al demosaicing completo (use_camera_wb=True),
+      poi la stessa pipeline libvips usata per le immagini standard
+- [x] Worker: process_video con ffmpeg → poster + HLS adaptive bitrate
+      (480p/720p/1080p, nessun upscaling) + sprite sheet per lo scrubbing
+- [x] API: route proxy HLS (`/g/:slug/files/:id/hls/...`) così le playlist
+      con percorsi di segmento relativi funzionano senza rendere pubblico il bucket
+- [x] Frontend: player video hls.js con fallback HLS nativo Safari
+- [x] Frontend: indicatori video e RAW nella griglia (icona play, badge RAW)
+- [x] Test worker (pytest, 6 verdi) per la selezione delle varianti HLS e il parsing dei kbps
+- [x] Usare l'anteprima di scrubbing video nel player (lo sprite sheet c'è già; passando sopra la barra di avanzamento appare una miniatura del frame con tooltip del tempo)
+- [x] Accelerazione HW opzionale (NVENC/QSV/VAAPI via LUMIO_HW_ENCODER, fallback su libx264; vedi DEVELOPMENT.md)
+- [x] HEIC/HEIF nell'API come rilevamento di tipo proprio (variante `"heic"` dedicata, badge del formato nello studio + tile cliente, suggerimento Windows nel download dal lightbox)
+- [x] Download web del video come MP4 standalone (nuova rendition `video_mp4`: 1080p o risoluzione sorgente, +faststart, encoder via select_encoder()/profile_for(); adattati sia il download singolo cliente che il builder ZIP; task di backfill `backfill_video_mp4` per lo stock esistente per galleria o globalmente)
+- [x] Estrazione anteprima PSD (composite via Pillow, `apps/worker/psd.py`; libvips non può leggere i PSD direttamente)
+
+### Branding & whitelabel ✅ (fase 1)
+
+- [x] Editor di branding nello studio (logo, favicon, colori, font, testi, CSS personalizzato)
+- [x] Override del branding per galleria (con fallback al default del tenant)
+- [x] Inserimento dominio personalizzato nelle impostazioni del tenant
+- [x] Resolver di branding con URL GET presigned per gli asset (cache di 24h)
+- [ ] TLS automatico per i domini personalizzati (attualmente: Caddy deve essere configurato manualmente)
+- [ ] Verifica DNS (challenge tramite record TXT)
+
+### Multi-tenancy & billing (modalità hosted) ✅
+
+Completamente implementato — dettagli nella fase 5.
+
+- [x] Definizioni dei piani (`services/plans.ts`) + migrazione seed
+- [x] Integrazione Stripe: checkout, webhook, customer portal (`routes/billing.ts`)
+- [x] Cronjob di tracciamento utilizzo (`worker/tasks/billing.py`, archiviazione + banda)
+- [x] Applicazione dei limiti su caricamento + galleria/dominio personalizzato/branding
+- [x] Registrazione self-service del tenant (`routes/signup.ts`)
+
+### Collaborazione
+
+- [ ] Voto di gruppo (più persone per token di accesso)
+- [ ] Cursore live nel lightbox (fanout WebSocket)
+- [x] Scarabocchi/annotazioni sull'immagine (`AnnotationOverlay.tsx` + campo schema `annotation`, nella galleria cliente e nel proofing dello studio)
+- [x] Limite di selezione ("il cliente può scegliere al massimo N") — impostazione della galleria nello studio, contatore "X di Y" nell'hero del cliente, rollback dell'optimistic update in caso di violazione del limite con un toast
+- [x] Sincronizzazione in tempo reale della selezione tra studio e cliente (lo studio riceve toast live sui cambi di selezione, commenti e finalizzazione via WebSocket; il lato cliente resta single-user come Picdrop)
+
+### Workflow
+
+- [x] Export XMP sidecar (compatibile Lightroom/Capture One)
+- [x] Azioni bulk nello studio: multi-selezione + eliminazione + hide/show + ordinamento drag & drop (touch + tastiera via @dnd-kit)
+- [x] Template/preset di galleria (modalità/toggle/branding/scadenza/descrizione predefinita)
+- [x] Notifiche email (selezione completata, nuovo commento)
+- [x] Modalità presentazione (slideshow a schermo intero con avanzamento automatico, cross-fade, intervallo regolabile)
+
+---
+
+## Fase 3 — Rifinitura & crescita
+
+- [x] Plugin Lightroom Classic (Lua) — porta la selezione direttamente nel catalogo (`apps/lightroom-plugin/`)
+- [x] Plugin Capture One (AppleScript + CLI Python per macOS, rispecchia la selezione nel catalogo/sessione attivi; mantiene la stessa API `/api/v1/plugin/*` del plugin Lightroom)
+- [x] Studio e pagina cliente multilingue (DE, EN — altre lingue seguiranno tramite il sistema di dizionari i18n; un selettore di lingua in galleria per i visitatori è ancora da fare)
+- [ ] App mobile (React Native) per iOS/Android — caricamento dal rullino fotografico
+- [ ] API pubblica con OAuth2
+- [x] Webhook per gli eventi dello studio (firmati HMAC-SHA256, consegna asincrona con retry a backoff esponenziale, UI /studio/webhooks con pulsante di test e log di consegna)
+- [x] Statistiche dettagliate della galleria (visualizzazioni negli ultimi 30 giorni, ripartizione per accesso con visite/like/commenti/stato finalizzato, file principali per like, download per tipo; `/studio/[id]/stats` con sparkline SVG)
+- [x] Tagging AI opzionale — **CLIP** in locale sul server (nessuna chiamata API esterna), opt-in tramite l'immagine ML worker (`docker-compose.ml.yml`, CPU/GPU), soglia via `LUMIO_CLIP_THRESHOLD`; vedi docs/ML.md
+- [ ] Firme elettroniche per contratti modella/modello e liberatorie sui diritti
+- [x] Print shop / vendita immagini — prodotti/varianti/spedizione/fornitori, ritaglio, carrello, checkout Stripe (Stripe Connect), conferma d'ordine + email (`services/print/*`, `routes/print-shop-public.ts`)
+- [x] 2FA per il login allo studio: TOTP (otplib + 8 codici di backup) + WebAuthn/passkey (@simplewebauthn, Touch ID/Windows Hello/chiavi di sicurezza, più credenziali per utente)
+- [x] Visualizzatore audit log nello studio (strumentato: login/logout, CRUD galleria, eliminazione/bulk file, creazione/eliminazione/sblocco condivisione, selection.finalize, CRUD branding; /studio/audit con filtri galleria/azione/tempo + export CSV lato client; export CSV lato server per log di grandi dimensioni ancora da fare)
+
+---
+
+## Fase 4 — Enterprise / DAM-light
+
+- [x] Ricerca globale su tutte le gallerie di un tenant (command palette Cmd/Ctrl+K con ricerca live su gallerie, file, branding, template; backend ILIKE, 4 query parallele in un solo roundtrip)
+- [x] Sistema di tag con gerarchia (tag a livello di tenant con relazione parent, colore, assegnazione alla galleria con filtro AND nell'elenco, componente TagPicker con chip inline; API file-tag pronta, la UI seguirà con le azioni bulk sui file)
+- [x] Super admin & gestione multi-tenant (area di login `/super`, tabella super_admins + sessioni dedicate, CRUD tenant con owner iniziale + email di setup, ciclo di vita suspend/reactivate/archive, guardie di stato del tenant nei percorsi di login + cliente, flusso di impostazione password per gli owner invitati)
+- [x] Design dell'header della galleria (immagine hero dalla galleria o caricata, colore overlay, colore di sfondo come fallback, logo evento per galleria, markdown di benvenuto con react-markdown, meta tag OG per le anteprime di condivisione su WhatsApp/iMessage/Slack, pulsante Web Share API con fallback negli appunti)
+- [x] Footer della galleria + colori della galleria (footerMarkdown per galleria, colorBackground e colorAccent come override del branding del tenant, calcolo automatico del colore del testo via luminanza WCAG)
+- [x] Varianti di layout hero (quattro varianti: Minimal, Splash con schermo intero + scroll hint, Side-by-side editoriale, Centered in stile rivista — campi condivisi, cambia solo la disposizione del rendering)
+- [x] Font della galleria (titolo + corpo selezionabili separatamente da un elenco curato di 8 font — 4 sans + 4 serif, conformi al GDPR via Bunny Fonts CDN, anteprima live nello studio)
+- [x] Varianti di layout a griglia (masonry/justified/equal — solo CSS, nessun layout JS)
+- [x] Espansione dello slideshow (tre effetti di transizione: fade/slide/Ken Burns con 4 direzioni di pan, rispetta prefers-reduced-motion)
+- [x] Musica di sottofondo per lo slideshow (caricamento audio per galleria MP3/AAC/OGG max 30 MB, auto-play nello slideshow grazie al gesto dell'utente, loop, slider del volume con persistenza in localStorage)
+- [x] Capitoli/sezioni della galleria (livello di raggruppamento opzionale, i file mantengono il comportamento del bucket predefinito quando non c'è una sezione, la vista cliente ottiene navigazione con ancore sticky + fasce divisorie con immagine di copertina opzionale, editor dello studio con riordino + selettore bulk dei file)
+- [x] Smart collection / filtri salvati (macro di filtro interne allo studio analoghe a Lightroom: modalità + stato + tag collegati con AND, salvati per utente per tenant, accesso rapido dalla sidebar + pagina di modifica dedicata, filtri ad-hoc via query param a /galleries, filtri persistiti via CRUD /collections; intervallo di date preparato nel backend, il datepicker frontend seguirà)
+- [ ] Workflow di approvazione (più revisori in sequenza)
+- [ ] SSO (SAML, OIDC)
+- [ ] Log delle attività con export per la conformità
+- [ ] Permessi per cartella
+
+---
+
+## Fase 5 — Variante Cloud (estensione SaaS)
+
+**Obiettivo:** Lumio come servizio gestito su `lumio-cloud.de` con iscrizione self-service e fatturazione automatica. Il nucleo dell'app resta source-available (FSL) e self-hostable — questa fase riguarda solo il livello di servizio hosted che ci sta sopra. **Stato: live su lumio-cloud.de.**
+
+### Modello dei piani & limiti ✅ (commit `e15c5bc`)
+
+- [x] Definizioni dei piani (Start €9, Solo €19, Studio €39, Pro €89; + trial di 14 giorni)
+      come modulo centrale in `services/plans.ts`
+- [x] Aggregazione live dell'utilizzo di archiviazione senza drift dei contatori
+- [x] Applicazione dei limiti nelle route esistenti:
+      init caricamento, creazione galleria, dominio personalizzato, branding
+- [x] Tabella BillingSubscription con storageAddonGib + readOnlySince
+- [x] Migrazione che fa il seed dei 3 piani + una subscription Pro automatica per
+      i tenant esistenti
+- [x] Pagina studio `/studio/billing` con piano + barra archiviazione +
+      barra gallerie + panoramica funzionalità + confronto piani
+- [x] Banner di archiviazione in cima a ogni pagina dello studio oltre l'80% di archiviazione,
+      fine trial <3 giorni o modalità sola lettura
+- [x] Dialog 402 al caricamento con link alla pagina dei piani
+- [x] Feature gate: impostazioni di dominio personalizzato + branding disabilitate
+      e con un suggerimento sul piano quando non coperte
+- [x] Controllato tramite la env `BILLING_ENABLED` — il self-hosted senza billing
+      funziona del tutto invariato
+
+### Separazione dei domini app ↔ marketing
+
+- [x] Punti del codice app con `lumio-cloud.de` hardcoded passati a
+      `studio.lumio-cloud.de` (default plugin Lightroom e
+      Capture One, esempi nel README, commenti nel codice)
+- [x] Documentazione Caddy sul nuovo dominio. Più una nota che i siti
+      marketing vivono nei propri repo.
+- [x] MULTI_TENANT.md: riferimenti dell'app a studio.lumio-cloud.de,
+      i sottodomini dei tenant restano deliberatamente su `*.lumio-cloud.de`
+      (il wildcard DNS è separato dalla root del sito marketing)
+- [x] DNS: `studio.lumio-cloud.de` punta al server dell'app
+- [x] Caddy serve il dominio dell'app + il wildcard `*.lumio-cloud.de`
+- [x] Questione dei sottodomini dei tenant decisa: `<slug>.lumio-cloud.de`
+      via il wildcard acme-dns
+
+### Integrazione Stripe ✅
+
+Implementata in `routes/billing.ts` + `services/stripe-service.ts`/`stripe-client.ts`:
+
+- [x] `POST /billing/subscription` — sessione di checkout con trial di 14 giorni
+- [x] `POST /billing/portal` — customer portal (carta/piano/cancellazione)
+- [x] `POST /billing/webhook` — verificato tramite firma; elabora
+      `checkout.session.completed`, `customer.subscription.updated/deleted`,
+      `invoice.payment_succeeded/failed`
+- [x] `/billing/plans`, `/billing/usage`, route di riattivazione
+- [x] Add-on di archiviazione + metodi di pagamento (via Stripe)
+- [ ] Operativamente per ogni deployment: bootstrap di prodotti/prezzi Stripe
+      (`docker compose exec api npm run stripe-bootstrap`)
+
+### Logica di grazia ✅
+
+Costruita una state machine per i tenant `past_due` (`worker/tasks/billing.py`, `plugins/read-only.ts`, campo `readOnlySince`): retry Stripe + solleciti → blocco login → sola lettura → annuncio di eliminazione → hard delete con un'offerta di export dati conforme al GDPR prima della cancellazione.
+
+### Flusso di sign-up ✅
+
+- [x] Autoregistrazione (`routes/signup.ts`: `/signup`,
+      `/signup/check-email`, `/signup/check-slug`)
+- [x] Tenant + utente owner + subscription trial + customer Stripe in un'unica transazione
+- [x] Email di onboarding/setup
+- [x] Fine trial → addebito automatico o sola lettura
+
+### Estensioni future (aperte, nessuno sprint pianificato)
+
+- [x] Sconto annuale (~17%: prezzo annuale = 10 prezzi mensili, `priceYearlyCents` in `plans.ts`; toggle annuale nella UI di billing)
+- [ ] Variante ad acquisto singolo per le coppie di sposi ("€49 una tantum,
+      galleria attiva per 12 mesi") come caso d'uso separato
+- [ ] Programma affiliati/partner
+- [ ] Open core: separare le funzionalità Pro dal repo FSL
+      (es. SSO, account team) in caso di pressione del mercato
+- [ ] Opzione di dual-licensing (licenza commerciale su richiesta)
+      se emerge un caso d'uso concreto
+
+---
+
+## Non pianificato
+
+Escluso deliberatamente — a meno di richieste forti:
+
+- ❌ Un editor immagini integrato (ritaglio, filtri) — resta nel workflow di Lightroom/Capture One.
+- ❌ Gestione complessa dei permessi con decine di ruoli — Lumio resta snello.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](ROADMAP.de.md)
+**English** · [Deutsch](ROADMAP.de.md) · [Italiano](ROADMAP.it.md)
 
 # Lumio — Roadmap
 

--- a/docs/SAAS_MODE.de.md
+++ b/docs/SAAS_MODE.de.md
@@ -1,4 +1,4 @@
-[English](SAAS_MODE.md) · **Deutsch**
+[English](SAAS_MODE.md) · **Deutsch** · [Italiano](SAAS_MODE.it.md)
 
 # SaaS-Mode
 

--- a/docs/SAAS_MODE.it.md
+++ b/docs/SAAS_MODE.it.md
@@ -1,0 +1,277 @@
+[English](SAAS_MODE.md) · [Deutsch](SAAS_MODE.de.md) · **Italiano**
+
+# Modalità SaaS
+
+> ⚠️ **Nota sulla licenza:** L'uso multi-tenant per la **tua organizzazione o
+> agenzia** è senza restrizioni. Ma far girare Lumio come **SaaS commerciale
+> per terzi paganti** — esattamente ciò che questa guida rende possibile —
+> è *Competing Use* e **non** è consentito di default secondo la
+> FSL-1.1-ALv2. Serve una licenza commerciale (è il modello di business
+> dietro lumio-cloud.de, gestito dallo stesso maintainer). Vedi
+> [LICENSE](../LICENSE).
+
+Lumio può funzionare non solo come strumento per un singolo studio, ma anche
+come piattaforma SaaS completa: tenant multipli, fatturazione Stripe,
+periodi di prova, registrazione autonoma. Questa guida descrive la
+configurazione.
+
+**Prerequisito:** il [setup di produzione](SELFHOSTING.it.md) è completato
+con successo, Lumio gira sotto il tuo dominio con HTTPS.
+
+---
+
+## Concetto
+
+In modalità SaaS:
+
+- **DEPLOYMENT_MODE=multi** – uno stack Lumio, tanti tenant
+- Ogni tenant è uno studio autonomo con proprie gallerie, utenti, branding
+- Periodo di prova alla registrazione (14 giorni di accesso completo)
+- Stripe si occupa della gestione degli abbonamenti e dei pagamenti
+- Il super admin gestisce l'intera piattaforma tramite `/super`
+
+Piani (definizioni aggiornate in `apps/api/src/services/plans.ts`):
+
+| Piano | Archiviazione | Prezzo/mese | Prezzo/anno |
+|---|---|---|---|
+| Trial | 50 GB | €0 (14 giorni) | – |
+| Solo | 50 GB | €19 | €190 (2 mesi gratis) |
+| Studio | 250 GB | €39 | €390 |
+| Pro | 1 TB | (vedi plans.ts) | (vedi plans.ts) |
+
+Più un **pacchetto di archiviazione** opzionale come componente aggiuntivo
+per ogni piano.
+
+---
+
+## Configurazione
+
+### 1. Attiva la modalità multi
+
+In `.env`:
+
+```bash
+DEPLOYMENT_MODE=multi
+LUMIO_HOST=studio.your-saas-domain.com       # login domain for all tenants
+BILLING_ENABLED=true
+```
+
+Poi:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build api worker
+```
+
+### 2. Prepara l'account Stripe
+
+- Crea un account Stripe (o usane uno esistente)
+- Usa la **modalità test** finché tutto non funziona – attiva/disattiva le
+  API key in alto nella dashboard tra test/live
+- Copia la secret key: Developers → API Keys → Secret key (`sk_test_...` per
+  test, `sk_live_...` per produzione)
+
+### 3. Stripe in `.env`
+
+```bash
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_WEBHOOK_SECRET=                # stays empty for now, comes in step 5
+BILLING_CURRENCY=EUR
+```
+
+Riavvia l'API:
+
+```bash
+docker compose restart api
+```
+
+### 4. Crea i piani in Stripe
+
+Lumio include uno script di bootstrap che crea tutti i prodotti e i prezzi
+in Stripe e scrive gli ID nel DB di Lumio:
+
+```bash
+docker compose exec api npm run stripe-bootstrap
+```
+
+L'output dovrebbe essere:
+```
+[stripe-bootstrap] ✓ Product 'Lumio Solo' synced
+[stripe-bootstrap] ✓ Price 'plan_solo_monthly' created (price_xxx)
+[stripe-bootstrap] ✓ Price 'plan_solo_yearly' created (price_xxx)
+... (for Studio, Pro, storage pack)
+```
+
+Nella Stripe Dashboard → Products dovresti ora vedere tre prodotti Lumio.
+
+Lo script è **idempotente** – eseguirlo più volte è sicuro e aggiorna solo
+ciò che è cambiato.
+
+### 5. Configura il webhook
+
+Stripe deve informare Lumio quando un pagamento va a buon fine o un
+abbonamento viene annullato.
+
+Nella Stripe Dashboard → Developers → Webhooks → Add endpoint:
+
+- **Endpoint URL:** `https://studio.your-saas-domain.com/api/billing/webhook`
+- **Eventi:**
+  - `customer.subscription.created`
+  - `customer.subscription.updated`
+  - `customer.subscription.deleted`
+  - `customer.subscription.trial_will_end`
+  - `invoice.payment_succeeded`
+  - `invoice.payment_failed`
+  - `checkout.session.completed`
+
+Dopo averlo creato, copia il "Signing secret" (`whsec_...`) → in `.env`:
+
+```bash
+STRIPE_WEBHOOK_SECRET=whsec_...
+```
+
+Riavvia l'API:
+
+```bash
+docker compose restart api
+```
+
+Test: nel dettaglio del webhook in Stripe clicca "Send test webhook" →
+l'evento dovrebbe comparire nei log dell'API.
+
+### 6. Crea un super admin
+
+```bash
+docker compose exec api npm run create-super-admin -- \
+  --email=ops@your-saas-domain.com \
+  --password=atleast12chars \
+  --name="Ops"
+```
+
+Password: almeno 12 caratteri.
+
+### 7. Testa la registrazione
+
+Sul sito marketing (se deployato) percorri il flusso di registrazione.
+Oppure direttamente:
+
+→ `https://studio.your-saas-domain.com/signup`
+
+Il periodo di prova dovrebbe iniziare subito, senza bisogno di pagamento
+Stripe all'avvio del periodo di prova.
+
+Area super admin:
+
+→ `https://studio.your-saas-domain.com/super`
+
+Qui vedi tutti i tenant, gli abbonamenti, l'MRR.
+
+---
+
+## Andare in produzione
+
+Una volta che il setup in modalità test gira stabilmente:
+
+1. In Stripe disattiva "View test data" in alto a sinistra (torna a live)
+2. Copia la secret key e la publishable key live
+3. In `.env` cambia `sk_test_...` → `sk_live_...` e `pk_test_...` →
+   `pk_live_...`
+4. **Crea di nuovo il webhook** in modalità live (live e test hanno webhook
+   separati)
+5. Aggiorna `STRIPE_WEBHOOK_SECRET` con il nuovo signing secret
+6. **Esegui di nuovo `stripe-bootstrap`** – crea i prodotti nello Stripe live
+   (i prodotti di test restano in modalità test)
+7. Riavvia l'API
+
+---
+
+## Routing dei tenant
+
+In modalità multi si pone una domanda importante: come fa Lumio a sapere a
+quale tenant appartiene una richiesta?
+
+La risoluzione avviene nell'API in questo ordine:
+
+1. **Utente autenticato** – il cookie di sessione indica il tenant
+2. **Header `X-Lumio-Tenant`** – per l'app mobile e i client API
+3. **Dominio personalizzato** – `client-photos.com` confrontato con
+   `tenants.customDomain`
+4. **Sottodominio** – `studio-mueller.your-domain.com` (serve un certificato
+   wildcard, vedi [WILDCARD.md](WILDCARD.it.md))
+
+**Consiglio per iniziare:** tutti i tenant accedono tramite
+`studio.your-saas-domain.com`. La risoluzione del tenant avviene quindi
+tramite l'utente autenticato. Puoi attivare domini personalizzati e
+sottodomini più avanti – vedi [MULTI_TENANT.md](MULTI_TENANT.it.md).
+
+---
+
+## Ciclo di vita della prova e dell'abbonamento
+
+- **Registrazione** → vengono creati tenant e utente, la prova ha inizio
+  (14 giorni), nessun pagamento
+- **La prova scade** → l'utente riceve un banner nell'interfaccia, il
+  webhook `trial_will_end` (3 giorni prima) attiva un'email
+- **Scelta del piano** → Stripe Checkout, poi il webhook
+  `checkout.session.completed` imposta il piano
+- **Pagamento fallito** → `invoice.payment_failed` → il tenant passa a
+  `past_due`, dopo la logica di retry di Stripe a `suspended`
+- **Sospeso** → il login del tenant funziona ancora (per aggiornare il
+  piano), ma le gallerie sono di sola lettura
+- **Annullamento** → il tenant viene marcato in `tenants.archived`, non
+  eliminato immediatamente. L'eliminazione definitiva viene eseguita da uno
+  sweeper dopo un periodo di grazia.
+
+Implementazione concreta in `apps/api/src/services/billing.ts` e
+`apps/api/src/routes/billing.ts`.
+
+---
+
+## Configurare l'invio email
+
+Per i promemoria di prova, le notifiche di pagamento fallito, gli inviti
+alle gallerie, ecc. ti serve SMTP:
+
+```bash
+SMTP_HOST=smtp.your-mail.com
+SMTP_PORT=587
+SMTP_SECURE=false                    # STARTTLS, true for SMTPS on port 465
+SMTP_USER=noreply@your-saas-domain.com
+SMTP_PASSWORD=...
+SMTP_FROM="Lumio <noreply@your-saas-domain.com>"
+SMTP_REPLY_TO="Support <support@your-saas-domain.com>"   # optional, see below
+SUPPORT_EMAIL=support@your-saas-domain.com               # optional, see below
+FEEDBACK_EMAIL=feedback@your-saas-domain.com             # optional, see below
+LEAD_ADMIN_EMAIL=ops@your-saas-domain.com
+```
+
+**Reply-To:** Se `SMTP_FROM` è un indirizzo no-reply senza una casella di
+posta dietro, le risposte rimbalzano. Imposta `SMTP_REPLY_TO` su un
+indirizzo monitorato (casella reale o inoltro). Senza, non viene impostato
+alcun header Reply-To.
+
+**Indirizzi di contatto nelle email di sistema:** Lumio adatta il testo
+delle sue email a ciò che è effettivamente configurato — non promette mai un
+canale di risposta che non esiste:
+
+| Configurazione | Cosa dicono le email |
+|---|---|
+| `SMTP_REPLY_TO` impostato | "Rispondi pure a questa email oppure scrivi a …" |
+| solo `SUPPORT_EMAIL` impostato | "Scrivici a …" |
+| nessuno dei due | nessun indirizzo di contatto |
+
+`SUPPORT_EMAIL` ricade sull'indirizzo di `SMTP_REPLY_TO` se non impostato,
+`FEEDBACK_EMAIL` ricade su `SUPPORT_EMAIL`. Entrambi si aspettano un
+indirizzo nudo senza nome visualizzato.
+
+Se `SMTP_HOST` resta vuoto, tutto gira in modalità no-op – le email di prova
+non vengono inviate, il resto funziona normalmente.
+
+Provider consigliati: **Postmark** (transazionale, alta deliverability),
+**Mailjet** (server UE, GDPR), **SES** (economico, legato ad AWS).
+
+---
+
+## Errori comuni
+
+→ vedi [TROUBLESHOOTING.md – problemi in modalità SaaS](TROUBLESHOOTING.it.md#problemi-in-modalità-saas)

--- a/docs/SAAS_MODE.md
+++ b/docs/SAAS_MODE.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](SAAS_MODE.de.md)
+**English** · [Deutsch](SAAS_MODE.de.md) · [Italiano](SAAS_MODE.it.md)
 
 # SaaS mode
 

--- a/docs/SCALING.de.md
+++ b/docs/SCALING.de.md
@@ -1,4 +1,4 @@
-[English](SCALING.md) · **Deutsch**
+[English](SCALING.md) · **Deutsch** · [Italiano](SCALING.it.md)
 
 # Horizontale Skalierung — zusätzliche Worker-Nodes
 

--- a/docs/SCALING.it.md
+++ b/docs/SCALING.it.md
@@ -1,0 +1,281 @@
+[English](SCALING.md) · [Deutsch](SCALING.de.md) · **Italiano**
+
+# Scalabilità orizzontale — nodi worker aggiuntivi
+
+Lumio elabora immagini, RAW, video ed export ZIP in **worker Celery** che estraggono i job da una coda Redis centrale. Se la potenza di calcolo di un server non basta più (shooting di grandi dimensioni, molti video in parallelo), puoi collegare **server aggiuntivi** che eseguono solo worker. Celery distribuisce i job automaticamente su tutti i worker connessi — nessun load balancer, nessuna assegnazione manuale dei job.
+
+> **Self-hoster con un solo nodo?** Questo capitolo è **irrilevante** per te. Lascia tutto com'è — le variabili descritte qui (`REDIS_PASSWORD`, `REDIS_BIND_IP`, `POSTGRES_BIND_IP`) sono opzionali e vengono fornite nello stato "solo locale, nessuna password". Un singolo server non ha bisogno di nulla di tutto ciò. Non cambiare nulla su Redis/Postgres se gestisci un solo server.
+
+---
+
+## Concetto: cosa scala, cosa resta centrale
+
+```
+        Rete privata (es. Hetzner Private Network, gratuita)
+        ┌──────────────────────────┬──────────────────────────────┐
+        │                          │                              │
+  ┌─────┴───────────────┐    ┌─────┴────────────────┐
+  │  Server principale  │    │  Nodo/i worker       │
+  │  10.0.0.2           │    │  10.0.0.3, .4, …     │
+  │                     │    │                      │
+  │  API, frontend      │    │  Worker × N          │
+  │  Caddy, acme-dns    │    │  (solo Celery)       │
+  │  Postgres ◄─────────┼────┤  legge/scrive il DB  │
+  │  Redis (coda) ◄─────┼────┤  estrae i job        │
+  │  Worker (anche qui) │    │                      │
+  └─────────────────────┘    └──────────────────────┘
+            │                          │
+            └───────────┬──────────────┘
+                        ▼
+          S3 / object storage (esterno, raggiungibile da tutti)
+```
+
+**Centrale (esattamente una volta, sul server principale):**
+- **Postgres** — l'unica fonte di verità per tutti i metadati
+- **Redis** — la coda dei job (broker Celery) e cache
+- **API, frontend, Caddy** — livello web, migrazioni del database
+
+**Distribuibile (un numero qualsiasi di nodi):**
+- **Worker** — non mantengono uno stato proprio. Prendono un job da Redis, lo elaborano (immagine/RAW/video/ZIP), scrivono il risultato su S3, fine.
+
+**Esterno (raggiungibile da qualsiasi luogo):**
+- **S3 / object storage** — es. Hetzner Object Storage. Già esterno, quindi raggiungibile da ogni nodo senza configurazione aggiuntiva.
+
+I nodi worker non eseguono **alcuna** migrazione del database e non hanno bisogno di **alcuna** porta aperta verso l'esterno. Sono puri consumatori.
+
+---
+
+## Requisiti
+
+- Due (o più) server in una **rete privata condivisa**. Su Hetzner Cloud: un "Network", entrambi i server nella **stessa regione** (es. Falkenstein/fsn1), gratuito.
+- Il server principale è già in esecuzione (vedi [SELFHOSTING.md](SELFHOSTING.it.md)).
+- Storage esterno compatibile S3 (non MinIO-in-Docker, perché sarebbe presente solo sul server principale). Vedi [STORAGE.md](STORAGE.it.md).
+
+> **Perché S3 esterno è obbligatorio:** un nodo worker deve poter leggere i file originali e riscrivere le rendition. Se lo storage gira come container MinIO solo sul server principale, anche quello dovrebbe essere esposto sulla rete privata. Un object storage esterno (Hetzner/S3/R2/B2/Wasabi), comunque raggiungibile da tutti i nodi, è più pulito e più robusto.
+
+---
+
+## Passaggio 1 — Rete privata
+
+**Hetzner Cloud Console → Networks → Create Network:**
+- Name: `lumio-net`
+- IP range: `10.0.0.0/16`
+
+Aggiungi entrambi i server alla rete (Server → Networking → Attach). Ottengono IP privati, in questa guida:
+- Server principale: `10.0.0.2`
+- Nodo worker: `10.0.0.3`
+
+Verifica su **entrambi** i server che l'interfaccia privata sia presente:
+
+```bash
+ip addr | grep 10.0.0
+```
+
+Se non mostra nulla, il server non ha ancora ottenuto l'IP privato — di solito un `reboot` dopo l'attach risolve.
+
+---
+
+## Passaggio 2 — Mettere in sicurezza + esporre Redis (server principale)
+
+Sulla rete privata Redis è raggiungibile solo tra i tuoi server, ma impostiamo comunque una password (defense in depth) e lo bindiamo **esclusivamente** all'IP privato — mai a `0.0.0.0`.
+
+```bash
+cd /opt/docker/lumio/lumio
+git pull
+
+# Generate a password — keep it safe, the worker node needs it
+REDIS_PW=$(openssl rand -hex 24)
+echo "Redis password: $REDIS_PW"
+
+# Add to .env
+echo "REDIS_PASSWORD=$REDIS_PW"  >> .env
+echo "REDIS_BIND_IP=10.0.0.2"    >> .env
+echo "POSTGRES_BIND_IP=10.0.0.2" >> .env
+
+# Switch the REDIS_URL of all local services to the password
+sed -i 's|^REDIS_URL=.*|REDIS_URL=redis://:'"$REDIS_PW"'@redis:6379|' .env
+```
+
+Come funziona: il container Redis aggiunge `--requirepass` solo se `REDIS_PASSWORD` è impostata (espansione sh nel `command`). `REDIS_BIND_IP`/`POSTGRES_BIND_IP` controllano il mapping della porta host — il default è `127.0.0.1` (solo locale), qui lo impostiamo sull'IP privato.
+
+---
+
+## Passaggio 3 — Riavviare lo stack (server principale)
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.ml.yml \
+  up -d
+```
+
+Una breve interruzione (secondi) mentre Redis + i servizi si riavviano con il nuovo URL.
+
+---
+
+## Passaggio 4 — Verificare (server principale)
+
+```bash
+# Redis now requires auth
+docker exec lumio_redis redis-cli ping
+# → (error) NOAUTH Authentication required.     ✓
+
+docker exec lumio_redis redis-cli -a "$REDIS_PW" ping
+# → PONG                                         ✓
+
+# Redis + Postgres listen ONLY on the private IP
+ss -tlnp | grep -E '10.0.0.2:(6379|5432)'
+# → both listed                                  ✓
+
+# ... and NOT publicly
+ss -tlnp | grep -E '0.0.0.0:(6379|5432)'
+# → empty                                        ✓
+```
+
+---
+
+## Passaggio 5 — Configurare il nodo worker (10.0.0.3)
+
+### 5a. Installare Docker
+
+```bash
+curl -fsSL https://get.docker.com | sh
+docker compose version
+```
+
+### 5b. Testare la connettività (prima di tutto!)
+
+```bash
+nc -zv 10.0.0.2 6379    # Redis
+nc -zv 10.0.0.2 5432    # Postgres
+```
+
+Entrambi "open/succeeded" → continua. Altrimenti controlla la rete privata (`ip addr | grep 10.0.0`).
+
+### 5c. Clonare il repo
+
+```bash
+mkdir -p /opt/docker/lumio && cd /opt/docker/lumio
+git clone https://github.com/markusthiel/lumio.git lumio
+cd lumio
+```
+
+### 5d. Creare `.env.worker`
+
+```bash
+cp .env.worker.example .env.worker
+nano .env.worker
+```
+
+I valori: user/nome/password del DB e credenziali S3 **1:1 dal server principale** (esegui lì `grep -E "^POSTGRES_|^REDIS_PASSWORD|^S3_" /opt/docker/lumio/lumio/.env`), host sull'**IP privato** del server principale:
+
+```
+DATABASE_URL=postgres://lumio:<DB_PASSWORD>@10.0.0.2:5432/lumio
+REDIS_URL=redis://:<REDIS_PASSWORD>@10.0.0.2:6379
+STORAGE_PROVIDER=s3
+S3_ENDPOINT=https://fsn1.your-objectstorage.com
+S3_REGION=fsn1
+S3_BUCKET=lumio-prod
+S3_ACCESS_KEY=...
+S3_SECRET_KEY=...
+S3_FORCE_PATH_STYLE=true
+WORKER_CONCURRENCY=10
+LOG_LEVEL=info
+```
+
+### 5e. Avviare il worker
+
+```bash
+docker compose -f docker-compose.worker.yml --env-file .env.worker up -d --build
+```
+
+### 5f. Verificare
+
+```bash
+docker compose -f docker-compose.worker.yml --env-file .env.worker logs -f
+```
+
+Indicatori di successo nel log:
+- `Connected to redis://:**@10.0.0.2:6379//` — la connessione al broker è attiva
+- `mingle: sync with 1 nodes` / `mingle: sync complete` — il nuovo worker ha trovato gli altri worker (cluster formato)
+- `celery@… ready.` — accetta job
+
+Non appena arriva un job, vedrai `Task … received` / `… succeeded`.
+
+---
+
+## Tuning
+
+**Job paralleli per nodo** = `WORKER_CONCURRENCY` × `replicas`.
+
+- `WORKER_CONCURRENCY` (in `.env.worker`): regola pratica ≈ numero di core CPU. Server a 12 vCPU → 10–12.
+- `replicas` (in `docker-compose.worker.yml`): più processi worker per nodo. Di solito 1 con concurrency alta basta.
+
+**Carico CPU per tipo di job:**
+- Il **transcoding video** (libx264 senza GPU) è il maggior divoratore di CPU — qui l'hardware aggiuntivo aiuta di più.
+- **Immagine/RAW** (libvips/LibRaw) è relativamente leggero — un nodo copre parecchio.
+
+Più nodi: ripeti il passaggio 5 su altri server (10.0.0.4, .5, …). Nulla da cambiare sul server principale — i nuovi worker si registrano automaticamente via `mingle`.
+
+**Code:** Celery usa `default`, `heavy` (video/job grandi), `io` e `ml` (auto-tagging/CLIP). Quali code serve un worker è controllato dalla variabile d'ambiente `WORKER_QUEUES` (default `default,heavy,io,ml`). Se vuoi riservare un nodo solo al video, puoi limitarlo a `WORKER_QUEUES=heavy` — estendi secondo necessità.
+
+**Importante — CLIP/auto-tagging:** il tagger CLIP gira solo nei worker con l'immagine ML (`docker-compose.ml.yml`, di solito il server principale). I nodi Celery puri senza CLIP **non** devono quindi estrarre dalla coda `ml` — altrimenti le immagini elaborate lì riceverebbero solo i tag rule-based (formato/luminosità), ma nessun tag CLIP di contenuto. `docker-compose.worker.yml` imposta perciò `WORKER_QUEUES=default,heavy,io` (senza `ml`); i task di auto-tagging finiscono così esclusivamente sul server principale abilitato a CLIP. Se il tuo server principale non ha l'immagine ML, l'auto-tagging gira comunque (il default estrae `ml`), ma allora fornisce solo tag rule-based.
+
+---
+
+## Aggiornamenti sul nodo worker
+
+```bash
+cd /opt/docker/lumio/lumio
+git pull
+docker compose -f docker-compose.worker.yml --env-file .env.worker up -d --build
+```
+
+Importante: aggiorna i nodi worker dopo il server principale (prima le migrazioni sul server principale via API, poi i worker), così lo schema del DB corrisponde.
+
+### Quale modifica richiede quale server?
+
+| Modificato | Server principale | Nodo/i worker |
+|---|---|---|
+| `apps/frontend` (UI studio/cliente) | ✅ `up -d --build frontend` | — |
+| `apps/api` (backend, endpoint) | ✅ `up -d --build api` | — |
+| `apps/worker` (elaborazione immagini/video/RAW/ZIP) | ✅ `up -d --build worker` | ✅ `up -d --build` |
+| File Compose/infra | a seconda del servizio interessato | solo se rilevante per il worker |
+| Documentazione, siti marketing | — (o il proprio deploy marketing) | — |
+
+Regola pratica: il frontend e l'API girano **solo** sul server principale. Solo le modifiche ad `apps/worker` (la logica di conversione) devono essere distribuite anche su ogni nodo worker. Il deploy standard del server principale resta:
+
+```bash
+cd /opt/docker/lumio/lumio && git pull && docker compose \
+  -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.ml.yml \
+  up -d --build
+```
+
+---
+
+## Sicurezza — riepilogo
+
+- Redis + Postgres si bindano **solo** all'IP privato (`10.0.0.2`), mai a `0.0.0.0`. Dall'esterno (l'IP pubblico) le porte sono chiuse.
+- Redis è inoltre protetto da password.
+- I nodi worker non hanno bisogno di **alcuna** porta in ingresso verso l'esterno.
+- La rete privata non trasporta traffico internet — la connessione worker↔DB/Redis non lascia mai la rete interna Hetzner.
+
+---
+
+## Troubleshooting
+
+**`Connection refused` verso 10.0.0.2:6379/5432 dal nodo worker**
+La rete privata non è end-to-end. Esegui `ip addr | grep 10.0.0` su entrambi i server; se necessario riavvia il server dopo l'attach della rete. `nc -zv 10.0.0.2 6379` per testare.
+
+**`NOAUTH` / `WRONGPASS` nel log del worker**
+`REDIS_URL` in `.env.worker` non contiene la password (o ne contiene una sbagliata). Deve corrispondere esattamente al `REDIS_PASSWORD` del server principale: `redis://:<PW>@10.0.0.2:6379`.
+
+**Il worker parte ma non estrae job**
+Controlla se `mingle: sync` ha funzionato. Se `mingle: all alone`, il nodo non vede la coda — di solito una connessione Redis sbagliata o mancante. Controlla anche: c'è effettivamente carico sul server principale? Con una coda vuota, il silenzio è normale.
+
+**`SecurityWarning: running with superuser privileges`**
+Solo un avviso, non un errore. I worker girano come root nel container (come sul server principale). Non critico.
+
+**Le immagini vengono elaborate ma mancano le rendition**
+Le credenziali S3 sul nodo worker non corrispondono a quelle del server principale, oppure bucket/endpoint sbagliati. Il worker allora scrive nel vuoto. Confronta `.env.worker` con il `.env` principale.

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](SCALING.de.md)
+**English** · [Deutsch](SCALING.de.md) · [Italiano](SCALING.it.md)
 
 # Horizontal scaling — additional worker nodes
 

--- a/docs/SELFHOSTING-SYNOLOGY.de.md
+++ b/docs/SELFHOSTING-SYNOLOGY.de.md
@@ -1,4 +1,4 @@
-[English](SELFHOSTING-SYNOLOGY.md) · **Deutsch**
+[English](SELFHOSTING-SYNOLOGY.md) · **Deutsch** · [Italiano](SELFHOSTING-SYNOLOGY.it.md)
 
 # Lumio auf einer Synology-NAS betreiben
 

--- a/docs/SELFHOSTING-SYNOLOGY.it.md
+++ b/docs/SELFHOSTING-SYNOLOGY.it.md
@@ -1,0 +1,227 @@
+[English](SELFHOSTING-SYNOLOGY.md) · [Deutsch](SELFHOSTING-SYNOLOGY.de.md) · **Italiano**
+
+# Eseguire Lumio su un NAS Synology
+
+Lumio è un semplice stack Docker Compose che porta con sé tutto il necessario
+(PostgreSQL, Redis, MinIO per l'archiviazione a oggetti, Caddy, l'app stessa).
+Questo significa che *può* funzionare su un NAS Synology — con alcune
+avvertenze su modello, RAM e TLS. Questa pagina è il complemento specifico
+per Synology di [SELFHOSTING.md](SELFHOSTING.it.md); leggi anche quella, qui
+sono trattate solo le differenze.
+
+> **Stato:** Synology non è un target testato ufficialmente. Funziona perché
+> è Docker Compose standard su amd64/arm64 — ma non esiste un pacchetto a un
+> clic e dovresti essere a tuo agio con SSH e il Reverse Proxy di DSM.
+
+## La tua Synology può farlo girare?
+
+- [ ] **DSM 7.2 o più recente con il pacchetto *Container Manager*.** Container
+      Manager include Docker Engine ≥ 24 **e Compose v2** (`docker compose`),
+      che Lumio richiede. Il vecchio pacchetto "Docker" su DSM 6 / inizio DSM 7
+      aveva solo Compose v1 e *non* funzionerà senza intervento manuale.
+- [ ] **Modello a 64 bit.** Sono supportati sia `amd64` (Intel/AMD) sia
+      `arm64` (aarch64). **I modelli x86-64 "Plus"/"+" sono fortemente
+      consigliati** (es. DS920+/DS923+, DS1522+/DS1621+). I vecchi modelli
+      ARM a 32 bit **non** sono supportati.
+- [ ] **RAM** (il solito collo di bottiglia):
+    - Solo foto: **minimo 4 GB**
+    - Con transcodifica video: **8 GB**
+    - Con auto-tagging IA (worker ML): **+4 GB** in più — meglio lasciarlo
+      **disattivato** su un NAS
+- [ ] **Spazio disco libero** su un volume per i volumi `minio_data` /
+      `postgres_data`, dimensionato in base alla tua libreria foto/video.
+
+Se il tuo NAS ha 2 GB di RAM o è un modello ARM a 32 bit, fermati qui — non
+sarà una buona esperienza.
+
+## Prestazioni — cosa aspettarsi
+
+- **Il primo `up` compila le immagini dal sorgente** (frontend, API e il
+  worker Python con libvips). Sulla CPU di un NAS è lento e affamato di RAM;
+  metti in conto **10-30+ minuti** e assicurati di avere un paio di GB di RAM
+  liberi durante la build. Un NAS debole/con poca RAM può andare in OOM qui —
+  in quel caso, compila le immagini su una macchina più potente e copiale,
+  oppure aggiungi RAM.
+- **La transcodifica video è di gran lunga il compito più pesante** (x264 su
+  CPU). Un NAS a 2 core transcodificherà i clip di un matrimonio lentamente e
+  uno alla volta. Gli studi che gestiscono solo foto sono molto più leggeri.
+- **L'auto-tagging IA (CLIP) è opzionale e pesante** — l'immagine del worker
+  ML è ~2,5 GB e richiede +4 GB di RAM. Su un NAS, **non attivare il profilo
+  ML**; tutto il resto funziona anche senza.
+- **L'archiviazione locale con MinIO** va bene per un singolo studio; come
+  regola empirica è sensata fino a ~500 GB. Oltre, punta Lumio verso un S3
+  esterno (vedi [STORAGE.md](STORAGE.it.md)) in modo che il NAS esegua solo
+  l'app, non l'archiviazione.
+- **I download dei clienti avvengono direttamente da MinIO sul tuo NAS**,
+  quindi la velocità di download per i tuoi clienti è limitata dalla tua
+  **banda di upload di casa**. Per gallerie grandi questo conta più del NAS
+  stesso. (Gli ZIP grandi vengono divisi automaticamente in parti, il che
+  aiuta con connessioni instabili.)
+
+Tabella hardware di riferimento: [REQUIREMENTS.md](REQUIREMENTS.it.md).
+
+## Limitazioni su una Synology
+
+- **Nessun auto-tagging GPU.** L'accelerazione GPU richiede NVIDIA/CUDA (solo
+  amd64) — non disponibile su nessuna Synology. Su CPU, il tagging è
+  funzionalmente identico, solo più lento. Vedi [GPU.md](GPU.it.md).
+- **Le porte 80/443 sono occupate da DSM.** Rimapperai il Caddy di Lumio su
+  porte alte e lo metterai dietro il Reverse Proxy di DSM (sotto).
+- **Compilare sul NAS può essere doloroso** sui modelli di fascia bassa (vedi
+  Prestazioni).
+- **Gli aggiornamenti/riavvii di DSM riavviano i container.** Con
+  `restart: unless-stopped` lo stack torna su da solo, ma aspettati qualche
+  minuto di downtime durante la manutenzione DSM.
+- **Questo è self-hosting a studio singolo.** Il multi-tenant/wildcard-TLS
+  ([MULTI_TENANT.md](MULTI_TENANT.it.md)) non è qualcosa che vuoi far girare
+  su un NAS di casa.
+
+## Configurazione
+
+### 1. Attiva Container Manager
+
+Installa **Container Manager** dal Package Center (DSM 7.2+). Conferma via
+SSH:
+
+```bash
+sudo docker compose version   # must print v2.x
+```
+
+### 2. Metti i file sul NAS
+
+Crea una cartella su un volume dati, es. `/volume1/docker/lumio`, e porta lì
+il sorgente. Il modo più semplice è via SSH (Pannello di controllo →
+Terminal & SNMP → attiva SSH):
+
+```bash
+mkdir -p /volume1/docker && cd /volume1/docker
+git clone https://github.com/markusthiel/lumio.git
+cd lumio
+cp .env.example .env
+```
+
+Se `git` non è disponibile sul tuo NAS, scarica il repository come ZIP sul
+tuo PC e carica invece la cartella estratta tramite **File Station**.
+
+### 3. Secrets e modalità
+
+Genera i secrets (come nella guida generica):
+
+```bash
+sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=')|" .env
+sed -i "s|^JWT_SECRET=.*|JWT_SECRET=$(openssl rand -base64 32 | tr -d '/+=')|" .env
+sed -i "s|^SESSION_SECRET=.*|SESSION_SECRET=$(openssl rand -base64 32 | tr -d '/+=')|" .env
+sed -i "s|^S3_ACCESS_KEY=.*|S3_ACCESS_KEY=$(openssl rand -hex 12)|" .env
+sed -i "s|^S3_SECRET_KEY=.*|S3_SECRET_KEY=$(openssl rand -base64 32 | tr -d '/+=')|" .env
+```
+
+`DEPLOYMENT_MODE=single` è il valore predefinito — lascialo così. La
+modalità single crea automaticamente uno studio al primo avvio; non serve un
+super admin.
+
+### 4. Sposta le porte lontano da DSM
+
+DSM è già in ascolto su 80/443. Imposta il Caddy di Lumio su porte alte in
+`.env` in modo che i container non entrino in conflitto con DSM:
+
+```bash
+CADDY_HTTP_PORT=8080
+CADDY_HTTPS_PORT=8443
+```
+
+(Puoi lasciare le porte di MinIO ai valori predefiniti 9000/9001, a meno che
+qualcos'altro sul NAS non le usi già.)
+
+### 5. TLS — usa il Reverse Proxy di DSM (consigliato)
+
+Su un NAS la strada più pulita è lasciare che **DSM termini l'HTTPS** con un
+certificato gestito da Synology e inoltri HTTP semplice al Caddy di Lumio.
+Il Caddy di Lumio supporta esplicitamente l'esecuzione dietro un reverse
+proxy esterno.
+
+1. **DNS:** punta un hostname verso il tuo NAS — un dominio reale, o il DDNS
+   Synology (`something.synology.me`). Servono due nomi, es.
+   `gallery.example.com` e `s3.example.com` (un sottodominio S3 è lo schema
+   di reverse proxy documentato).
+2. **Certificato:** in **Pannello di controllo → Sicurezza → Certificato**,
+   ottieni un certificato Let's Encrypt per entrambi i nomi (Synology lo fa
+   per te con DDNS o il tuo dominio).
+3. **Reverse Proxy:** **Pannello di controllo → Portale di accesso →
+   Avanzate → Reverse Proxy**, crea due regole, entrambe verso la porta
+   HTTP di Caddy:
+    - `https://gallery.example.com` → `http://localhost:8080`
+    - `https://s3.example.com` → `http://localhost:8080`
+   Attiva HTTP/2 e, sotto *Intestazione personalizzata*, inoltra l'header
+   `Host` (attiva anche il supporto WebSocket — Lumio usa `/ws`).
+4. **`.env`:** comunica a Lumio la sua identità pubblica:
+
+```bash
+LUMIO_HOST=gallery.example.com
+LUMIO_S3_HOST=s3.example.com
+PUBLIC_URL=https://gallery.example.com
+S3_PUBLIC_URL=https://s3.example.com
+```
+
+Il Caddy di Lumio si fida di `X-Forwarded-Proto` proveniente da range
+privati, quindi rileva correttamente l'HTTPS terminato da DSM.
+
+**Alternativa (Caddy gestisce il TLS da solo):** se preferisci lasciare che
+Lumio gestisca i certificati, devi liberare le porte 80/443 — o sposta le
+porte di DSM stesso (Pannello di controllo → Portale di accesso → cambia le
+porte HTTP/HTTPS di DSM) in modo che Caddy possa usare
+`CADDY_HTTP_PORT=80` / `CADDY_HTTPS_PORT=443`, oppure inoltra sul router
+80→8080 / 443→8443. Caddy ottiene quindi da solo il certificato Let's
+Encrypt (serve che la porta 80 sia raggiungibile da internet). Il percorso
+del Reverse Proxy DSM sopra è di solito meno complicato su un NAS.
+
+### 6. Avvia
+
+```bash
+sudo docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+Il primo avvio compila le immagini (vedi Prestazioni — abbi pazienza).
+Osserva il progresso:
+
+```bash
+sudo docker compose logs -f
+```
+
+### 7. Crea il tuo utente admin
+
+```bash
+sudo docker compose exec api npm run create-admin -- \
+  --email=you@example.com \
+  --password=atleast12chars \
+  --name="Your Studio"
+```
+
+### 8. Accedi
+
+Apri `https://gallery.example.com`, crea una galleria di prova, carica
+un'immagine, condividi il link e aprilo dal tuo telefono. Se questo giro
+funziona, sei live.
+
+## Note operative
+
+- **Le modifiche al Caddyfile richiedono un restart, non un reload**
+  (`admin off` è impostato): `sudo docker compose restart caddy`.
+- **Fai il backup di due cose:** il database Postgres e i dati oggetto di
+  MinIO (volume `minio_data`). Vedi [BACKUP.md](BACKUP.it.md). Synology
+  Hyper Backup può fare il backup della cartella `/volume1/docker/lumio` e
+  dei volumi Docker.
+- **Aggiornamento:** `git pull` nella cartella del progetto, poi riesegui il
+  comando `up -d` del passo 6 (aggiungi `--build` per forzare una
+  ricompilazione). Le migrazioni del DB vengono eseguite automaticamente
+  all'avvio dell'API.
+- Bloccato? [TROUBLESHOOTING.md](TROUBLESHOOTING.it.md).
+
+## Vedi anche
+
+- [SELFHOSTING.md](SELFHOSTING.it.md) — la guida generica al self-hosting
+  (leggi prima questa)
+- [REQUIREMENTS.md](REQUIREMENTS.it.md) — hardware, architettura,
+  dimensionamento
+- [STORAGE.md](STORAGE.it.md) — MinIO vs. S3 esterno
+- [BACKUP.md](BACKUP.it.md) — strategia di backup
+- [GPU.md](GPU.it.md) — perché il tagging GPU non è disponibile qui

--- a/docs/SELFHOSTING-SYNOLOGY.md
+++ b/docs/SELFHOSTING-SYNOLOGY.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](SELFHOSTING-SYNOLOGY.de.md)
+**English** · [Deutsch](SELFHOSTING-SYNOLOGY.de.md) · [Italiano](SELFHOSTING-SYNOLOGY.it.md)
 
 # Running Lumio on a Synology NAS
 

--- a/docs/SELFHOSTING.de.md
+++ b/docs/SELFHOSTING.de.md
@@ -1,4 +1,4 @@
-[English](SELFHOSTING.md) · **Deutsch**
+[English](SELFHOSTING.md) · **Deutsch** · [Italiano](SELFHOSTING.it.md)
 
 # Production Self-Hosting
 

--- a/docs/SELFHOSTING.it.md
+++ b/docs/SELFHOSTING.it.md
@@ -1,0 +1,270 @@
+[English](SELFHOSTING.md) · [Deutsch](SELFHOSTING.de.md) · **Italiano**
+
+# Production Self-Hosting
+
+Hai finito la Quick Start e ora vuoi far girare Lumio in modo pulito sotto
+il tuo dominio, con HTTPS e backup. Questa guida richiede **15 minuti** e
+presuppone:
+
+- Un server Linux con IP pubblico (Hetzner, Netcup, hardware tuo – non
+  importa), **amd64 o arm64** — entrambi supportati
+- Un dominio (es. `gallery.your-studio.com`)
+- Docker + Docker Compose v2
+
+Requisiti dettagliati hardware/architettura: [REQUIREMENTS.md](REQUIREMENTS.it.md).
+
+Questa guida copre lo **studio singolo**. Per il multi-tenant vedi
+[MULTI_TENANT.md](MULTI_TENANT.it.md).
+
+In esecuzione su un **NAS Synology**? Vedi il complemento specifico per
+Synology: [SELFHOSTING-SYNOLOGY.md](SELFHOSTING-SYNOLOGY.it.md).
+
+---
+
+## 1. Configura il DNS
+
+Presso il tuo provider DNS, crea un record A (e opzionalmente AAAA per
+IPv6):
+
+```
+gallery.your-studio.com.   A     <server-ip>
+```
+
+Tieni il TTL basso per ora (300s); puoi alzarlo più avanti.
+
+Verifica:
+
+```bash
+dig gallery.your-studio.com +short
+```
+
+Dovrebbe restituire l'IP del tuo server.
+
+## 2. Apri il firewall
+
+Sul server (o tramite la console cloud):
+
+```bash
+# UFW as an example
+ufw allow 22/tcp
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw enable
+```
+
+**Importante su Hetzner Cloud**: oltre al firewall del sistema operativo
+c'è anche il Cloud Firewall nella console Hetzner – apri 80 e 443 anche lì,
+altrimenti non passa nulla.
+
+## 3. Installa Lumio
+
+```bash
+mkdir -p /opt/docker && cd /opt/docker
+git clone https://github.com/markusthiel/lumio.git
+cd lumio
+cp .env.example .env
+```
+
+Genera secrets sicuri:
+
+```bash
+sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=$(openssl rand -base64 24 | tr -d '/+=')|" .env
+sed -i "s|^JWT_SECRET=.*|JWT_SECRET=$(openssl rand -base64 32 | tr -d '/+=')|" .env
+sed -i "s|^SESSION_SECRET=.*|SESSION_SECRET=$(openssl rand -base64 32 | tr -d '/+=')|" .env
+sed -i "s|^S3_ACCESS_KEY=.*|S3_ACCESS_KEY=$(openssl rand -hex 12)|" .env
+sed -i "s|^S3_SECRET_KEY=.*|S3_SECRET_KEY=$(openssl rand -base64 32 | tr -d '/+=')|" .env
+```
+
+## 4. Imposta il dominio in .env
+
+```bash
+nano .env
+```
+
+Imposta questi valori:
+
+```bash
+LUMIO_HOST=gallery.your-studio.com
+PUBLIC_URL=https://gallery.your-studio.com
+
+# S3 needs its OWN subdomain — a path prefix (…/s3) does NOT work:
+# MinIO verifies the AWS V4 signature over the full path incl. bucket,
+# so path rewriting breaks every upload. Set BOTH values and add a
+# DNS A record for the subdomain pointing to the same server IP:
+LUMIO_S3_HOST=s3.your-studio.com
+S3_PUBLIC_URL=https://s3.your-studio.com
+```
+
+(Senza un dominio — solo test via IP — lascia entrambi i valori S3 non
+impostati: l'API allora firma automaticamente contro `http://<host>:9000`;
+assicurati che la porta 9000 sia raggiungibile.)
+
+## 5. Avvia
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+Caddy ottiene automaticamente un certificato Let's Encrypt (richiede circa
+30 secondi). Osservalo:
+
+```bash
+docker compose logs -f caddy
+```
+
+Il successo si presenta così: `certificate obtained successfully ...
+gallery.your-studio.com`.
+
+## 6. Crea un utente admin
+
+In modalità single Lumio crea automaticamente un tenant chiamato "My
+Studio" al primo avvio – non ti serve un super admin e non devi creare un
+tenant manualmente. Solo il primo utente:
+
+```bash
+docker compose exec api npm run create-admin -- \
+  --email=you@your-studio.com \
+  --password=atleast12chars \
+  --name="Your Studio"
+```
+
+## 7. Accedi
+
+→ `https://gallery.your-studio.com`
+
+Al primo login crea una galleria di prova, carica un'immagine, condividi il
+link della galleria, aprilo da un altro dispositivo. Se tutto funziona: sei
+live.
+
+---
+
+## Attivare funzionalità opzionali (print shop, analytics, …)
+
+Le funzionalità beta/sperimentali sono dietro feature flag e disattivate di
+default. In self-hosting (senza UI super admin) le attivi globalmente
+tramite `.env`:
+
+```bash
+FEATURES_ENABLED=print_shop,advanced_analytics
+```
+
+Chiavi disponibili: `print_shop`, `lightroom_plugin`, `advanced_analytics`,
+`ai_tagging` (richiede il worker ML, `docker-compose.ml.yml`),
+`video_streaming_4k`. Riavvia l'API dopo la modifica:
+`docker compose up -d api`. In modalità multi, gli override per tenant
+dalla UI super admin hanno la precedenza — anche per disattivare.
+
+Il print shop ha inoltre un'**attivazione a livello di provider**
+(normalmente fatta nella UI super admin). La stampa in proprio funziona
+sempre; per le integrazioni con i laboratori imposta:
+
+```bash
+PRINT_PROVIDERS_ENABLED=prodigi,gelato
+```
+
+Ogni studio inserisce poi le proprie credenziali API sotto Print shop →
+Providers.
+
+## Backup
+
+Fai il backup di almeno due cose:
+
+1. **Postgres** – l'intero database dell'applicazione (utenti, gallerie,
+   permessi)
+2. **Bucket S3** – le immagini/video veri e propri
+
+### Dump notturno di Postgres
+
+Aggiungi a crontab (`crontab -e`):
+
+```cron
+0 3 * * * cd /opt/docker/lumio && docker compose exec -T postgres pg_dump -U lumio lumio | gzip > /backup/lumio-$(date +\%Y\%m\%d).sql.gz && find /backup -name "lumio-*.sql.gz" -mtime +14 -delete
+```
+
+Mantiene 14 giorni. Poi sincronizza fuori sede (es. con `rclone` verso un
+provider di backup).
+
+### Backup del bucket S3
+
+Con MinIO basta fare rsync del volume `minio_data`. Con S3 esterno
+(Hetzner, R2, B2) attiva versioning + lifecycle – i provider lo fanno dalla
+loro console.
+
+### Test di restore
+
+**Esegui regolarmente un test di restore su una VM di prova.** Un backup
+non testato non è un backup.
+
+---
+
+## Aggiornamenti
+
+```bash
+cd /opt/docker/lumio
+git pull
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+```
+
+Le migrazioni Prisma vengono eseguite automaticamente all'avvio dell'API.
+**Fai un dump di Postgres prima di ogni aggiornamento** – le migrazioni
+raramente sono reversibili.
+
+Puoi vedere la versione attualmente in esecuzione con
+`docker compose logs api | grep "Lumio API ready"`.
+
+---
+
+## Il tuo S3 esterno al posto di MinIO
+
+MinIO funziona bene per setup più piccoli (fino a ~500 GB). Per volumi
+maggiori conviene un S3 esterno:
+
+- **Hetzner Object Storage** – economico, GDPR, può stare nello stesso
+  datacenter del server
+- **Cloudflare R2** – egress gratuito, ottimo per setup CDN
+- **Backblaze B2** – prezzo di archiviazione più economico, latenza
+  leggermente più alta
+
+Passaggi di configurazione: vedi [STORAGE.md](STORAGE.it.md).
+
+**Importante con S3 esterno**: imposta il CORS sul bucket! Lumio carica le
+immagini direttamente dal browser a S3 (URL presigned). Senza CORS
+fallisce. Nello specifico:
+
+```json
+{
+  "CORSRules": [{
+    "AllowedOrigins": ["https://gallery.your-studio.com"],
+    "AllowedMethods": ["GET", "PUT", "POST", "HEAD"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 3000
+  }]
+}
+```
+
+Per Hetzner Object Storage imposta inoltre `S3_FORCE_PATH_STYLE=true` e
+`S3_REGION=fsn1` (o la posizione del tuo bucket).
+
+---
+
+## Sicurezza
+
+- **Non fare mai commit di `.env`** – è in `.gitignore`, ma controlla
+  comunque
+- **Non esporre la porta Postgres verso l'esterno** – il default è già
+  corretto, raggiungibile solo internamente
+- **Metti in sicurezza la console MinIO (porta 9001)** – nel compose di
+  produzione non è raggiungibile dall'esterno di default, solo via
+  `docker exec`
+- **Cripta i backup** quando sono archiviati su storage di terze parti
+  (`gpg`, `restic`, `borg`)
+- **Login SSH solo con chiave** sul server, nessuna autenticazione via
+  password
+- **Attiva gli unattended upgrades** per le patch del sistema operativo
+
+---
+
+## Insidie comuni
+
+→ vedi [TROUBLESHOOTING.md](TROUBLESHOOTING.it.md)

--- a/docs/SELFHOSTING.md
+++ b/docs/SELFHOSTING.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](SELFHOSTING.de.md)
+**English** · [Deutsch](SELFHOSTING.de.md) · [Italiano](SELFHOSTING.it.md)
 
 # Production Self-Hosting
 

--- a/docs/STORAGE.de.md
+++ b/docs/STORAGE.de.md
@@ -1,4 +1,4 @@
-[English](STORAGE.md) · **Deutsch**
+[English](STORAGE.md) · **Deutsch** · [Italiano](STORAGE.it.md)
 
 # Storage
 

--- a/docs/STORAGE.it.md
+++ b/docs/STORAGE.it.md
@@ -1,0 +1,296 @@
+[English](STORAGE.md) · [Deutsch](STORAGE.de.md) · **Italiano**
+
+# Archiviazione
+
+Lumio usa un'archiviazione a oggetti compatibile con S3 per tutti i file
+foto e video. Il setup predefinito è **MinIO nello stesso stack Compose** –
+funziona subito, senza account esterno.
+
+Non appena hai esigenze di scalabilità o di backup, passare a un S3 esterno
+conviene.
+
+## Quando usare cosa
+
+| Setup | Quando |
+|---|---|
+| **MinIO (predefinito)** | Studio singolo, <500 GB di dati, un server |
+| **Hetzner Object Storage** | Server anche su Hetzner, il GDPR conta, <10 TB |
+| **Cloudflare R2** | Setup CDN, molto traffico pubblico, risparmiare sull'egress |
+| **Backblaze B2** | Molto economico per TB, grandi volumi, carattere archivistico |
+| **Wasabi** | Prezzo fisso, costi prevedibili, nessun limite di chiamate API |
+| **AWS S3** | Multi-regione, compliance enterprise |
+
+---
+
+## Configurazione generale
+
+In `.env`:
+
+```bash
+STORAGE_PROVIDER=custom        # for everything except MinIO
+S3_ENDPOINT=https://...
+S3_REGION=...
+S3_BUCKET=lumio-prod
+S3_ACCESS_KEY=...
+S3_SECRET_KEY=...
+S3_FORCE_PATH_STYLE=true       # for all S3-compatibles except AWS itself
+S3_PUBLIC_URL=https://...      # same endpoint, unless you put a CDN in front
+```
+
+`STORAGE_PROVIDER` può essere: `minio`, `s3`, `r2`, `b2`, `wasabi`,
+`custom`. I valori del provider sono solo indicazioni per il logging – la
+configurazione effettiva viene dalle variabili `S3_*`.
+
+Dopo il cambio: `docker compose restart api worker`.
+
+**Imposta sempre anche il CORS sul bucket** (vedi sotto), altrimenti i
+caricamenti dal browser falliscono.
+
+---
+
+## Sicurezza degli accessi (mantieni il bucket privato)
+
+Il modello di accesso di Lumio si basa sul fatto che il **bucket resti
+privato**. Non attivare l'accesso pubblico in lettura — non serve e
+comprometterebbe la protezione:
+
+- **Nessuna ACL pubblica.** Lumio non marca mai come pubblici gli oggetti
+  caricati; ereditano il default del bucket, che deve restare privato. Un
+  URL di oggetto grezzo senza firma deve restituire `AccessDenied`.
+- **Accesso firmato e limitato nel tempo.** Tutta la distribuzione
+  (thumbnail, anteprime, download, asset di branding) avviene tramite **URL
+  presigned** che l'API emette solo all'interno di handler di richiesta
+  autorizzati; scadono dopo ~1 ora. I download video (HLS) e ZIP vengono
+  trasmessi in streaming attraverso l'API stessa, quindi il browser non
+  legge mai direttamente il bucket.
+- **Chiavi non indovinabili.** Le chiavi di archiviazione sono basate su
+  UUID (`t/<tenant-uuid>/g/<gallery-uuid>/r/<file-uuid>/…`) — non possono
+  essere enumerate né indovinate.
+
+Limite intrinseco di cui essere consapevoli: un URL presigned funziona per
+chiunque lo possieda finché non scade (è così che funziona il presigning).
+Espone un singolo oggetto per quella finestra temporale, non la galleria —
+ma non trattare un link presigned come qualcosa da pubblicare.
+
+Verifica rapida che il tuo bucket sia privato: una richiesta non firmata
+verso qualsiasi URL di oggetto (anche una chiave inesistente) dovrebbe
+restituire HTTP `403 AccessDenied`. Se ottieni `200` o un elenco di file
+XML, il bucket è pubblico — correggilo prima di andare in produzione.
+
+## Hetzner Object Storage
+
+Archiviazione compatibile S3 a Falkenstein, Norimberga o Helsinki. GDPR,
+provider tedesco.
+
+### Crea il bucket
+
+Hetzner Cloud Console → Object Storage → "Create Bucket"
+- Location: Falkenstein (o dove si trova il tuo server – risparmia latenza
+  e costi di traffico)
+- Nome: `lumio-prod` (o quello che vuoi)
+- Genera le credenziali, annota ACCESS_KEY e SECRET_KEY
+
+### `.env`
+
+```bash
+STORAGE_PROVIDER=custom
+S3_ENDPOINT=https://fsn1.your-objectstorage.com    # adjust for NBG1/HEL1 accordingly
+S3_REGION=fsn1
+S3_BUCKET=lumio-prod
+S3_ACCESS_KEY=<from console>
+S3_SECRET_KEY=<from console>
+S3_FORCE_PATH_STYLE=true
+S3_PUBLIC_URL=https://fsn1.your-objectstorage.com
+```
+
+### CORS
+
+Nella Hetzner Cloud Console: Bucket → CORS:
+- Allowed Origins: `https://gallery.your-studio.com`
+- Methods: `GET, PUT, POST, HEAD`
+- Headers: `*`
+- Expose: `ETag`
+
+### Prezzi
+
+A partire da €6,49/mese netti per 1 TB di archiviazione + 1 TB di egress.
+L'utilizzo aggiuntivo è pay-as-you-go. Traffico tra un server Hetzner Cloud
+e Hetzner Object Storage nella stessa regione: gratuito.
+
+---
+
+## Cloudflare R2
+
+Zero costi di egress. Ideale quando ci si aspetta molto traffico pubblico
+di immagini.
+
+### Crea il bucket
+
+Cloudflare Dashboard → R2 → "Create Bucket"
+- Nome bucket: `lumio-prod`
+- Location: Automatic o EU (per il GDPR)
+- Crea un token API: R2 → "Manage R2 API Tokens" → diritti di modifica per
+  il bucket
+
+### `.env`
+
+```bash
+STORAGE_PROVIDER=r2
+S3_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+S3_REGION=auto
+S3_BUCKET=lumio-prod
+S3_ACCESS_KEY=<R2 access key>
+S3_SECRET_KEY=<R2 secret key>
+S3_FORCE_PATH_STYLE=true
+S3_PUBLIC_URL=https://<account-id>.r2.cloudflarestorage.com
+```
+
+Opzionale: per URL immagine diretti tramite la CDN Cloudflare, configura un
+dominio personalizzato per R2 e punta `S3_PUBLIC_URL` a quel dominio.
+
+### CORS
+
+In R2 → Bucket → Settings → CORS Policy.
+
+### Prezzi
+
+$0,015/GB-mese di archiviazione, **egress completamente gratuito**.
+Operazioni Class A (scritture) $4,50/milione.
+
+---
+
+## Backblaze B2
+
+Prezzo più economico per TB. Combinato con Cloudflare come CDN: egress
+gratuito.
+
+### Crea il bucket
+
+B2 Cloud Storage Dashboard → Create Bucket
+- Nome bucket: `lumio-prod` (deve essere univoco a livello globale)
+- Privato
+- Crea una application key: "Add a New Application Key", limitata al bucket
+
+### `.env`
+
+```bash
+STORAGE_PROVIDER=b2
+S3_ENDPOINT=https://s3.<region>.backblazeb2.com    # e.g. eu-central-003
+S3_REGION=eu-central-003
+S3_BUCKET=lumio-prod
+S3_ACCESS_KEY=<keyID>
+S3_SECRET_KEY=<applicationKey>
+S3_FORCE_PATH_STYLE=true
+S3_PUBLIC_URL=https://s3.<region>.backblazeb2.com
+```
+
+### CORS
+
+B2 Dashboard → Bucket → CORS Rules.
+
+### Prezzi
+
+$6/TB di archiviazione. Egress gratuito fino a 3x la dimensione
+dell'archiviazione, poi $0,01/GB. Con una CDN Cloudflare davanti: illimitato
+e gratuito.
+
+---
+
+## Wasabi
+
+Prezzo fisso, nessun costo per le chiamate API. Ma: 90 giorni di
+archiviazione minima per oggetto.
+
+### `.env`
+
+```bash
+STORAGE_PROVIDER=wasabi
+S3_ENDPOINT=https://s3.<region>.wasabisys.com   # e.g. eu-central-1
+S3_REGION=eu-central-1
+S3_BUCKET=lumio-prod
+S3_ACCESS_KEY=<from Wasabi console>
+S3_SECRET_KEY=<from Wasabi console>
+S3_FORCE_PATH_STYLE=true
+S3_PUBLIC_URL=https://s3.<region>.wasabisys.com
+```
+
+---
+
+## AWS S3
+
+Quando sei comunque già su AWS o hai requisiti di compliance.
+
+### `.env`
+
+```bash
+STORAGE_PROVIDER=s3
+S3_ENDPOINT=https://s3.<region>.amazonaws.com
+S3_REGION=eu-central-1     # Frankfurt
+S3_BUCKET=lumio-prod
+S3_ACCESS_KEY=<IAM access key>
+S3_SECRET_KEY=<IAM secret>
+S3_FORCE_PATH_STYLE=false     # AWS uses virtual-hosted style
+S3_PUBLIC_URL=https://lumio-prod.s3.<region>.amazonaws.com
+```
+
+Policy IAM per l'utente: come minimo `s3:GetObject`, `s3:PutObject`,
+`s3:DeleteObject`, `s3:ListBucket`, `s3:AbortMultipartUpload`, limitata al
+bucket.
+
+---
+
+## Migrare da MinIO a S3 esterno
+
+Se hai MinIO in produzione e vuoi migrare:
+
+```bash
+# Into the MinIO container, mc is already there
+docker compose exec minio mc alias set src http://localhost:9000 <minio-key> <minio-secret>
+docker compose exec minio mc alias set dst https://<external-endpoint> <ext-key> <ext-secret>
+
+docker compose exec minio mc mirror --overwrite src/lumio dst/lumio-prod
+```
+
+Lumio può continuare a girare durante la migrazione. Al termine, cambia
+`.env` verso il nuovo provider, `docker compose restart api worker`. Il
+container MinIO può poi essere fermato.
+
+Per grandi volumi di dati, preferisci `rclone` sull'host: parallelizzabile,
+ripristinabile.
+
+---
+
+## Configurazione CORS
+
+Lumio usa URL presigned. Il browser carica direttamente su S3. Senza CORS
+il browser lo blocca.
+
+Regola CORS standard per tutti i provider:
+
+```json
+{
+  "CORSRules": [{
+    "AllowedOrigins": ["https://your-domain.com"],
+    "AllowedMethods": ["GET", "PUT", "POST", "HEAD"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 3000
+  }]
+}
+```
+
+Più origin (produzione + staging) come array. I wildcard (`*`) funzionano
+ma non sono sicuri.
+
+Se il provider non ha una UI web per questo:
+
+```bash
+docker run --rm \
+  -e AWS_ACCESS_KEY_ID="<key>" \
+  -e AWS_SECRET_ACCESS_KEY="<secret>" \
+  amazon/aws-cli s3api put-bucket-cors \
+  --bucket lumio-prod \
+  --endpoint-url https://<endpoint> \
+  --region <region> \
+  --cors-configuration file:///path/to/cors.json
+```

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](STORAGE.de.md)
+**English** · [Deutsch](STORAGE.de.md) · [Italiano](STORAGE.it.md)
 
 # Storage
 

--- a/docs/TROUBLESHOOTING.de.md
+++ b/docs/TROUBLESHOOTING.de.md
@@ -1,4 +1,4 @@
-[English](TROUBLESHOOTING.md) · **Deutsch**
+[English](TROUBLESHOOTING.md) · **Deutsch** · [Italiano](TROUBLESHOOTING.it.md)
 
 # Troubleshooting
 

--- a/docs/TROUBLESHOOTING.it.md
+++ b/docs/TROUBLESHOOTING.it.md
@@ -1,0 +1,299 @@
+[English](TROUBLESHOOTING.md) · [Deutsch](TROUBLESHOOTING.de.md) · **Italiano**
+
+# Troubleshooting
+
+Una raccolta dei problemi più comuni nel self-hosting e delle loro soluzioni.
+
+## Strumenti diagnostici
+
+Prima di ogni altra cosa: guarda i log.
+
+```bash
+# Status of all containers
+docker compose ps
+
+# Logs of a service (follow live with -f)
+docker compose logs api --tail=50 -f
+docker compose logs caddy --tail=50 -f
+docker compose logs worker --tail=50 -f
+
+# All services at once
+docker compose logs --tail=20 -f
+
+# Last 30 seconds of all containers
+docker compose logs --since=30s
+```
+
+Health-check dell'API:
+
+```bash
+curl -s http://localhost/health
+```
+
+---
+
+## Problemi di configurazione
+
+### ERR_CONNECTION_REFUSED — niente risponde sulla porta 80
+
+Sulle installazioni precedenti alla v0.49.3, Caddy non riusciva mai a partire
+su un clone fresco (loop di restart) per tre ragioni sovrapposte: un
+`LUMIO_HOST` vuoto produceva un site block senza chiave, gli indirizzi di
+default morti di due blocchi collidevano, e il plugin acme-dns richiede il
+suo file di credenziali all'avvio anche quando il blocco wildcard non è
+usato. Aggiorna alla v0.49.3+ (`git pull`,
+`docker compose up -d --build`). Per confermare che è questo il problema:
+
+```bash
+docker compose ps            # caddy restarting?
+docker compose logs caddy --tail=20
+```
+
+### I container non partono
+
+```bash
+docker compose ps
+```
+
+Se un servizio mostra `Restarting` o `Exited`, guarda i suoi log:
+
+```bash
+docker compose logs <service-name> --tail=100
+```
+
+Cause comuni:
+
+- **`POSTGRES_PASSWORD` non impostata** → il container Postgres esce con "POSTGRES_PASSWORD not specified". Controlla il file `.env`.
+- **Porta 80 o 443 occupata** → un altro web server è già in esecuzione. Trovalo con `ss -tlnp | grep -E ':80|:443'` e fermalo, oppure cambia `CADDY_HTTP_PORT`/`CADDY_HTTPS_PORT` in `.env`.
+- **Disco pieno** → controlla `df -h`. Le immagini Docker + i log divorano velocemente diversi GB.
+
+### Dominio irraggiungibile (Connection Refused / Timeout)
+
+Ordine dei controlli:
+
+1. **Il DNS punta all'IP giusto?** `dig your-domain.com +short`
+2. **Firewall aperto?** Su Hetzner Cloud: sia il firewall del sistema operativo (`ufw`) che il firewall della cloud console. Entrambi!
+3. **Caddy è in esecuzione?** `docker compose ps caddy` → deve essere "running"
+4. **Caddy binda 80/443?** `docker compose ps caddy` mostra porte come `0.0.0.0:80->80/tcp`. Se solo `127.0.0.1:...` → il servizio Caddy non è stato avviato.
+
+Errore comune: `docker compose up -d --build api worker frontend` – questo avvia **solo** i servizi indicati, Caddy manca. Usa invece semplicemente `docker compose up -d` (tutti i servizi).
+
+### Caddy non ottiene i certificati
+
+```bash
+docker compose logs caddy | grep -iE "error|acme"
+```
+
+Errori tipici:
+
+- **`connection refused` durante la challenge ACME** → porta 80 non raggiungibile dall'esterno. Controlla firewall, firewall cloud, IP DNS sbagliato.
+- **`no solvers available for remaining challenges (offered=[dns-01])`** → stai cercando di ottenere un certificato wildcard (`*.your-domain.com`). I wildcard richiedono la challenge DNS-01, non HTTP-01. Vedi [MULTI_TENANT.md](MULTI_TENANT.it.md#wildcard-zertifikate).
+- **`too many requests` (rate limit)** → Let's Encrypt consente max. 50 certificati per dominio a settimana. Se fai test spesso: passa Caddy alla staging CA.
+
+---
+
+## Problemi di caricamento
+
+### "Failed" durante il caricamento delle immagini
+
+L'API è a posto, il caricamento dal browser a S3 fallisce. Il classico **problema CORS**.
+
+Lumio usa URL presigned – il browser carica direttamente sul bucket S3, non tramite l'API. Senza header CORS sul bucket, il browser blocca la richiesta PUT.
+
+**Soluzione per S3 esterno** (Hetzner, R2, B2, Wasabi):
+
+Nella console del bucket del provider crea una regola CORS:
+
+```json
+{
+  "CORSRules": [{
+    "AllowedOrigins": ["https://your-domain.com"],
+    "AllowedMethods": ["GET", "PUT", "POST", "HEAD"],
+    "AllowedHeaders": ["*"],
+    "ExposeHeaders": ["ETag"],
+    "MaxAgeSeconds": 3000
+  }]
+}
+```
+
+Se il tuo storage provider non ha una UI web per questo, tramite AWS CLI:
+
+```bash
+docker run --rm \
+  -e AWS_ACCESS_KEY_ID="<key>" \
+  -e AWS_SECRET_ACCESS_KEY="<secret>" \
+  amazon/aws-cli s3api put-bucket-cors \
+  --bucket lumio-prod \
+  --endpoint-url https://<your-s3-endpoint> \
+  --region <your-region> \
+  --cors-configuration file:///path/to/cors.json
+```
+
+**Con MinIO** il CORS è permissivo di default e dovrebbe funzionare senza problemi. Se non funziona, nel container MinIO:
+
+```bash
+docker compose exec minio mc anonymous set download local/lumio
+```
+
+### "S3 connection refused" / l'init del caricamento fallisce
+
+Guarda i log dell'API (`docker compose logs api`). Cause comuni:
+
+- **`S3_ENDPOINT` sbagliato** – dovrebbe essere `http://minio:9000` per MinIO o `https://<your-endpoint>` per S3 esterno. **Non** localhost, il container non ci arriva.
+- **`S3_REGION` sbagliata** – il default è `us-east-1`. Per Hetzner deve essere `fsn1` (o `nbg1`/`hel1`), altrimenti un signature mismatch (403).
+- **`S3_FORCE_PATH_STYLE` mancante** – per la maggior parte dei servizi S3-compatibili (tranne AWS stesso) deve essere `true`.
+- **Il bucket non esiste** – alcuni provider non lo creano automaticamente. Crealo manualmente nella console del provider.
+
+---
+
+## Problemi di login
+
+### "JSON.parse: unexpected character" / "Unexpected token '<'" al login
+
+Il frontend ha ricevuto HTML invece di JSON dall'API. Due cause comuni:
+
+1. **Stai bypassando il proxy.** Lumio va raggiunto tramite Caddy sulla
+   **porta 80/443** — che instrada `/api/*` verso l'API. Accedere direttamente
+   alla porta del frontend (3000), es. via tunnel SSH `ssh -L 3000:127.0.0.1:3000 …`,
+   colpisce Next.js senza le route API. Fai invece il tunnel della porta 80:
+   `ssh -L 8080:127.0.0.1:80 your-server` → apri `http://localhost:8080`.
+   (Dalla v0.49.1 la porta 3000 fa proxy delle chiamate API anche come fallback,
+   ma sulle versioni precedenti questo è esattamente il sintomo.)
+2. **Il container API è down** — Caddy allora risponde con una pagina di
+   errore HTML. Controlla `docker compose ps` e `docker compose logs api --tail=50`.
+
+Dalla v0.49.1 il frontend mostra un messaggio di errore descrittivo invece
+del fallimento grezzo di `JSON.parse`.
+
+### Il login riesce ma vieni subito disconnesso (accesso via IP del server)
+
+Prima della v0.49.2 il cookie di sessione veniva sempre impostato con il flag
+`Secure`. I browser lo accettano su `http://localhost`, ma lo scartano
+silenziosamente su `http://<server-ip>` — il login restituisce OK, ma la
+sessione non tiene mai. Risolto nella v0.49.2 (il flag ora segue il protocollo
+effettivo; i setup HTTPS mantengono `Secure` come prima). Se la pagina non si
+carica affatto via IP, controlla:
+
+- **Firewall**: la porta 80 deve essere aperta (Hetzner Cloud Firewall, `ufw status`).
+- **Upgrade HTTPS del browser**: alcuni browser (es. Brave) forzano `https://` —
+  non c'è certificato per un IP nudo. Digita esplicitamente `http://<ip>`.
+
+### Nessun pulsante di login, pagina vuota
+
+Log del frontend:
+
+```bash
+docker compose logs frontend --tail=50
+```
+
+Se `ECONNREFUSED` verso la porta 3001 → l'API è irraggiungibile. Spesso a causa di un errore di migrazione in Postgres. Controlla i log dell'API:
+
+```bash
+docker compose logs api | grep -iE "error|migration"
+```
+
+### "Invalid credentials" nonostante i dati corretti
+
+Causa più comune: l'utente è stato creato in un tenant diverso e stai facendo login sul dominio sbagliato.
+
+Non critico in modalità single. In modalità multi: controlla lo slug del tenant nell'URL di login.
+
+Elenca gli utenti:
+
+```bash
+docker compose exec api npx prisma studio
+```
+
+(Apre una UI web sulla porta 5555 dove puoi ispezionare la tabella utenti.)
+
+### `create-admin` viene eseguito, ma il login non funziona
+
+La password deve essere lunga almeno 12 caratteri. Con password più corte lo script si interrompe – ma se chiami `create-admin` tramite codice custom, una password troppo corta potrebbe passare inosservata e fallire al login.
+
+Soluzione: crea di nuovo l'admin, lo script è idempotente (sovrascrive quello esistente).
+
+---
+
+## Problemi in modalità SaaS
+
+### `price_not_configured` alla registrazione
+
+I piani Stripe non sono ancora stati creati. Una volta:
+
+```bash
+docker compose exec api npm run stripe-bootstrap
+```
+
+Prerequisito: `STRIPE_SECRET_KEY` deve essere impostata in `.env` (con `sk_test_...` per la modalità test).
+
+Lo script è idempotente e può essere eseguito più volte. Crea tre piani (Solo, Studio, Pro) + un pacchetto di archiviazione in Stripe e scrive i price ID nel DB di Lumio.
+
+### I webhook Stripe non arrivano
+
+Controlla nella Stripe Dashboard → Developers → Webhooks:
+
+- URL dell'endpoint corretto: `https://your-domain.com/api/billing/webhook`
+- Eventi sottoscritti: almeno `customer.subscription.*`, `invoice.payment_*`, `checkout.session.completed`
+- Signing secret in `.env` come `STRIPE_WEBHOOK_SECRET`
+- Riavvia il container API dopo la modifica di .env: `docker compose restart api`
+
+Test: nella Stripe Dashboard puoi attivare eventi di test e vedere se Lumio li accetta.
+
+---
+
+## Problemi di performance
+
+### Caricamento lento
+
+Dal frontend all'API → allo storage S3 e ritorno al browser è una deviazione. Lumio usa **URL presigned**: il browser carica direttamente su S3, senza passare dall'API.
+
+Se è lento:
+
+- **S3 esterno invece di MinIO** – MinIO su una VM piccola satura rapidamente il disco
+- **Storage nello stesso datacenter** del server (es. Hetzner Cloud + Hetzner Object Storage a Falkenstein)
+- **`UPLOAD_CHUNK_SIZE_MIB`** in `.env` alzato da 8 a 16 per i file grandi
+
+### La generazione delle miniature richiede un'eternità
+
+Log del worker:
+
+```bash
+docker compose logs worker --tail=50
+```
+
+- **Uso CPU alto?** Scala i worker: `docker compose up -d --scale worker=4`
+- **Molti file RAW di grandi dimensioni?** È intrinsecamente CPU-intensivo. Per l'accelerazione GPU vedi [GPU.md](GPU.it.md).
+- **Auto-tagging AI attivo?** CLIP gira sulla CPU a 1–3 s per immagine. Anche qui aiutano GPU o più worker.
+
+---
+
+## Debug come ultima risorsa
+
+Quando nient'altro aiuta, resetta tutto (⚠️ **tutti i dati persi**):
+
+```bash
+docker compose down -v   # -v also deletes volumes!
+docker compose up -d --build
+```
+
+Oppure parzialmente – solo il DB da capo:
+
+```bash
+docker compose down
+docker volume rm lumio_postgres_data
+docker compose up -d
+```
+
+E prima ancora, clona di nuovo Lumio in una directory **nuova** per essere sicuro che non ci sia drift locale nelle config.
+
+---
+
+## Segnalare un problema
+
+Se hai trovato un bug che non è elencato qui: apri un issue su https://github.com/markusthiel/lumio/issues con:
+
+1. Cosa stavi cercando di fare?
+2. Cosa è successo?
+3. Log (`docker compose logs --tail=200`)
+4. Modalità di setup (single/multi, MinIO o S3 esterno, Caddy o proxy esterno)
+5. Versione di Lumio (`git rev-parse HEAD`)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](TROUBLESHOOTING.de.md)
+**English** · [Deutsch](TROUBLESHOOTING.de.md) · [Italiano](TROUBLESHOOTING.it.md)
 
 # Troubleshooting
 

--- a/docs/VERSIONING.de.md
+++ b/docs/VERSIONING.de.md
@@ -1,4 +1,4 @@
-[English](VERSIONING.md) · **Deutsch**
+[English](VERSIONING.md) · **Deutsch** · [Italiano](VERSIONING.it.md)
 
 # Versionierung
 

--- a/docs/VERSIONING.it.md
+++ b/docs/VERSIONING.it.md
@@ -1,0 +1,59 @@
+[English](VERSIONING.md) · [Deutsch](VERSIONING.de.md) · **Italiano**
+
+# Versionamento
+
+Lumio segue il [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`.
+
+La versione è soprattutto un **segnale per i self-hoster** su quanto sia rischioso un aggiornamento — perché aggiornano manualmente tramite `git pull` + `docker compose up`.
+
+## Le tre posizioni
+
+| Posizione | Esempio | Significato | Azione del self-hoster |
+|--------|----------|-----------|--------------------------|
+| **PATCH** | 0.9.0 → 0.9.**1** | bugfix, retrocompatibile | solo pull + deploy |
+| **MINOR** | 0.**9** → 0.**10**.0 | nuova funzionalità, retrocompatibile (es. una nuova env *opzionale* con un default) | solo pull + deploy |
+| **MAJOR** | 0.x → **1**.0.0 | breaking change | intervento manuale secondo le note di upgrade |
+
+### L'unica regola pratica
+
+> Dopo il `git pull`, il self-hoster deve toccare qualcosa in `.env`, nel comando Compose o nel DB, altrimenti si rompe?
+> **Sì → MAJOR.** Altrimenti MINOR (funzionalità) o PATCH (fix).
+
+Esempi di breaking change (MAJOR):
+- variabili env **obbligatorie** rinominate o nuove
+- un'invocazione Compose modificata (es. il refactor `--profile wildcard`)
+- funzionalità o endpoint rimossi
+- una migrazione DB che non gira automaticamente in modo pulito
+
+## Pre-1.0
+
+Siamo a `0.x`. Questo segnala deliberatamente: strutturalmente le cose possono ancora muoversi. I breaking change vengono comunque segnalati chiaramente nel `CHANGELOG.md` sotto **⚠️ Upgrade notes**. Imposteremo `1.0.0` quando vorremo promettere stabilità.
+
+## Unica fonte di verità
+
+La versione canonica vive in **`/VERSION`** (radice del repo). Da essa derivano:
+
+- `apps/api/src/version.ts` → `LUMIO_VERSION` (in `/health` e `/meta`)
+- `apps/worker/version.py` → `__version__` (log di avvio)
+- `version` nei `package.json` dei workspace
+
+Questi file **non vengono modificati a mano** ma tenuti sincronizzati dallo script di bump. Una `LUMIO_VERSION` env impostata sovrascrive a runtime il valore integrato (es. per immagini con timbro CI).
+
+## Flusso di release
+
+```bash
+# 1. Bump the version (syncs all files + creates a Git tag)
+./scripts/bump-version.sh 0.10.0
+
+# 2. CHANGELOG.md: move entries from [Unreleased] into the new section,
+#    for breaking changes add a "⚠️ Upgrade notes" block.
+
+# 3. Push commit + tag
+git push && git push --tags
+```
+
+Successivamente crea una release dal tag in Forgejo (la sezione del changelog come note di release). I self-hoster vedono la versione in esecuzione nel footer dello studio e sotto `GET /health`.
+
+## Siti marketing
+
+`lumio-app-de` e `lumio-cloud-de` sono contenuti con deploy continuo e non necessitano **nessun** SemVer. Il versioning riguarda solo l'app (`lumio`).

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](VERSIONING.de.md)
+**English** · [Deutsch](VERSIONING.de.md) · [Italiano](VERSIONING.it.md)
 
 # Versioning
 

--- a/docs/WILDCARD.de.md
+++ b/docs/WILDCARD.de.md
@@ -1,4 +1,4 @@
-[English](WILDCARD.md) · **Deutsch**
+[English](WILDCARD.md) · **Deutsch** · [Italiano](WILDCARD.it.md)
 
 # Wildcard-Zertifikate für Tenant-Subdomains
 

--- a/docs/WILDCARD.it.md
+++ b/docs/WILDCARD.it.md
@@ -1,0 +1,264 @@
+[English](WILDCARD.md) · [Deutsch](WILDCARD.de.md) · **Italiano**
+
+# Certificati wildcard per i sottodomini dei tenant
+
+Se fai girare Lumio in **modalità multi** con sottodomini dei tenant (es. `saro.lumio-cloud.de`, `acme.lumio-cloud.de`), ti serve un certificato wildcard per `*.lumio-cloud.de`. Ecco la soluzione pulita — funziona con **qualsiasi** provider DNS, anche se non ha un'API.
+
+> Per la **modalità single** (un dominio, uno studio) e i **domini personalizzati** (il cliente punta il proprio dominio verso il tuo IP) questo **non** serve. Caddy ottiene automaticamente certificati standard per il dominio principale singolo e per i domini personalizzati via HTTP-01.
+
+## Perché non un plugin DNS diretto?
+
+Let's Encrypt richiede una challenge DNS-01 per i wildcard — Caddy deve poter impostare un record TXT `_acme-challenge.lumio-cloud.de`. Direttamente questo funziona solo con plugin API dei provider DNS (Cloudflare, Route53, ecc.). Molti provider (domain reselling, Strato, IONOS senza piano premium) non hanno accesso API o richiedono piani premium. Soluzione: **acme-dns** come intermediario.
+
+## Come funziona acme-dns
+
+`acme-dns` è un piccolissimo server DNS che serve solo record TXT `_acme-challenge`. Deleghi esattamente questo unico record al tuo server acme-dns, tutto il resto resta presso il tuo provider principale. Vantaggi:
+
+- **Indipendente dal provider:** non ti serve alcun accesso API
+- **Sicuro:** se le credenziali di acme-dns vengono compromesse, l'attaccante può modificare solo `_acme-challenge`, non i tuoi record DNS principali
+- **Componente standard:** Caddy ha un plugin ufficiale, è in produzione da anni
+
+Lumio include acme-dns come servizio Docker (`lumio_acme_dns`) — devi configurarlo solo una volta.
+
+## Requisiti
+
+- Lumio gira in modalità multi
+- Hai un dominio (es. `lumio-cloud.de`) presso un provider DNS qualsiasi
+- La porta 53 UDP+TCP è raggiungibile dall'esterno sul tuo server (apri il firewall cloud se necessario)
+- Conosci l'IP pubblico del tuo server
+
+## Configurazione in 6 passaggi
+
+### 1. Disinnescare systemd-resolved (Ubuntu/Debian)
+
+Su Ubuntu, `systemd-resolved` ascolta su `127.0.0.53:53`. Linux vieta quindi i bind su `0.0.0.0:53` — anche se si tratta solo di loopback. Per questo bindiamo acme-dns esplicitamente sull'IP esterno del server invece che su 0.0.0.0:
+
+```bash
+# Add the server IP to .env
+echo "ACME_DNS_BIND_IP=YOUR.SERVER.IP" >> .env
+```
+
+systemd-resolved continua a funzionare normalmente, acme-dns ascolta sull'IP esterno. Nessun conflitto.
+
+### 2. Creare un DB Postgres per acme-dns
+
+Su un'installazione fresca lo script di init `02-acme-dns.sql` lo fa automaticamente. Su un Postgres già esistente (volume già presente) va fatto manualmente:
+
+```bash
+docker compose exec postgres psql -U lumio -d postgres -c \
+  "CREATE USER acme_dns WITH PASSWORD 'acme_dns_local_pw';"
+docker compose exec postgres psql -U lumio -d postgres -c \
+  "CREATE DATABASE acme_dns OWNER acme_dns;"
+docker compose exec postgres psql -U lumio -d postgres -c \
+  "GRANT ALL PRIVILEGES ON DATABASE acme_dns TO acme_dns;"
+```
+
+### 3. Firewall cloud: aprire la porta 53
+
+Sulla Hetzner Cloud Console → Firewalls → Add Rule:
+- TCP 53, inbound, source: Any
+- UDP 53, inbound, source: Any
+
+Su AWS / DigitalOcean / altri: analogamente nel security group.
+
+### 4. Creare la config live + avviare il container
+
+acme-dns legge la sua config da `infra/acme-dns/config.local.cfg` (in gitignore, non toccata da `git pull`). Creala una volta dal template e inserisci il tuo dominio reale + IP:
+
+```bash
+cp infra/acme-dns/config.cfg infra/acme-dns/config.local.cfg
+# Open config.local.cfg and replace:
+#   auth.example.com  → your auth subdomain (e.g. auth.lumio-cloud.de)
+#   203.0.113.10      → your public server IP
+```
+
+Poi avvia acme-dns. Il container sta dietro al profilo Compose `wildcard` e parte solo quando il profilo è attivo:
+
+```bash
+docker compose --profile wildcard \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.ml.yml \
+  up -d acme_dns
+```
+
+> **Importante:** da ora in poi ti serve `--profile wildcard` a **ogni** deploy, altrimenti Compose ferma il container acme-dns e i certificati wildcard non possono più essere rinnovati. Il tuo comando di deploy standard diventa quindi:
+>
+> ```bash
+> docker compose --profile wildcard \
+>   -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.ml.yml \
+>   up -d --build
+> ```
+
+Verifica:
+
+```bash
+docker logs lumio_acme_dns --tail=10
+```
+
+Atteso: `Starting DNS listener` e `Listening HTTP`, nessun errore sqlite.
+
+### 5. Record DNS presso il provider
+
+Presso il tuo provider DNS per la zona `lumio-cloud.de` (dominio di esempio — sostituiscilo ovunque col tuo):
+
+| Type | Hostname | Value | TTL |
+|---|---|---|---|
+| A | `auth` | `YOUR.SERVER.IP` | 300 |
+| NS | `auth` | `auth.lumio-cloud.de.` | 300 |
+
+Importante: il valore NS con un punto finale.
+
+Dopo ~5-10 min di propagazione, testa:
+
+```bash
+dig auth.lumio-cloud.de +short              # → YOUR.SERVER.IP
+dig NS auth.lumio-cloud.de +short            # → auth.lumio-cloud.de.
+dig auth.lumio-cloud.de SOA                  # ANSWER with auth.lumio-cloud.de.
+```
+
+Tutti e tre devono funzionare prima del passaggio successivo.
+
+### 6. Creare l'account acme-dns + impostare il CNAME
+
+```bash
+docker exec lumio_acme_dns \
+  wget -qO- --post-data='' --header='Content-Type: application/json' \
+  http://localhost:80/register
+```
+
+Risposta (esempio):
+```json
+{
+  "username": "6a1c4fbe-974b-...",
+  "password": "oDfYLXqJmhy...",
+  "subdomain": "af7bc62d-eac2-...",
+  "fulldomain": "af7bc62d-eac2-....auth.lumio-cloud.de"
+}
+```
+
+**Conserva questi valori con cura.** Vengono generati una sola volta e non sono più recuperabili.
+
+Presso il tuo provider DNS aggiungi un CNAME:
+
+| Type | Hostname | Value |
+|---|---|---|
+| CNAME | `_acme-challenge` | `<fulldomain>.` (con un punto finale) |
+
+Testa la propagazione:
+
+```bash
+dig _acme-challenge.lumio-cloud.de +short
+# → <fulldomain>.
+```
+
+### 7. Configurare Caddy
+
+Salva le credenziali per Caddy:
+
+```bash
+mkdir -p infra/caddy/secrets
+cat > infra/caddy/secrets/acmedns.json <<'EOF'
+{
+  "username": "6a1c4fbe-974b-...",
+  "password": "oDfYLXqJmhy...",
+  "subdomain": "af7bc62d-eac2-...",
+  "fulldomain": "af7bc62d-eac2-....auth.lumio-cloud.de",
+  "server_url": "http://acme_dns:80"
+}
+EOF
+chmod 600 infra/caddy/secrets/acmedns.json
+```
+
+
+> Dalla v0.49.3, Caddy si avvia anche *senza* questo file (ricade su un
+> dummy incorporato così le installazioni fresche non vanno in crash) — ma il
+> TLS wildcard non funzionerà finché non esiste il file di credenziali reale.
+> Questo passaggio resta quindi obbligatorio per il setup wildcard.
+Abilita l'host wildcard in `.env`:
+
+```bash
+sed -i 's|^LUMIO_WILDCARD_HOST=.*|LUMIO_WILDCARD_HOST=*.lumio-cloud.de|' .env
+```
+
+Riavvia Caddy con una build personalizzata (il plugin acme-dns viene compilato dentro):
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.prod.yml \
+  -f docker-compose.ml.yml \
+  up -d --build caddy
+```
+
+Osserva l'emissione del certificato:
+
+```bash
+docker logs lumio_caddy -f --tail=30
+```
+
+Atteso:
+```
+trying to solve challenge ... challenge_type=dns-01
+authorization finalized ... authz_status=valid
+certificate obtained successfully ... *.lumio-cloud.de
+```
+
+La prima volta richiede 30-90 sec. Il rinnovo successivo gira in modo completamente automatico ogni ~60 giorni.
+
+## Verifica
+
+```bash
+curl -sI https://<any-subdomain>.lumio-cloud.de | head -3
+```
+
+Dovrebbe restituire `HTTP/2 200` con un certificato valido (nessun avviso TLS).
+
+## Troubleshooting
+
+**`address already in use` su `up -d acme_dns`**
+La porta 53 è occupata. Controlla `ss -tulnp | grep ':53'`. Se systemd-resolved ascolta su 127.0.0.53 — va bene così, devi solo bindare sull'IP esterno (vedi passaggio 1). Se gira un altro server DNS (bind9, dnsmasq): fermalo.
+
+**`sql: unknown driver "sqlite3"` nei log di acme-dns**
+L'immagine `joohoi/acme-dns:latest` non ha più un driver sqlite3 compilato. Lumio quindi usa Postgres — se il tuo setup è ancora configurato per sqlite, crea il DB Postgres (passaggio 2) e passa `infra/acme-dns/config.cfg` a `engine = "postgres"`.
+
+**`presenting DNS record` va in timeout**
+Il record CNAME non si è ancora propagato. Controlla `dig _acme-challenge.lumio-cloud.de +short` — deve puntare a `<fulldomain>.`. La propagazione DNS può richiedere fino a 1 ora a seconda del provider e del TTL precedente.
+
+**`tls.obtain: ... no DNS-01 challenge support`**
+Caddy non ha il plugin acme-dns compilato dentro. Ricostruisci con `docker compose ... up -d --build caddy` — la build usa `infra/caddy/Dockerfile` con `xcaddy --with github.com/caddy-dns/acmedns`.
+
+**`failed to set TXT record: 401 unauthorized`**
+Le credenziali in `infra/caddy/secrets/acmedns.json` sono sbagliate. Ricontrolla — username + password devono provenire esattamente dall'output di `/register`, senza spazi.
+
+**Il certificato viene emesso, ma il browser mostra un avviso**
+Caddy non ha ancora servito il nuovo certificato. `docker exec lumio_caddy caddy reload --config /etc/caddy/Caddyfile` oppure riavvia Caddy.
+
+## Diagramma dell'architettura
+
+```
+Setup DNS presso il tuo provider:
+  auth.lumio-cloud.de        A      <SERVER-IP>
+  auth.lumio-cloud.de        NS     auth.lumio-cloud.de.
+  _acme-challenge.lumio...   CNAME  <fulldomain>.auth.lumio-cloud.de.
+
+
+Flusso di rinnovo (ogni 60 giorni):
+
+  Let's Encrypt ──chiede──▶  DNS del domain-reselling (la tua zona)
+                                    │
+                                    │ segue il CNAME _acme-challenge → fulldomain
+                                    ▼
+                            server acme-dns (sul tuo host)
+                                    ▲
+                                    │ scrive il TXT via HTTP API
+                                    │
+  Caddy ────scrive il TXT────────────┘
+       (con le credenziali da secrets/acmedns.json)
+```
+
+## Cosa acme-dns NON fa
+
+- Non ospita record A/MX/altri — è il puro intermediario TXT per `_acme-challenge`
+- Non sostituisce il tuo provider DNS — ti serve comunque una zona "vera" per il tuo dominio principale
+- Non si occupa dei certificati per i domini personalizzati — quelli continuano a funzionare via HTTP-01 (comportamento standard di Caddy, nessuna configurazione necessaria)

--- a/docs/WILDCARD.md
+++ b/docs/WILDCARD.md
@@ -1,4 +1,4 @@
-**English** · [Deutsch](WILDCARD.de.md)
+**English** · [Deutsch](WILDCARD.de.md) · [Italiano](WILDCARD.it.md)
 
 # Wildcard certificates for tenant subdomains
 

--- a/infra/umami/README.it.md
+++ b/infra/umami/README.it.md
@@ -1,0 +1,59 @@
+[Deutsch](README.md) · **Italiano**
+
+# Umami — Web analytics per i siti marketing
+
+Analytics self-hosted e senza cookie per `lumio-cloud.de` e
+`lumio-app.de`. Gira come stack a sé, servito dal Caddy dell'app su
+`stats.lumio-cloud.de`.
+
+## Perché senza cookie / senza banner di consenso
+
+Umami non imposta cookie, non usa `localStorage` né un
+identificatore persistente. Genera un hash giornaliero rotante e non
+ricostruibile e non salva l'IP. Non accede quindi al dispositivo
+dell'utente (il § 25 TDDDG non si applica); il breve trattamento
+dell'IP può basarsi sul legittimo interesse (art. 6, par. 1, lett. f
+GDPR). Self-hosted in Germania (Hetzner) → nessun trasferimento verso
+paesi terzi.
+
+Resta comunque necessaria la menzione nell'informativa sulla privacy
+(già presente su entrambi i siti). Non è una consulenza legale —
+l'approvazione finale spetta a una revisione legale.
+
+`DISABLE_TELEMETRY=1` è impostato in modo che Umami stesso non invii
+statistiche di utilizzo anonime verso l'esterno.
+
+## Setup iniziale
+
+1. Imposta il **record A** `stats.lumio-cloud.de` → IP del server.
+2. Imposta `LUMIO_UMAMI_HOST=stats.lumio-cloud.de` nel `.env` dello
+   stack app e rideploya lo stack app (Caddy carica il blocco stats
+   e ottiene il certificato; senza questa variabile il blocco resta
+   inattivo).
+3. Crea i secret e avvia lo stack:
+   ```
+   cd /opt/docker/lumio/lumio/infra/umami
+   cp .env.example .env
+   # UMAMI_DB_PASSWORD + UMAMI_APP_SECRET eintragen (openssl rand ...)
+   docker compose up -d
+   ```
+4. Apri `https://stats.lumio-cloud.de`, accedi con il login
+   predefinito (`admin` / `umami`) e **cambia subito la password**.
+5. In *Settings → Websites* crea due siti web:
+   - Domain `lumio-cloud.de`
+   - Domain `lumio-app.de`
+   Ognuno restituisce un **Website-ID** (UUID).
+6. Inserisci gli ID nel `.env` del rispettivo sito marketing
+   (`PUBLIC_UMAMI_WEBSITE_ID`, `PUBLIC_UMAMI_SRC`) e ricostruisci il
+   sito (`docker compose up -d --build`). Solo a quel punto viene
+   caricato lo snippet di tracking.
+
+## Aggiornamenti
+
+```
+cd /opt/docker/lumio/lumio/infra/umami
+docker compose pull && docker compose up -d
+```
+
+I dati si trovano nel volume `umami_db_data` e sopravvivono agli
+aggiornamenti.

--- a/infra/umami/README.md
+++ b/infra/umami/README.md
@@ -1,3 +1,5 @@
+**Deutsch** · [Italiano](README.it.md)
+
 # Umami — Web-Analytics für die Marketing-Sites
 
 Cookieloses, self-hosted Analytics für `lumio-cloud.de` und `lumio-app.de`.


### PR DESCRIPTION
## Summary

Adds Italian (`*.it.md`) documentation, following the existing EN/DE bilingual convention.

- New `.it.md` for every doc that already ships an EN/DE pair: `README`, `CONTRIBUTING`, `brand/README`, `brand/social/README`, and all 19 files under `docs/`.
- New `.it.md` for the four plugin/tooling READMEs that previously existed only in German (`apps/capture-one-plugin`, `apps/lightroom-plugin`, `bench`, `infra/umami`) — these also get a new DE ⟷ IT language switcher.
- Language-switcher line at the top of every touched file updated to link to the new Italian version.
- Internal cross-doc links inside the new Italian files point to the Italian counterpart of the referenced doc; same-file table-of-contents anchors (e.g. `docs/OPERATIONS.it.md`) were re-slugged to match the translated headings.
- Terminology kept consistent with the existing in-app Italian translation (`apps/frontend/src/lib/i18n/it.ts`): informal "tu" register, *galleria/gallerie*, *caricamento/caricare*, *archiviazione*, with *tenant*, *studio*, *backup* and *self-hosting* left as-is as established technical terms.
- `CHANGELOG.md` is intentionally out of scope (tracked in the issue).

Closes #10.

## Test plan

- [x] `docs/frontend`-style structural check: every new `.it.md` has the same heading count as its English source (27/27 match).
- [x] All internal Markdown links in the new files resolve to an existing file.
- [x] All same-file anchor links (tables of contents) resolve to an existing heading slug.
- [x] Code fences are balanced in every new file (no truncated content).
- [x] Spot-checked several files for tone/terminology/register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)