### PR TITLE
fix(lightroom-plugin): repair plugin loading, uploads and selection import

### DIFF
--- a/apps/lightroom-plugin/lumio.lrdevplugin/ImportSelectionDialog.lua
+++ b/apps/lightroom-plugin/lumio.lrdevplugin/ImportSelectionDialog.lua
@@ -25,10 +25,10 @@ LrTasks.startAsyncTask(function()
     LrFunctionContext.callWithContext("ImportSelectionDialog", function(context)
 
         -- Galerien laden, mit User-friendly Error
-        local ok, galleries = pcall(LumioApi.listGalleries)
+        local ok, galleries = LrTasks.pcall(LumioApi.listGalleries)
         if not ok then
             LrDialogs.message(
-                "Lumio: Verbindung fehlgeschlagen",
+                "Lumio: connection failed",
                 tostring(galleries):gsub("^.-: ", ""),
                 "critical"
             )
@@ -37,8 +37,8 @@ LrTasks.startAsyncTask(function()
         if #galleries == 0 then
             LrDialogs.message(
                 "Lumio",
-                "Keine Galerien gefunden. Lege im Studio eine an oder prüfe, " ..
-                "dass der Token zum richtigen User gehört."
+                "No galleries found. Create one in the studio, or check " ..
+                "that the token belongs to the right user."
             )
             return
         end
@@ -71,7 +71,7 @@ LrTasks.startAsyncTask(function()
 
             f:row {
                 f:static_text {
-                    title = "Galerie:",
+                    title = "Gallery:",
                     width = 100,
                 },
                 f:popup_menu {
@@ -84,46 +84,46 @@ LrTasks.startAsyncTask(function()
             f:separator { fill_horizontal = 1 },
 
             f:static_text {
-                title = "Was importieren?",
+                title = "What to import?",
                 font = "<system/bold>",
             },
             f:checkbox {
-                title = "Picks als Lightroom-Flag setzen",
+                title = "Set picks as Lightroom flags",
                 value = LrView.bind("applyPick"),
             },
             f:checkbox {
-                title = "Likes als 1-Stern-Bewertung (zusätzlich zu Picks)",
+                title = "Likes as 1-star rating (in addition to picks)",
                 value = LrView.bind("applyLikes"),
             },
             f:checkbox {
-                title = "Bewertungen (1–5 Sterne) übernehmen",
+                title = "Apply ratings (1–5 stars)",
                 value = LrView.bind("applyRating"),
             },
             f:checkbox {
-                title = "Color-Labels übernehmen",
+                title = "Apply colour labels",
                 value = LrView.bind("applyColor"),
             },
 
             f:separator { fill_horizontal = 1 },
 
             f:static_text {
-                title = "Suche nach Dateinamen:",
+                title = "Match by filename:",
                 font = "<system/bold>",
             },
             f:radio_button {
-                title    = "Im aktuellen Katalog",
+                title    = "In the whole catalog",
                 value    = LrView.bind("matchScope"),
                 checked_value = "library",
             },
             f:radio_button {
-                title    = "Nur in der aktiven Sammlung",
+                title    = "Only in the active collection",
                 value    = LrView.bind("matchScope"),
                 checked_value = "collection",
             },
 
             f:static_text {
-                title = "Hinweis: Lumio matcht am Original-Dateinamen. Wenn du Dateien " ..
-                        "umbenannt hast, finden wir sie nicht.",
+                title = "Note: Lumio matches on the original filename. If you have renamed " ..
+                        "the files, they cannot be found.",
                 width_in_chars = 70,
                 height_in_lines = 2,
                 size = "small",
@@ -131,7 +131,7 @@ LrTasks.startAsyncTask(function()
         }
 
         local result = LrDialogs.presentModalDialog {
-            title = "Lumio-Auswahl importieren",
+            title = "Import Lumio selection",
             contents = contents,
             resizable = false,
         }

--- a/apps/lightroom-plugin/lumio.lrdevplugin/ImportSelectionTask.lua
+++ b/apps/lightroom-plugin/lumio.lrdevplugin/ImportSelectionTask.lua
@@ -17,6 +17,7 @@
 ]]
 
 local LrApplication    = import "LrApplication"
+local LrPathUtils      = import "LrPathUtils"
 local LrTasks          = import "LrTasks"
 local LrFunctionContext = import "LrFunctionContext"
 local LrProgressScope  = import "LrProgressScope"
@@ -37,16 +38,63 @@ local COLOR_MAP = {
 -- Dateinamen haben (z.B. zwei Kameras mit DSC_0001.NEF im selben Katalog),
 -- speichern wir alle und matchen jeden Lumio-File gegen ALLE Treffer.
 local function buildIndex(photos)
-    local idx = {}
+    local byFull, byBase = {}, {}
     for _, p in ipairs(photos) do
         local fname = p:getFormattedMetadata("fileName")
         if fname then
-            local key = fname:lower()
-            idx[key] = idx[key] or {}
-            table.insert(idx[key], p)
+            local full = fname:lower()
+            byFull[full] = byFull[full] or {}
+            table.insert(byFull[full], p)
+
+            -- Also index the extension-less basename; see findMatches.
+            local base = LrPathUtils.removeExtension(fname):lower()
+            byBase[base] = byBase[base] or {}
+            table.insert(byBase[base], p)
         end
     end
-    return idx
+    return { byFull = byFull, byBase = byBase }
+end
+
+-- CRITICAL. Publishing forces the uploaded name to "<basename>.jpg"
+-- (LumioPublishService.lua:308) and the server stores it verbatim. Import,
+-- on the other hand, indexed the catalog by its REAL filename including the
+-- extension, so "int_4325.jpg" could never match the catalog's
+-- "int_4325.nef". Measured on a real catalog: dng 1083, nef 967, jpg 91,
+-- tif 7 -> 95.8 % of the photos would NEVER have been found.
+-- Now: try the exact name first, then the extension-less basename.
+-- Returns (photos, kind) where kind is "ok" | "ambiguous" | "none".
+local function findMatches(idx, filename)
+    local fn = (filename or ""):lower()
+    if fn == "" then return nil, "none" end
+
+    -- Publishing ALWAYS sends the name as "<basename>.jpg", so both the exact
+    -- name and the basename are relevant. Collect both and only then decide --
+    -- returning on the first exact hit would let an exported JPEG in the
+    -- catalog win over the RAW master.
+    local candidates, seen = {}, {}
+    local function add(list)
+        for _, p in ipairs(list or {}) do
+            if not seen[p] then seen[p] = true; table.insert(candidates, p) end
+        end
+    end
+    add(idx.byFull[fn])
+    add(idx.byBase[LrPathUtils.removeExtension(fn)])
+    if #candidates == 0 then return nil, "none" end
+
+    -- Prefer the master (RAW/DNG/TIF) over an exported copy
+    local masters = {}
+    for _, p in ipairs(candidates) do
+        local n = (p:getFormattedMetadata("fileName") or ""):lower()
+        if not n:match("%.jpe?g$") then table.insert(masters, p) end
+    end
+    local chosen = (#masters > 0) and masters or candidates
+
+    -- Several masters sharing one basename = e.g. the same shot as both .NEF
+    -- and .DNG, two cameras with the same running number, or virtual copies.
+    -- We cannot know which one the client's selection refers to, so we write
+    -- to NONE of them -- a silent multi-write is worse than a skip.
+    if #chosen > 1 then return chosen, "ambiguous" end
+    return chosen, "ok"
 end
 
 local function applyOne(photo, file, opts)
@@ -81,14 +129,14 @@ function M.run(opts)
 
             local catalog = LrApplication.activeCatalog()
             local progress = LrProgressScope {
-                title = "Lumio-Auswahl wird importiert",
+                title = "Importing Lumio selection",
                 functionContext = context,
             }
             progress:setCancelable(true)
 
             -- 1. Selection vom Server holen
-            progress:setCaption("Lade Auswahl von Lumio…")
-            local ok, data = pcall(LumioApi.getSelection, opts.galleryId)
+            progress:setCaption("Loading selection from Lumio…")
+            local ok, data = LrTasks.pcall(LumioApi.getSelection, opts.galleryId)
             if not ok or not data then
                 LrDialogs.message(
                     "Lumio",
@@ -102,13 +150,13 @@ function M.run(opts)
             if #files == 0 then
                 LrDialogs.message(
                     "Lumio",
-                    "Diese Galerie hat noch keine Files mit Status 'ready'."
+                    "This gallery has no files with status 'ready' yet."
                 )
                 return
             end
 
             -- 2. Photo-Pool bestimmen
-            progress:setCaption("Durchsuche Katalog…")
+            progress:setCaption("Searching catalog…")
             local pool
             if opts.matchScope == "collection" then
                 local sources = catalog:getActiveSources()
@@ -124,8 +172,8 @@ function M.run(opts)
                 if #pool == 0 then
                     LrDialogs.message(
                         "Lumio",
-                        "Aktive Sammlung ist leer. Wähle eine andere oder " ..
-                        "stelle auf 'Im aktuellen Katalog' um."
+                        "The active collection is empty. Choose another one or " ..
+                        "switch to 'In the whole catalog'."
                     )
                     return
                 end
@@ -142,47 +190,109 @@ function M.run(opts)
             local matchedPhotos = 0
             local missing = {}
 
-            catalog:withWriteAccessDo("Lumio-Auswahl importieren", function()
-                for i, file in ipairs(files) do
-                    if progress:isCanceled() then break end
+            -- The whole transaction had no error handling. Any exception (most
+            -- commonly: the catalog write lock is unavailable because another
+            -- operation holds it) ended up in LR's generic "An internal error
+            -- has occurred" dialog -- no log, no summary, and no indication of
+            -- whether anything had been written to the catalog at all.
+            -- Now: pcall + timeout, and progress:done() plus the summary ALWAYS run.
+            local ambiguousList, applyErrors, canceled = {}, 0, false
 
-                    progress:setPortionComplete(i, #files)
-                    progress:setCaption(
-                        "Wende Auswahl an (" .. i .. "/" .. #files .. ")"
-                    )
+            local okTx, txErr = LrTasks.pcall(function()
+                catalog:withWriteAccessDo("Lumio-Auswahl importieren", function()
+                    for i, file in ipairs(files) do
+                        if progress:isCanceled() then canceled = true break end
 
-                    local matches = idx[(file.filename or ""):lower()]
-                    if matches and #matches > 0 then
-                        matchedFiles = matchedFiles + 1
-                        for _, photo in ipairs(matches) do
-                            applyOne(photo, file, opts)
-                            matchedPhotos = matchedPhotos + 1
+                        progress:setPortionComplete(i, #files)
+                        progress:setCaption(
+                            "Wende Auswahl an (" .. i .. "/" .. #files .. ")"
+                        )
+
+                        local matches, kind = findMatches(idx, file.filename)
+                        if kind == "none" then
+                            table.insert(missing, file.filename)
+                        elseif kind == "ambiguous" then
+                            table.insert(ambiguousList,
+                                string.format("%s (%d photos)", file.filename, #matches))
+                        else
+                            matchedFiles = matchedFiles + 1
+                            for _, photo in ipairs(matches) do
+                                -- This used to be a plain pcall, on the assumption
+                                -- that applyOne does not yield. That was wrong: the
+                                -- log proved "Yielding is not allowed within a C or
+                                -- metamethod call". photo:getRawMetadata and
+                                -- setRawMetadata ARE yielding catalog operations, so
+                                -- every write that carried real data failed silently
+                                -- (57 "successes" were no-ops).
+                                local okApply, applyErr = LrTasks.pcall(applyOne, photo, file, opts)
+                                if okApply then
+                                    matchedPhotos = matchedPhotos + 1
+                                else
+                                    applyErrors = applyErrors + 1
+                                    log:warn(string.format("applyOne failed for %s (%s): %s",
+                                        tostring(file.filename),
+                                        tostring(photo:getFormattedMetadata("fileName")),
+                                        tostring(applyErr)))
+                                end
+                            end
                         end
-                    else
-                        table.insert(missing, file.filename)
                     end
-                end
+                end, { timeout = 30 })
             end)
 
             progress:done()
 
+            if not okTx then
+                log:error("import transaction failed: " .. tostring(txErr))
+                LrDialogs.message(
+                    "Lumio import failed",
+                    "The catalog could not be updated:\n\n" .. tostring(txErr) ..
+                    "\n\nThis usually means another operation is holding the " ..
+                    "catalog lock. Close other dialogs and try again.",
+                    "critical"
+                )
+                return
+            end
+
             -- 4. Zusammenfassung
             local summary = string.format(
-                "Importiert für %d von %d Files (%d Photos im Katalog aktualisiert).",
+                "Imported for %d of %d files (%d photos updated in the catalog).",
                 matchedFiles, #files, matchedPhotos
             )
+            if canceled then
+                summary = "IMPORT WAS CANCELED.\n\n" .. summary ..
+                    "\n\nWhat was already written stays in the catalog — " ..
+                    "undo it with Cmd+Z if you want it reverted."
+            end
+            if #ambiguousList > 0 then
+                summary = summary .. string.format(
+                    "\n\n%d filename(s) SKIPPED because they matched several " ..
+                    "photos (e.g. the same shot as both NEF and DNG, or virtual " ..
+                    "copies). Nothing was written for these — pick the right " ..
+                    "photo by hand:\n", #ambiguousList)
+                for i = 1, math.min(10, #ambiguousList) do
+                    summary = summary .. "  • " .. ambiguousList[i] .. "\n"
+                end
+                if #ambiguousList > 10 then
+                    summary = summary .. "  …and " .. (#ambiguousList - 10) .. " more"
+                end
+            end
+            if applyErrors > 0 then
+                summary = summary .. string.format(
+                    "\n\n%d photo(s) could not be updated.", applyErrors)
+            end
             if #missing > 0 then
-                summary = summary .. "\n\nNicht gefunden:\n"
+                summary = summary .. "\n\nNot found:\n"
                 for i = 1, math.min(20, #missing) do
                     summary = summary .. "  • " .. missing[i] .. "\n"
                 end
                 if #missing > 20 then
-                    summary = summary .. "  …und " .. (#missing - 20) .. " weitere"
+                    summary = summary .. "  …and " .. (#missing - 20) .. " more"
                 end
             end
 
             log:info("import done: " .. summary:gsub("\n", " | "))
-            LrDialogs.message("Lumio-Import fertig", summary)
+            LrDialogs.message("Lumio import finished", summary)
         end)
     end)
 end

--- a/apps/lightroom-plugin/lumio.lrdevplugin/Info.lua
+++ b/apps/lightroom-plugin/lumio.lrdevplugin/Info.lua
@@ -3,7 +3,7 @@
 
     Zwei Richtungen:
       1. Selection-Import: Kunden-Picks aus Lumio in den LR-Katalog
-         (Bibliothek → Zusatzmoduloptionen → "Lumio-Auswahl importieren…")
+         (Bibliothek → Zusatzmoduloptionen → "Import Lumio selection…")
       2. Publish-Service: Bilder aus LR in Lumio-Galerien hochladen
          (Bibliothek → Veroeffentlichungsdienste → "Lumio")
 
@@ -16,7 +16,7 @@
          "lumio.lrplugin", falls .lrdevplugin in Finder als Bundle hindert)
       2. In Lightroom: Datei → Zusatzmodul-Manager → Hinzufügen
       3. In den Plugin-Optionen Host + Token eingeben
-      4a. Selection-Import: Bibliothek → Zusatzmoduloptionen → "Lumio-Auswahl importieren…"
+      4a. Selection-Import: Bibliothek → Zusatzmoduloptionen → "Import Lumio selection…"
       4b. Publish:          Bibliothek → Veroeffentlichungsdienste → "Lumio einrichten…"
 
     Author: Lumio
@@ -37,7 +37,7 @@ return {
     -- Menü-Eintrag in Bibliothek → Zusatzmoduloptionen
     LrLibraryMenuItems = {
         {
-            title = "Lumio-Auswahl importieren…",
+            title = "Import Lumio selection…",
             file  = "ImportSelectionDialog.lua",
         },
     },

--- a/apps/lightroom-plugin/lumio.lrdevplugin/LumioApi.lua
+++ b/apps/lightroom-plugin/lumio.lrdevplugin/LumioApi.lua
@@ -16,6 +16,7 @@
 ]]
 
 local LrHttp           = import "LrHttp"
+local LrTasks          = import "LrTasks"
 local LrPrefs          = import "LrPrefs"
 local LrPathUtils      = import "LrPathUtils"
 local LrFileUtils      = import "LrFileUtils"
@@ -44,49 +45,133 @@ local function getToken()
     return token
 end
 
+-- RETRY.
+-- Before: a single HTTP 429 failed the call permanently. Observed in real use
+-- (Lumio.log 14:15:45): at the end of a 23-photo batch the PATCH status=live
+-- got a 429 and the gallery stayed a draft. The rate limit is 300/min and is
+-- SHARED with the browser.
+-- Now: 429, transient 5xx and network errors are retried with delays of
+-- 5/15/45 s (four attempts in total), honouring the Retry-After header.
+local RETRY_DELAYS   = { 5, 15, 45 }
+local MAX_DELAY      = 30   -- katto yhdelle odotukselle, myös Retry-Afterille
+local MAX_TOTAL_WAIT = 90   -- kokonaisbudjetti yhtä kutsua kohti
+local MAX_NET_RETRIES = 1   -- verkkovirhe on usein PYSYVÄ (väärä host) -> vain 1 uusinta
+
+-- A caller can set this so that long waits are interrupted by a cancellation.
+-- Without it LrTasks.sleep does not react to the Cancel button at all.
+M.isCanceled = nil
+
+local function interruptibleSleep(seconds)
+    local slept = 0
+    while slept < seconds do
+        if M.isCanceled and M.isCanceled() then
+            error("Lumio: peruutettu")
+        end
+        local step = math.min(1, seconds - slept)
+        LrTasks.sleep(step)
+        slept = slept + step
+    end
+end
+
+local function retryAfterSeconds(responseHeaders, fallback)
+    for _, h in ipairs(responseHeaders or {}) do
+        if h.field and tostring(h.field):lower() == "retry-after" then
+            local n = tonumber(h.value)  -- HTTP-päiväysmuoto -> nil -> fallback
+            if n and n > 0 then return math.min(n, MAX_DELAY) end
+        end
+    end
+    return math.min(fallback, MAX_DELAY)
+end
+
+local function httpDispatch(method, url, headers, body)
+    if method == "GET" then
+        return LrHttp.get(url, headers)
+    elseif method == "POST" then
+        table.insert(headers, { field = "Content-Type", value = "application/json" })
+        return LrHttp.post(url, body and json.encode(body) or "", headers)
+    elseif method == "PATCH" then
+        table.insert(headers, { field = "Content-Type", value = "application/json" })
+        return LrHttp.post(url, body and json.encode(body) or "", headers, "PATCH")
+    elseif method == "DELETE" then
+        return LrHttp.post(url, "", headers, "DELETE")
+    else
+        error("unsupported method: " .. method)
+    end
+end
+
 -- Low-Level Request. Gibt body + status zurück, throws bei Auth-Fehler.
 function M.request(method, path, body)
     local url = getBase() .. "/api/v1" .. path
-    local headers = {
-        { field = "Authorization", value = "Bearer " .. getToken() },
-        { field = "Accept",        value = "application/json" },
-    }
     log:info("HTTP " .. method .. " " .. url)
 
-    local responseBody, responseHeaders
-    if method == "GET" then
-        responseBody, responseHeaders = LrHttp.get(url, headers)
-    elseif method == "POST" then
-        table.insert(headers, {
-            field = "Content-Type", value = "application/json"
-        })
-        responseBody, responseHeaders = LrHttp.post(
-            url, body and json.encode(body) or "", headers
-        )
-    elseif method == "PATCH" then
-        table.insert(headers, {
-            field = "Content-Type", value = "application/json"
-        })
-        responseBody, responseHeaders = LrHttp.post(
-            url, body and json.encode(body) or "", headers, "PATCH"
-        )
-    elseif method == "DELETE" then
-        responseBody, responseHeaders = LrHttp.post(
-            url, "", headers, "DELETE"
-        )
-    else
-        error("unsupported method: " .. method)
+    -- POST IS NOT IDEMPOTENT. /uploads/init, /uploads/complete and
+    -- /plugin/galleries change server state: if the response is lost to a
+    -- network error, the request may still have been processed. A retry would
+    -- create a second file row (stuck in 'uploading' forever) or an entirely
+    -- second gallery. A 429 is safe for every method, because the rate limit
+    -- rejects the request BEFORE the handler runs.
+    local isPost = (method == "POST")
+
+    local responseBody, responseHeaders, status
+    local totalWait, netRetries = 0, 0
+
+    for attempt = 0, #RETRY_DELAYS do
+        local headers = {
+            { field = "Authorization", value = "Bearer " .. getToken() },
+            { field = "Accept",        value = "application/json" },
+        }
+        responseBody, responseHeaders = httpDispatch(method, url, headers, body)
+
+        -- LrHttp signaloi verkkovirheen responseHeaders.error-kentässä, EI poikkeuksena
+        local netErr = responseHeaders and responseHeaders.error
+        status = responseHeaders and tonumber(responseHeaders.status) or nil
+        local isNetworkFailure = (not responseHeaders) or netErr or (status == nil)
+
+        local retryable
+        if status == 429 then
+            retryable = true
+        elseif isPost then
+            retryable = false
+        elseif isNetworkFailure then
+            retryable = (netRetries < MAX_NET_RETRIES)
+            if retryable then netRetries = netRetries + 1 end
+        else
+            retryable = (status == 502 or status == 503 or status == 504)
+        end
+
+        if not retryable or attempt >= #RETRY_DELAYS then
+            if isNetworkFailure then
+                if netErr then
+                    error("Lumio: yhteys epäonnistui: " ..
+                        tostring(netErr.name or netErr.errorCode or "tuntematon verkkovirhe"))
+                end
+                -- Was `responseHeaders.status or 0`, which let a response with no
+                -- status pass as a "success" and silently returned nil.
+                error("Lumio: palvelin ei vastannut odotetusti (statuskoodi puuttuu)")
+            end
+            break -- 4xx/5xx: käsitellään alla normaalina HTTP-virheenä
+        end
+
+        local delay = retryAfterSeconds(responseHeaders, RETRY_DELAYS[attempt + 1])
+        if totalWait + delay > MAX_TOTAL_WAIT then
+            log:warn("odotusbudjetti täynnä (" .. totalWait .. " s), ei enää yrityksiä")
+            break
+        end
+        totalWait = totalWait + delay
+        log:warn(string.format("HTTP %s %s -> yritys %d/%d epäonnistui (%s), odotetaan %d s",
+            method, path, attempt + 1, #RETRY_DELAYS + 1,
+            netErr and "verkkovirhe" or tostring(status), delay))
+        interruptibleSleep(delay)
     end
 
     if not responseHeaders then
         error("Lumio: keine Antwort vom Server (Host erreichbar?)")
     end
-    local status = responseHeaders.status or 0
     if status == 401 then
         error("Lumio: API-Token ungültig oder abgelaufen")
     elseif status == 204 then
         return nil
-    elseif status >= 400 then
+    elseif status and status >= 400 then
         error("Lumio: HTTP " .. tostring(status) ..
             " " .. (responseBody or ""):sub(1, 200))
     end
@@ -192,16 +277,47 @@ function M.uploadFileToS3(presignedUrl, filepath, mimeType)
         { field = "Content-Type", value = mimeType or "application/octet-stream" },
     }
     log:info("S3 PUT " .. presignedUrl:sub(1, 80) .. "... (" .. #data .. " bytes)")
-    local responseBody, responseHeaders = LrHttp.post(
-        presignedUrl, data, headers, "PUT"
-    )
+
+    -- Retry here as well. This is the only multi-megabyte transfer and at the
+    -- same time the only call that is SAFE to repeat: a presigned PUT to the
+    -- same key with the same content is idempotent, unlike POST /uploads/init.
+    -- Without this, a single network hiccup discarded the whole photo.
+    local responseBody, responseHeaders
+    local waited = 0
+    for attempt = 0, #RETRY_DELAYS do
+        responseBody, responseHeaders = LrHttp.post(presignedUrl, data, headers, "PUT")
+
+        local netErr = responseHeaders and responseHeaders.error
+        local st = responseHeaders and tonumber(responseHeaders.status) or nil
+        local shouldRetry = (not responseHeaders) or netErr or (st == nil)
+            or st == 500 or st == 502 or st == 503 or st == 504
+
+        if not shouldRetry or attempt >= #RETRY_DELAYS then break end
+
+        local delay = math.min(RETRY_DELAYS[attempt + 1], MAX_DELAY)
+        if waited + delay > MAX_TOTAL_WAIT then break end
+        waited = waited + delay
+        log:warn(string.format("S3 PUT yritys %d epäonnistui (%s), odotetaan %d s",
+            attempt + 1, netErr and "verkkovirhe" or tostring(st), delay))
+        interruptibleSleep(delay)
+    end
+
     if not responseHeaders then
         error("Lumio: kein Response von S3 (Netzwerkproblem?)")
     end
-    local status = responseHeaders.status or 0
-    if status >= 400 then
-        error("Lumio: S3 HTTP " .. tostring(status) ..
-            " " .. (responseBody or ""):sub(1, 200))
+    -- Was `responseHeaders.status or 0`, so a MISSING status code (connection
+    -- dropped mid-transfer) was read as SUCCESS -> the server was left with a
+    -- file row and no object, and the user saw no error at all.
+    -- An explicit 2xx is now required.
+    local netErr = responseHeaders.error
+    local status = tonumber(responseHeaders.status)
+    if netErr then
+        error("Lumio: S3-lataus epäonnistui verkkovirheeseen: " ..
+            tostring(netErr.name or netErr.errorCode or "tuntematon"))
+    end
+    if type(status) ~= "number" or status < 200 or status >= 300 then
+        error("Lumio: S3-lataus epäonnistui (status " .. tostring(status) .. ") " ..
+            (responseBody or ""):sub(1, 200))
     end
     -- S3 liefert ein ETag-Header zurueck — nicht zwingend benoetigt
     -- bei single-PUT, aber wir geben ihn zurueck fuer evtl. multipart-

--- a/apps/lightroom-plugin/lumio.lrdevplugin/LumioPublishService.lua
+++ b/apps/lightroom-plugin/lumio.lrdevplugin/LumioPublishService.lua
@@ -48,6 +48,7 @@ local LrDate               = import "LrDate"
 local LrDialogs            = import "LrDialogs"
 local LrFunctionContext    = import "LrFunctionContext"
 local LrPathUtils          = import "LrPathUtils"
+local LrPrefs              = import "LrPrefs"
 local LrTasks              = import "LrTasks"
 local LrView               = import "LrView"
 local LrFileUtils          = import "LrFileUtils"
@@ -75,16 +76,31 @@ exportServiceProvider.hideSections = {
 }
 exportServiceProvider.allowFileFormats = { "JPEG" }
 exportServiceProvider.allowColorSpaces = { "sRGB" }
-exportServiceProvider.titleForPublishedCollection           = "Lumio-Galerie"
-exportServiceProvider.titleForPublishedCollection_standalone = "Lumio-Galerie"
-exportServiceProvider.titleForPublishedSmartCollection      = "Lumio Smart-Galerie"
-exportServiceProvider.titleForPublishedSmartCollection_standalone = "Lumio Smart-Galerie"
-exportServiceProvider.titleForGoToPublishedCollection       = "In Lumio anzeigen"
-exportServiceProvider.titleForGoToPublishedPhoto            = "In Lumio anzeigen"
+exportServiceProvider.titleForPublishedCollection           = "Lumio Gallery"
+exportServiceProvider.titleForPublishedCollection_standalone = "Lumio Gallery"
+exportServiceProvider.titleForPublishedSmartCollection      = "Lumio Smart Gallery"
+exportServiceProvider.titleForPublishedSmartCollection_standalone = "Lumio Smart Gallery"
+exportServiceProvider.titleForGoToPublishedCollection       = "Show in Lumio"
+exportServiceProvider.titleForGoToPublishedPhoto            = "Show in Lumio"
 exportServiceProvider.small_icon = "icon.png"
 exportServiceProvider.supportsCustomSortOrder = false
 exportServiceProvider.disableRenamePublishedCollection      = false
 exportServiceProvider.disableRenamePublishedCollectionSet   = true
+
+-- This was missing entirely. Without getCollectionBehaviorInfo, Lightroom
+-- assumes Collection Set support and fails with
+-- "?:0: attempt to call method 'hierarchyCreated' (a nil value)" when a
+-- collection is created in the publish service. The plug-in has NO set-level
+-- callbacks (e.g. updateCollectionSetSettings), so tell LR outright that
+-- hierarchies are unsupported: maxCollectionSetDepth = 0.
+function exportServiceProvider.getCollectionBehaviorInfo(publishSettings)
+    return {
+        defaultCollectionName         = "Lumio Gallery",
+        defaultCollectionCanBeDeleted = true,
+        canAddCollection              = true,
+        maxCollectionSetDepth         = 0,
+    }
+end
 
 -- Republish-Trigger: nur Datei-Inhalt, nicht Metadaten. Lightroom-Filename-
 -- Aenderungen wuerden zwar einen Republish triggern, sind aber selten — wir
@@ -105,17 +121,17 @@ end
 function exportServiceProvider.sectionsForTopOfDialog(viewFactory, propertyTable)
     return {
         {
-            title = "Lumio-Verbindung",
-            synopsis = "API-Token wird in den Plug-in-Optionen verwaltet",
+            title = "Lumio Connection",
+            synopsis = "API token is managed in the plug-in options",
             viewFactory:row {
                 viewFactory:static_text {
-                    title = "Host + API-Token werden global in den Plug-in-Optionen verwaltet.",
+                    title = "Host and API token are managed globally in the plug-in options.",
                     width_in_chars = 60,
                 },
             },
             viewFactory:row {
                 viewFactory:static_text {
-                    title = "Hinweis: Pro Lumio-Galerie wird eine Veröffentlichte Sammlung angelegt.",
+                    title = "Note: one published collection is created per Lumio gallery.",
                     width_in_chars = 60,
                     text_color = LrColor(0.5, 0.5, 0.5),
                 },
@@ -141,39 +157,99 @@ function exportServiceProvider.viewForCollectionSettings(viewFactory, publishSet
     props.galleryStatus = props.galleryStatus or "draft"
     props.makeLive = props.makeLive or false
 
-    -- Galerie-Liste async laden
-    LrTasks.startAsyncTask(function()
-        local ok, galleries = pcall(api.listGalleries)
-        if not ok then
-            log:warn("Galerie-Liste konnte nicht geladen werden: " .. tostring(galleries))
-            props.availableGalleries = {}
-            return
-        end
-        local items = { { title = "— Neue Galerie anlegen (Titel unten eingeben) —", value = "" } }
-        for _, g in ipairs(galleries) do
+    -- Existing galleries did not show up in the menu. The server was not at
+    -- fault: GET /plugin/galleries returns 200 and the correct list (verified
+    -- with a direct API call). Two bugs in the plug-in:
+    --   1. The list was set ONLY asynchronously, after the dialog had been
+    --      built, by which time the binding no longer refreshed the popup_menu.
+    --   2. The old line was `props.availableGalleries = props.availableGalleries or {...}`
+    --      and because props = info.collectionSettings PERSISTS, on the second
+    --      open the `or` kept the stale (usually "Loading…") value and the list
+    --      never refreshed.
+    -- Fix: build the menu SYNCHRONOUSLY from the prefs cache right away, and
+    -- refresh that cache in the background for the next open.
+    local prefs = LrPrefs.prefsForPlugin()
+
+    local function buildGalleryItems(list)
+        local items = { { title = "— Create new gallery (enter title below) —", value = "" } }
+        for _, g in ipairs(list or {}) do
             table.insert(items, {
-                title = string.format("%s (%s, %d Files)",
-                    g.title, g.status, g.fileCount or 0),
+                title = string.format("%s (%s, %d files)",
+                    tostring(g.title), tostring(g.status), g.fileCount or 0),
                 value = g.id,
             })
         end
-        props.availableGalleries = items
+        return items
+    end
+
+    -- The cache does NOT go into prefs as a table. LrPrefs only stores simple
+    -- values reliably; a table of tables was lost silently, so on the next open
+    -- the list read back empty. The log proved it: "gallery list refreshed:
+    -- 1 galleries" was written, yet the menu stayed empty. Store it as a JSON
+    -- string instead.
+    local cached = {}
+    if type(prefs.galleryCacheJson) == "string" and prefs.galleryCacheJson ~= "" then
+        local okDecode, decoded = pcall(json.decode, prefs.galleryCacheJson)
+        if okDecode and type(decoded) == "table" then cached = decoded end
+    end
+
+    -- 1) heti näkyviin: viimeksi haettu lista (tyhjä vasta ensimmäisellä kerralla)
+    props.availableGalleries = buildGalleryItems(cached)
+
+    -- If the collection already has a gallery but the cache is empty (the first
+    -- open after this change), the menu would show ONLY the "Create new gallery"
+    -- row with the value "". The user would pick it, galleryId would reset, and
+    -- the NEXT publish would create a stray extra gallery for the client.
+    -- Always keep the currently bound value in the list.
+    if props.galleryId and props.galleryId ~= "" then
+        local found = false
+        for _, it in ipairs(props.availableGalleries) do
+            if it.value == props.galleryId then found = true break end
+        end
+        if not found then
+            local label = (props.galleryTitle and props.galleryTitle ~= "")
+                and props.galleryTitle or props.galleryId
+            table.insert(props.availableGalleries, 2,
+                { title = "(current) " .. tostring(label), value = props.galleryId })
+        end
+    end
+
+    -- 2) taustalla tuore haku: päivittää välimuistin ja yrittää myös elävää sidontaa
+    LrTasks.startAsyncTask(function()
+        local ok, galleries = LrTasks.pcall(api.listGalleries)
+        if not ok then
+            log:warn("gallery list could not be loaded: " .. tostring(galleries))
+            return
+        end
+        -- NOTE: an empty list is cached on purpose. The error path is already
+        -- handled above (if not ok then ... return end), so an empty result that
+        -- reaches this point genuinely means an empty account. If we skipped
+        -- caching it, a gallery deleted in the Studio would linger in the menu
+        -- forever.
+        local okEnc, encoded = pcall(json.encode, galleries)
+        if okEnc then prefs.galleryCacheJson = encoded end
+        props.availableGalleries = buildGalleryItems(galleries)
+        log:info("gallery list refreshed: " .. #galleries ..
+                 " galleries, cache " .. (okEnc and "written" or "FAILED"))
     end)
 
-    -- Default-Items waehrend Loading
-    props.availableGalleries = props.availableGalleries or {
-        { title = "Lade…", value = "" }
-    }
-
-    return {
-        title = "Lumio-Galerie",
-        synopsis = LrView.bind { key = "galleryTitle" },
+    -- THIS was the real cause of the 'hierarchyCreated' failure.
+    -- sectionsForTopOfDialog returns a table of SECTIONS (title/synopsis/…),
+    -- but viewForCollectionSettings has to return a SINGLE VIEW. This returned
+    -- a sections-shaped table, so LR tried to call the method
+    -- 'hierarchyCreated' on it -> "An internal error has occurred". The
+    -- function itself ran to completion (hence the gallery fetches in the log),
+    -- but the dialog died on the return value -- which is why the dropdown was
+    -- never seen at all.
+    return f:group_box {
+        title = "Lumio Gallery",
+        fill_horizontal = 1,
         f:column {
             spacing = f:control_spacing(),
             fill_horizontal = 1,
             f:row {
                 f:static_text {
-                    title = "Vorhandene Galerie:",
+                    title = "Existing gallery:",
                     width = LrView.share "label_width",
                     alignment = "right",
                 },
@@ -186,20 +262,20 @@ function exportServiceProvider.viewForCollectionSettings(viewFactory, publishSet
             },
             f:row {
                 f:static_text {
-                    title = "ODER neue anlegen:",
+                    title = "OR create new:",
                     width = LrView.share "label_width",
                     alignment = "right",
                 },
                 f:edit_field {
                     bind_to_object = props,
                     value = LrView.bind("galleryTitle"),
-                    placeholder_string = "Galerie-Titel (z.B. 'Anna & Max Hochzeit')",
+                    placeholder_string = "Gallery title (e.g. 'Mäyränkatu 14')",
                     width_in_chars = 40,
                 },
             },
             f:row {
                 f:static_text {
-                    title = "Modus:",
+                    title = "Mode:",
                     width = LrView.share "label_width",
                     alignment = "right",
                 },
@@ -207,8 +283,8 @@ function exportServiceProvider.viewForCollectionSettings(viewFactory, publishSet
                     bind_to_object = props,
                     value = LrView.bind("galleryMode"),
                     items = {
-                        { title = "Auswahl / Proofing (Kunde liked/picked)", value = "collaboration" },
-                        { title = "Praesentation (nur Anzeige)", value = "presentation" },
+                        { title = "Selection / proofing (client likes & picks)", value = "collaboration" },
+                        { title = "Presentation (view only)", value = "presentation" },
                     },
                     width_in_chars = 40,
                 },
@@ -221,7 +297,7 @@ function exportServiceProvider.viewForCollectionSettings(viewFactory, publishSet
                 f:checkbox {
                     bind_to_object = props,
                     value = LrView.bind("makeLive"),
-                    title = "Nach Upload automatisch auf 'live' schalten",
+                    title = "Set gallery live automatically after upload",
                 },
             },
             f:row {
@@ -230,7 +306,7 @@ function exportServiceProvider.viewForCollectionSettings(viewFactory, publishSet
                     width = LrView.share "label_width",
                 },
                 f:static_text {
-                    title = "Tipp: Header, Branding und Passwort konfigurierst du im Lumio-Studio nach dem ersten Upload.",
+                    title = "Tip: configure header, branding and password in Lumio Studio after the first upload.",
                     width_in_chars = 50,
                     text_color = LrColor(0.5, 0.5, 0.5),
                     height_in_lines = 2,
@@ -286,7 +362,15 @@ local function uploadOnePhoto(rendition, filepath, galleryId)
     -- LR merkt sich die Lumio-File-ID. Bei spaeterem Republish/Delete
     -- liefert LR diese ID an deletePhotosFromPublishedCollection.
     rendition:recordPublishedPhotoId(u.fileId)
-    rendition:recordPublishedPhotoUrl(nil)
+    -- This was `rendition:recordPublishedPhotoUrl(nil)`. LR requires a string
+    -- and failed every photo with
+    -- "AgExportRendition:recordRemotePhotoUrl: URL must be a string".
+    -- The photos DID reach Lumio (the upload happens before this line), but LR
+    -- never marked them as published -> they stayed in "New Photos to Publish"
+    -- and would have been uploaded again on every publish = duplicates.
+    -- The URL call is optional in the SDK and the upload response carries no
+    -- viewable address (only a presigned PUT), so it is removed.
+    -- "Show in Lumio" at gallery level still works (host + /g/<slug>).
 end
 
 -- ============================================================================
@@ -316,16 +400,16 @@ function exportServiceProvider.processRenderedPhotos(functionContext, exportCont
         if title == "" then
             LrDialogs.message(
                 "Lumio",
-                "Diese Sammlung hat keine Galerie zugeordnet. Bitte oeffne 'Veroeffentlichungs-Sammlung bearbeiten' und waehle eine Galerie aus oder gib einen Titel fuer eine neue ein.",
+                "This collection has no gallery assigned. Open 'Edit Published Collection' and either choose an existing gallery or enter a title for a new one.",
                 "critical"
             )
             return
         end
-        local ok, created = pcall(
+        local ok, created = LrTasks.pcall(
             api.createGallery, title, collProps.galleryMode, nil
         )
         if not ok then
-            LrDialogs.message("Lumio", "Galerie konnte nicht angelegt werden: " .. tostring(created), "critical")
+            LrDialogs.message("Lumio", "Could not create gallery: " .. tostring(created), "critical")
             return
         end
         galleryId = created.id
@@ -343,7 +427,7 @@ function exportServiceProvider.processRenderedPhotos(functionContext, exportCont
     end
 
     if not galleryId or galleryId == "" then
-        LrDialogs.message("Lumio", "Keine Lumio-Galerie zugeordnet.", "critical")
+        LrDialogs.message("Lumio", "No Lumio gallery assigned.", "critical")
         return
     end
 
@@ -357,6 +441,11 @@ function exportServiceProvider.processRenderedPhotos(functionContext, exportCont
     local uploaded = 0
     local failed = 0
     local failedList = {}
+
+    -- Wire cancellation into the API layer's waits. Without this the retry
+    -- sleeps do not react to the Cancel button at all, because cancellation is
+    -- only checked BETWEEN photos.
+    api.isCanceled = function() return progressScope:isCanceled() end
 
     for i, rendition in exportContext:renditions { stopIfCanceled = true } do
         progressScope:setPortionComplete((i - 1) / nPhotos)
@@ -372,8 +461,12 @@ function exportServiceProvider.processRenderedPhotos(functionContext, exportCont
                 (rendition.photo:getFormattedMetadata("fileName") or "?") ..
                 ": " .. tostring(pathOrMessage))
             log:warn("Render failed: " .. tostring(pathOrMessage))
+            -- Tell LR that THIS photo failed. Without it LR's publish state is
+            -- left undefined and the photo can appear published even though it
+            -- was never uploaded.
+            rendition:uploadFailed(tostring(pathOrMessage))
         else
-            local ok, errMsg = pcall(uploadOnePhoto, rendition, pathOrMessage, galleryId)
+            local ok, errMsg = LrTasks.pcall(uploadOnePhoto, rendition, pathOrMessage, galleryId)
             if ok then
                 uploaded = uploaded + 1
             else
@@ -381,6 +474,7 @@ function exportServiceProvider.processRenderedPhotos(functionContext, exportCont
                 local fname = rendition.photo:getFormattedMetadata("fileName") or "?"
                 table.insert(failedList, fname .. ": " .. tostring(errMsg))
                 log:warn("Upload failed for " .. fname .. ": " .. tostring(errMsg))
+                rendition:uploadFailed(tostring(errMsg))
             end
             -- Temp-File aufraeumen
             if pathOrMessage and LrFileUtils.exists(pathOrMessage) then
@@ -392,29 +486,49 @@ function exportServiceProvider.processRenderedPhotos(functionContext, exportCont
     end
 
     -- Status auf 'live' setzen wenn gewuenscht
+    -- A failure here used to surface only in the log, so the photographer
+    -- believed the gallery was published and sent the client a link to a
+    -- gallery that was still a draft. This actually happened at 14:15 (HTTP 429).
+    local statusPatchError = nil
     if collProps and collProps.makeLive and uploaded > 0 then
-        local ok, err = pcall(function()
+        local ok, err = LrTasks.pcall(function()
             api.patchGallery(galleryId, { status = "live" })
         end)
         if not ok then
-            log:warn("status=live failed: " .. tostring(err))
+            statusPatchError = tostring(err)
+            log:warn("status=live failed: " .. statusPatchError)
         end
     end
 
-    -- Zusammenfassung
+    -- Close the progress bar and detach the cancellation hook BEFORE showing
+    -- dialogs. done() used to run only after all the modals, which left the bar
+    -- spinning for as long as the user was reading them.
+    progressScope:done()
+    api.isCanceled = nil
+
+    -- Combined summary: LR already shows its own "Export Results" modal for
+    -- failed renditions (rendition:uploadFailed), so rather than stacking three
+    -- dialogs we show a single message of our own.
+    local notes = {}
+    if statusPatchError then
+        table.insert(notes,
+            "Gallery status could NOT be set to live:\n" .. statusPatchError ..
+            "\nThe gallery is still a draft — set it live in Lumio Studio.")
+    end
     if failed > 0 then
-        local msg = uploaded .. " erfolgreich, " .. failed .. " fehlgeschlagen.\n\n"
+        local msg = uploaded .. " succeeded, " .. failed .. " failed.\n"
         for i, line in ipairs(failedList) do
             if i > 10 then
-                msg = msg .. "(weitere " .. (failed - 10) .. ")\n"
+                msg = msg .. "(and " .. (failed - 10) .. " more)\n"
                 break
             end
             msg = msg .. line .. "\n"
         end
-        LrDialogs.message("Lumio Upload — teils fehlgeschlagen", msg, "warning")
+        table.insert(notes, msg)
     end
-
-    progressScope:done()
+    if #notes > 0 then
+        LrDialogs.message("Lumio", table.concat(notes, "\n\n"), "warning")
+    end
 end
 
 -- ============================================================================
@@ -444,7 +558,7 @@ function exportServiceProvider.deletePhotosFromPublishedCollection(
     end
 
     for _, photoId in ipairs(arrayOfPhotoIds) do
-        local ok, err = pcall(api.deleteGalleryFile, galleryId, photoId)
+        local ok, err = LrTasks.pcall(api.deleteGalleryFile, galleryId, photoId)
         if ok then
             deletedCallback(photoId)
             log:info("deleted file " .. photoId)
@@ -457,16 +571,37 @@ end
 -- ============================================================================
 -- goToPublishedCollection
 -- ============================================================================
--- Wird vom "In Lumio anzeigen"-Menueeintrag gerufen. Oeffnet die
+-- Wird vom "Show in Lumio"-Menueeintrag gerufen. Oeffnet die
 -- Galerie im Browser.
 function exportServiceProvider.goToPublishedCollection(publishSettings, info)
     local LrHttp = import "LrHttp"
     local collInfo = info.publishedCollection and info.publishedCollection:getCollectionInfoSummary()
     if not collInfo then return end
-    local slug = collInfo.collectionSettings and collInfo.collectionSettings.gallerySlug
-    local host = publishSettings.host or ""
-    if not slug or not host or host == "" then
-        LrDialogs.message("Lumio", "Galerie-Slug oder Host fehlt", "warning")
+    local collSettings = collInfo.collectionSettings or {}
+    local slug = collSettings.gallerySlug
+    -- Was `publishSettings.host`, which does not exist -- the host is set in
+    -- the plug-in's own settings (PluginManager), not in the publish service
+    -- settings. That is why "Show in Lumio" could never have worked.
+    local host = (LrPrefs.prefsForPlugin().host or ""):gsub("/+$", "")
+
+    -- The slug is missing if the gallery was picked from the dropdown (it was
+    -- only stored when creating a new one). Look it up in the cache by galleryId.
+    if (not slug or slug == "") and collSettings.galleryId then
+        local prefs = LrPrefs.prefsForPlugin()
+        if type(prefs.galleryCacheJson) == "string" and prefs.galleryCacheJson ~= "" then
+            local okDecode, cached = pcall(json.decode, prefs.galleryCacheJson)
+            if okDecode and type(cached) == "table" then
+                for _, g in ipairs(cached) do
+                    if g.id == collSettings.galleryId then slug = g.slug break end
+                end
+            end
+        end
+    end
+
+    if not slug or slug == "" or host == "" then
+        LrDialogs.message("Lumio",
+            "Gallery slug or host is missing. Publish the collection once, " ..
+            "or set the server address in Plug-in Manager.", "warning")
         return
     end
     -- Public-Galerie-URL

--- a/apps/lightroom-plugin/lumio.lrdevplugin/PluginManager.lua
+++ b/apps/lightroom-plugin/lumio.lrdevplugin/PluginManager.lua
@@ -26,10 +26,10 @@ local function testConnection(propertyTable)
         prefs.token = propertyTable.token
 
         LrTasks.startAsyncTask(function()
-            propertyTable.testStatus = "Teste…"
-            local ok, result = pcall(LumioApi.testConnection)
+            propertyTable.testStatus = "Testing…"
+            local ok, result = LrTasks.pcall(LumioApi.testConnection)
             if ok and result and result.ok then
-                propertyTable.testStatus = "✓ Verbunden (API v" ..
+                propertyTable.testStatus = "✓ Connected (API v" ..
                     (result.apiVersion or "?") .. ")"
                 log:info("connection test ok")
             else
@@ -45,7 +45,13 @@ return {
     sectionsForTopOfDialog = function(viewFactory, _propertyTable)
         local f = viewFactory
 
-        local bindable = LrBinding.makePropertyTable(_propertyTable.context)
+        -- The original line was
+        --   local bindable = LrBinding.makePropertyTable(_propertyTable.context)
+        -- but LR does not expose a .context field -> "LrBinding.makePropertyTable:
+        -- missing functionContext" -> "Could not create info sections for
+        -- plug-in" -> the whole plug-in was flagged broken and no menu items
+        -- registered. LR already hands over a bindable table.
+        local bindable = _propertyTable
         bindable.host       = prefs.host or "https://studio.lumio-cloud.de"
         bindable.token      = prefs.token or ""
         bindable.testStatus = ""
@@ -56,7 +62,7 @@ return {
 
         return {
             {
-                title = "Lumio Verbindung",
+                title = "Lumio Connection",
                 bind_to_object = bindable,
 
                 f:row {
@@ -85,7 +91,7 @@ return {
                 f:row {
                     f:static_text { title = "", width = 80 },
                     f:push_button {
-                        title = "Verbindung testen",
+                        title = "Test connection",
                         action = function() testConnection(bindable) end,
                     },
                     f:static_text {
@@ -96,7 +102,7 @@ return {
                 f:row {
                     f:static_text { title = "", width = 80 },
                     f:static_text {
-                        title = "Token erzeugen in: Studio → Einstellungen → API-Tokens",
+                        title = "Create a token in: Studio → Settings → API tokens",
                         size = "small",
                     },
                 },


### PR DESCRIPTION
Fixes the Lightroom Classic plug-in, which does not load against a self-hosted instance and, once loaded, fails silently in two ways. Part of #12 — this is the independent piece; the locale work is separate.

Tested end to end against v0.64.0 with Lightroom Classic on macOS and a real catalog (dng 1083, nef 967, jpg 91, tif 7). Rebased onto current `main` (v0.66.3); touches only the six `.lua` files.

### Blocking — the plug-in did not load
- **PluginManager**: `LrBinding.makePropertyTable(_propertyTable.context)` throws because LR does not expose `.context` → *"Could not create info sections for plug-in"* → no menu items register. LR already hands over a bindable table.
- **LumioPublishService**: `viewForCollectionSettings` returned a sections table where LR expects a single view; `getCollectionBehaviorInfo` was missing entirely. Both surface as `attempt to call method 'hierarchyCreated' (a nil value)`.

### Silent data loss — appeared to work, wrote nothing
- **ImportSelectionTask**: a plain `pcall` wrapped the metadata writes, but `photo:getRawMetadata`/`setRawMetadata` yield, so every write failed with *"Yielding is not allowed within a C or metamethod call"* while the summary reported success. My first run said "57 photos updated" and had written nothing. Now `LrTasks.pcall`, with failures counted and logged.
- **ImportSelectionTask**: matching compared the catalog filename *with* extension against the name publishing sends, which is always `<basename>.jpg`, so `int_4325.jpg` could never match `int_4325.nef` — 95.8 % of the test catalog. Now exact name first, then basename, preferring the RAW/DNG/TIF master over an exported JPEG. Ambiguous basename matches are skipped and reported rather than written to all.
- **LumioPublishService**: `recordPublishedPhotoUrl(nil)` failed every photo with *"URL must be a string"*; uploads succeeded but LR never marked them published, so they would re-upload on every publish.

### Robustness
- **LumioApi**: retry with backoff for transient errors, but only for GET and for 429 on POST — `/uploads/init` and `/plugin/galleries` are not idempotent, so blind POST retries risked duplicate galleries and orphan rows. The S3 PUT is retried (idempotent) and now requires an explicit 2xx; a missing status is an error rather than a silent nil.
- **LumioPublishService**: `rendition:uploadFailed()` on both failure paths, and a failing `status=live` PATCH is now visible instead of leaving the gallery a draft with no warning.

The plug-in UI is translated from German to English per the language policy, and the new comments are in English.
