### PR TITLE
fix(mail): localise the layout footer + test the locale helpers

### DIFF
--- a/apps/api/src/services/mail-i18n.test.ts
+++ b/apps/api/src/services/mail-i18n.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the mail locale helpers.
+ *
+ * The formatting assertions guard a class of bug the codebase was carrying:
+ * dates and currency were formatted with `l === "de" ? "de-DE" : "en-GB"`,
+ * repeated in twelve places. That works by accident for exactly two locales
+ * and silently mis-formats every further one, since anything that is not
+ * German falls through to British English. CONTRIBUTING.md forbids hardcoding
+ * a locale identifier in Intl.*; these tests make the ban enforceable instead
+ * of a convention.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  localeTag,
+  normalizeLocale,
+  phrase,
+  interpolate,
+  type MailLocale,
+  type Phrase,
+} from "./mail-i18n.js";
+
+// Kept in sync with MailLocale by the compiler: adding a locale to the type
+// without adding it here makes this array fail to satisfy MailLocale[].
+const LOCALES: MailLocale[] = ["de", "en"];
+
+const LONG_DATE = {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+  timeZone: "UTC",
+} as const;
+
+describe("localeTag", () => {
+  it("returns a BCP-47 tag for every supported locale", () => {
+    for (const l of LOCALES) {
+      expect(localeTag(l)).toMatch(/^[a-z]{2}-[A-Z]{2}$/);
+    }
+  });
+
+  it("gives every locale its own tag", () => {
+    expect(new Set(LOCALES.map(localeTag)).size).toBe(LOCALES.length);
+  });
+
+  it("formats a date in each locale's own convention", () => {
+    const d = new Date(Date.UTC(2026, 8, 30));
+    // German puts a dot after the day number, British English does not.
+    expect(d.toLocaleDateString(localeTag("de"), LONG_DATE)).toContain("30.");
+    expect(d.toLocaleDateString(localeTag("en"), LONG_DATE)).not.toContain(
+      "30."
+    );
+  });
+
+  it("formats currency in each locale's own convention", () => {
+    const eur = { style: "currency", currency: "EUR" } as const;
+    // German uses a decimal comma, English a decimal point.
+    expect((1234.5).toLocaleString(localeTag("de"), eur)).toMatch(/1\D?234,50/);
+    expect((1234.5).toLocaleString(localeTag("en"), eur)).toMatch(/1,234\.50/);
+  });
+});
+
+describe("normalizeLocale", () => {
+  it("accepts a bare locale", () => {
+    for (const l of LOCALES) expect(normalizeLocale(l)).toBe(l);
+  });
+
+  it("accepts a regional variant and strips the region", () => {
+    expect(normalizeLocale("de-AT")).toBe("de");
+    expect(normalizeLocale("de_CH")).toBe("de");
+    expect(normalizeLocale("EN-GB")).toBe("en");
+  });
+
+  it("falls back for unknown or missing values", () => {
+    const fallback = normalizeLocale(null);
+    expect(LOCALES).toContain(fallback);
+    expect(normalizeLocale("xx")).toBe(fallback);
+    expect(normalizeLocale("")).toBe(fallback);
+    expect(normalizeLocale(undefined)).toBe(fallback);
+  });
+});
+
+describe("phrase / interpolate", () => {
+  const p: Phrase = {
+    de: "Hallo {name}, {count} Bilder",
+    en: "Hello {name}, {count} photos",
+  };
+
+  it("returns the text for the requested locale", () => {
+    expect(phrase(p, "de", { name: "Anna", count: 3 })).toBe(
+      "Hallo Anna, 3 Bilder"
+    );
+  });
+
+  it("carries the same placeholders in every locale", () => {
+    const names = (s: string) => (s.match(/\{(\w+)\}/g) ?? []).sort();
+    const ref = names(p.en);
+    for (const l of LOCALES) expect(names(p[l])).toEqual(ref);
+  });
+
+  it("leaves an unknown placeholder untouched instead of printing undefined", () => {
+    expect(interpolate("Hi {name}, {missing}", { name: "X" })).toBe(
+      "Hi X, {missing}"
+    );
+  });
+
+  it("returns the template unchanged when no vars are given", () => {
+    expect(interpolate("no vars here")).toBe("no vars here");
+  });
+});

--- a/apps/api/src/services/mail-layout.ts
+++ b/apps/api/src/services/mail-layout.ts
@@ -38,6 +38,12 @@
  */
 
 import { config } from "../config.js";
+import {
+  instanceMailLocale,
+  phrase,
+  type MailLocale,
+  type Phrase,
+} from "./mail-i18n.js";
 
 const LUMIO_BRAND_COLOR = "#FF4D2E"; // Vermillion, wie die Bildmarke
 
@@ -86,6 +92,18 @@ export interface MailBranding {
   headerStyle?: "line" | "banner" | null;
 }
 
+/**
+ * The one line of layout chrome not supplied by the caller. It follows the
+ * recipient's language like the rest of the mail, so it is a Phrase and the
+ * type demands a translation per locale. {link} wraps the product name.
+ */
+const layoutPhrases = {
+  sentVia: {
+    de: "Verschickt von {link}",
+    en: "Sent via {link}",
+  },
+} satisfies Record<string, Phrase>;
+
 export interface RenderMailOpts {
   /** Inhalt des Mail-Body als HTML-Fragmente (z.B. aus mailParagraph()) */
   bodyHtml: string;
@@ -94,6 +112,8 @@ export interface RenderMailOpts {
   /** Optional: Praeheader-Text — wird in Inbox-Preview unter dem Subject
    *  angezeigt. Wirkt subtil aber sehr stark auf Open-Rates. */
   preheader?: string;
+  /** Recipient language; defaults to the instance locale. */
+  locale?: MailLocale;
 }
 
 /**
@@ -107,6 +127,13 @@ export function renderMailLayout(opts: RenderMailOpts): string {
   const logoUrl = opts.branding?.logoUrl;
   const footerNote = opts.branding?.footerNote;
   const preheader = opts.preheader ?? "";
+  const locale = opts.locale ?? instanceMailLocale();
+  const lumioLink =
+    `<a href="https://github.com/markusthiel/lumio" ` +
+    `style="color:${LUMIO_MUTED_COLOR};text-decoration:underline;">Lumio</a>`;
+  const sentViaHtml = phrase(layoutPhrases.sentVia, locale, {
+    link: lumioLink,
+  });
 
   // Zwei Achsen mit Fallback-Kette auf den (deprecated) logoAlign.
   const logoPosition: "left" | "right" | "center" | "footer" =
@@ -193,7 +220,7 @@ ${escapeHtml(preheader)}
             ${footerLogoHtml}
             ${footerHtml}
             <p style="margin:0;color:${LUMIO_MUTED_COLOR};font-size:12px;line-height:1.5;">
-              Verschickt von <a href="https://lumio-cloud.de" style="color:${LUMIO_MUTED_COLOR};text-decoration:underline;">Lumio</a> — Foto-Galerien für Profis, gehostet in Deutschland.
+              ${sentViaHtml}
             </p>
           </td>
         </tr>


### PR DESCRIPTION
The remaining piece of #12 after your v0.66.3–v0.67 work: the mail-layout footer, and tests for the locale helpers. The three drift fixes are all upstream now, so this is only those two. Rebased onto current `main` (v0.69.0); touches `mail-layout.ts` and adds `mail-i18n.test.ts`, nothing else.

### Footer
It was hardcoded German and claimed the service is *"gehostet in Deutschland"*, which is untrue on a self-hosted instance. It is now a `Phrase` and follows the recipient's locale, so the type demands a translation per mail locale. `RenderMailOpts` gains an optional `locale`; callers that resolved one pass it, otherwise the instance default applies — no change for existing deployments. The link points at the repository rather than `lumio-cloud.de`, per your call in #12.

Renders as:
- `de` — `Verschickt von <a …>Lumio</a>`
- `en` — `Sent via <a …>Lumio</a>`

### Tests
Eleven tests for `localeTag`, `normalizeLocale`, `phrase` and `interpolate` — there were none. The formatting assertions guard the regression from #12: with a hardcoded `de-DE : en-GB` ternary, any non-German locale silently formatted as British English. Each locale is asserted to have its own BCP-47 tag and to format dates and currency in its own convention, so the rule against hardcoded locale identifiers becomes something the suite enforces rather than a line in the docs.

Verified against v0.69.0: `tsc --noEmit` clean, all 11 tests pass.
