### PR TITLE
fix(mail): translate the layout footer and correct its self-hosted claim

### DIFF
--- a/apps/api/src/routes/broadcasts.ts
+++ b/apps/api/src/routes/broadcasts.ts
@@ -26,6 +26,7 @@ import {
   type Audience,
 } from "../services/broadcast.js";
 import { sendMail } from "../services/mail.js";
+import { instanceMailLocale } from "../services/mail-i18n.js";
 import { config } from "../config.js";
 
 const audienceSchema = z.enum([
@@ -143,7 +144,8 @@ export async function registerBroadcastRoutes(app: FastifyInstance) {
     // wird in processBroadcast() pro Empfaenger frisch gerendert.
     const archivalHtml = renderBroadcastHtml(
       body.bodyMarkdown,
-      "{{UNSUBSCRIBE_URL}}"
+      "{{UNSUBSCRIBE_URL}}",
+      instanceMailLocale()
     );
 
     const row = await prisma.broadcast.create({
@@ -197,7 +199,13 @@ export async function registerBroadcastRoutes(app: FastifyInstance) {
     req.requireSuperAdmin();
     const body = previewSchema.parse(req.body);
     const exampleUnsubUrl = `${config.PUBLIC_URL.replace(/\/+$/, "")}/broadcasts/unsubscribe?t=example`;
-    return { html: renderBroadcastHtml(body.bodyMarkdown, exampleUnsubUrl) };
+    return {
+      html: renderBroadcastHtml(
+        body.bodyMarkdown,
+        exampleUnsubUrl,
+        instanceMailLocale()
+      ),
+    };
   });
 
   // -------------------------------------------------------------------------
@@ -214,7 +222,11 @@ export async function registerBroadcastRoutes(app: FastifyInstance) {
     const body = testSendSchema.parse(req.body);
 
     const dummyUnsub = `${config.PUBLIC_URL.replace(/\/+$/, "")}/broadcasts/unsubscribe?t=test-only-no-effect`;
-    const html = renderBroadcastHtml(body.bodyMarkdown, dummyUnsub);
+    const html = renderBroadcastHtml(
+      body.bodyMarkdown,
+      dummyUnsub,
+      instanceMailLocale()
+    );
 
     await sendMail({
       to: sa.admin.email,

--- a/apps/api/src/routes/super-tenants.ts
+++ b/apps/api/src/routes/super-tenants.ts
@@ -1611,7 +1611,7 @@ export async function registerSuperTenantRoutes(app: FastifyInstance) {
         to: user.email,
         subject: body.subject,
         text: body.body,
-        html: renderAdminMessageHtml(body.body),
+        html: renderAdminMessageHtml(body.body, await userMailLocale(user.id)),
       });
 
       await logEvent({

--- a/apps/api/src/services/broadcast.ts
+++ b/apps/api/src/services/broadcast.ts
@@ -33,6 +33,11 @@ import { logger } from "../logger.js";
 import { config } from "../config.js";
 import { sendMail } from "./mail.js";
 import { renderMailLayout } from "./mail-layout.js";
+import {
+  normalizeLocale,
+  instanceMailLocale,
+  type MailLocale,
+} from "./mail-i18n.js";
 
 export type Audience =
   | "all_paid_owners"
@@ -52,10 +57,14 @@ export const AUDIENCE_LABELS: Record<Audience, string> = {
  *  = 5 Mails/Sekunde = 18000/Stunde. Mehr als genug fuer Lumio. */
 const SEND_INTERVAL_MS = 200;
 
-/** Markdown zu HTML konvertieren und ins Standard-Mail-Layout einbetten. */
+/** Markdown zu HTML konvertieren und ins Standard-Mail-Layout einbetten.
+ *  bodyMarkdown selbst bleibt unuebersetzt (vom Admin frei getippt, siehe
+ *  INLINE_ALLOWED in check-mail-i18n.mjs) — locale steuert nur Layout-
+ *  Footer und lang-Attribut. */
 export function renderBroadcastHtml(
   bodyMarkdown: string,
-  unsubscribeUrl: string
+  unsubscribeUrl: string,
+  locale: MailLocale
 ): string {
   // marked.parse ist synchron wenn kein async-Renderer registriert ist.
   // Wir nutzen die default options + ein paar Security-Settings.
@@ -74,6 +83,7 @@ export function renderBroadcastHtml(
   return renderMailLayout({
     bodyHtml: inner + footerHtml,
     preheader: extractPreheader(bodyMarkdown),
+    locale,
   });
 }
 
@@ -82,7 +92,10 @@ export function renderBroadcastHtml(
  * Wie renderBroadcastHtml, aber OHNE Abmelde-Footer — das ist kein Bulk-
  * Marketing, sondern eine persönliche/operative Nachricht.
  */
-export function renderAdminMessageHtml(bodyMarkdown: string): string {
+export function renderAdminMessageHtml(
+  bodyMarkdown: string,
+  locale: MailLocale
+): string {
   const inner = marked.parse(bodyMarkdown, {
     async: false,
     gfm: true,
@@ -91,6 +104,7 @@ export function renderAdminMessageHtml(bodyMarkdown: string): string {
   return renderMailLayout({
     bodyHtml: inner,
     preheader: extractPreheader(bodyMarkdown),
+    locale,
   });
 }
 
@@ -111,10 +125,14 @@ function escapeAttr(s: string): string {
 }
 
 /** Empfaenger fuer eine Audience zusammenstellen. */
-export async function listAudienceUsers(
-  audience: Audience
-): Promise<
-  Array<{ id: string; email: string; name: string | null; tenantId: string }>
+export async function listAudienceUsers(audience: Audience): Promise<
+  Array<{
+    id: string;
+    email: string;
+    name: string | null;
+    tenantId: string;
+    locale: string | null;
+  }>
 > {
   // Basis: aktive User in aktiven Tenants. Wir filtern OptOut WEG bevor
   // der Versand startet — Count-Anzeige im Frontend zeigt 'X gesendet,
@@ -128,7 +146,13 @@ export async function listAudienceUsers(
     case "all_owners":
       return prisma.user.findMany({
         where: { ...baseWhere, role: "owner" },
-        select: { id: true, email: true, name: true, tenantId: true },
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          tenantId: true,
+          locale: true,
+        },
       });
     case "all_paid_owners":
       return prisma.user.findMany({
@@ -142,7 +166,13 @@ export async function listAudienceUsers(
             },
           },
         },
-        select: { id: true, email: true, name: true, tenantId: true },
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          tenantId: true,
+          locale: true,
+        },
       });
     case "all_trial_owners":
       return prisma.user.findMany({
@@ -154,12 +184,24 @@ export async function listAudienceUsers(
             subscription: { status: "trialing" },
           },
         },
-        select: { id: true, email: true, name: true, tenantId: true },
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          tenantId: true,
+          locale: true,
+        },
       });
     case "all_active_users":
       return prisma.user.findMany({
         where: baseWhere,
-        select: { id: true, email: true, name: true, tenantId: true },
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          tenantId: true,
+          locale: true,
+        },
       });
   }
 }
@@ -235,7 +277,8 @@ export async function processBroadcast(broadcastId: string): Promise<void> {
       const token = await ensureOptOutToken(r.id);
       const html = renderBroadcastHtml(
         broadcast.bodyMarkdown,
-        unsubscribeUrl(token)
+        unsubscribeUrl(token),
+        normalizeLocale(r.locale)
       );
       const plainFooter = `\n\n—\nDu kannst diese Mails hier abbestellen:\n${unsubscribeUrl(token)}`;
 

--- a/apps/api/src/services/mail-i18n.test.ts
+++ b/apps/api/src/services/mail-i18n.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the locale helpers in mail-i18n.ts — localeTag() and
+ * normalizeLocale() are pure functions, tested directly per the
+ * project's convention (see tags.test.ts): DB-touching helpers
+ * (tenantMailLocale, userMailLocale) are thin prisma wrappers around
+ * normalizeLocale and are left to integration/manual testing.
+ *
+ * Added per Issue #12: these helpers broke twice in two days with no
+ * test coverage at all — the maintainer's own words after fixing the
+ * locale-drift and hardcoded-ternary bugs.
+ */
+import { describe, it, expect } from "vitest";
+import { localeTag, normalizeLocale } from "./mail-i18n.js";
+
+describe("localeTag", () => {
+  it("maps de to de-DE", () => {
+    expect(localeTag("de")).toBe("de-DE");
+  });
+
+  it("maps en to en-GB", () => {
+    expect(localeTag("en")).toBe("en-GB");
+  });
+});
+
+describe("normalizeLocale", () => {
+  it("passes through a known locale unchanged", () => {
+    expect(normalizeLocale("de")).toBe("de");
+    expect(normalizeLocale("en")).toBe("en");
+  });
+
+  it("strips a region subtag (de-DE -> de, en-US -> en)", () => {
+    expect(normalizeLocale("de-DE")).toBe("de");
+    expect(normalizeLocale("en-US")).toBe("en");
+  });
+
+  it("accepts an underscore-separated tag (de_DE -> de)", () => {
+    expect(normalizeLocale("de_DE")).toBe("de");
+  });
+
+  it("is case-insensitive", () => {
+    expect(normalizeLocale("DE")).toBe("de");
+    expect(normalizeLocale("En-GB")).toBe("en");
+  });
+
+  it("falls back to the instance default for an unsupported locale", () => {
+    // "it" and "fi" are real UI/candidate locales that MAIL_LOCALES does
+    // not (yet) cover — this is the exact gap Issue #12 flagged, so the
+    // fallback path matters more here than for a nonsense string.
+    expect(normalizeLocale("it")).toBe("de");
+    expect(normalizeLocale("fi")).toBe("de");
+  });
+
+  it("falls back to the instance default for garbage input", () => {
+    expect(normalizeLocale("xx-yy")).toBe("de");
+  });
+
+  it("falls back to the instance default for null", () => {
+    expect(normalizeLocale(null)).toBe("de");
+  });
+
+  it("falls back to the instance default for undefined", () => {
+    expect(normalizeLocale(undefined)).toBe("de");
+  });
+
+  it("falls back to the instance default for an empty string", () => {
+    expect(normalizeLocale("")).toBe("de");
+  });
+});

--- a/apps/api/src/services/mail-layout.ts
+++ b/apps/api/src/services/mail-layout.ts
@@ -38,8 +38,16 @@
  */
 
 import { config } from "../config.js";
+import { phrase, type MailLocale, type Phrase } from "./mail-i18n.js";
 
 const LUMIO_BRAND_COLOR = "#FF4D2E"; // Vermillion, wie die Bildmarke
+
+// Ziel des "Verschickt von Lumio"-Links im Footer. Frueher lumio-cloud.de,
+// das gehostete Produkt — auf einer selbst betriebenen Instanz bewirbt das
+// den Betreiber der eigenen Instanz nicht sinnvoll (Issue #12). Das
+// Repository passt fuer Self-Hoster wie fuer die gehostete Variante gleich
+// gut.
+const LUMIO_REPO_URL = "https://github.com/markusthiel/lumio";
 
 // Die Bildmarke als PNG. SVG faellt aus: Gmail und Outlook rendern es
 // nicht. Die Dateien liegen im Frontend unter /public und sind damit
@@ -56,6 +64,15 @@ const LUMIO_TEXT_COLOR = "#1f2937"; // gray-800
 const LUMIO_MUTED_COLOR = "#6b7280"; // gray-500
 const LUMIO_BORDER_COLOR = "#e5e7eb"; // gray-200
 const LUMIO_BG_COLOR = "#f6f7f9";
+
+// Fixzeile im Footer jeder Mail. War frueher ein deutsches Literal, das
+// unabhaengig von der Empfaenger-Sprache erschien (Issue #12) — inklusive
+// der Behauptung "gehostet in Deutschland", die fuer eine selbst betriebene
+// Instanz schlicht falsch ist. Jetzt eine Phrase wie jeder andere Text.
+const footerBrandPhrase: Phrase = {
+  de: `Verschickt von <a href="${LUMIO_REPO_URL}" style="color:${LUMIO_MUTED_COLOR};text-decoration:underline;">Lumio</a> — Foto-Galerien für Profis.`,
+  en: `Sent by <a href="${LUMIO_REPO_URL}" style="color:${LUMIO_MUTED_COLOR};text-decoration:underline;">Lumio</a> — photo galleries for professionals.`,
+};
 
 const FONT_STACK =
   "-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
@@ -94,6 +111,10 @@ export interface RenderMailOpts {
   /** Optional: Praeheader-Text — wird in Inbox-Preview unter dem Subject
    *  angezeigt. Wirkt subtil aber sehr stark auf Open-Rates. */
   preheader?: string;
+  /** Sprache dieser Mail — steuert den Footer-Text und das lang-Attribut.
+   *  Bewusst Pflichtfeld statt Default: ein vergessenes Feld soll ein
+   *  Typfehler sein, kein still falsches Deutsch (Issue #12). */
+  locale: MailLocale;
 }
 
 /**
@@ -164,7 +185,7 @@ export function renderMailLayout(opts: RenderMailOpts): string {
     : "";
 
   return `<!doctype html>
-<html lang="de">
+<html lang="${opts.locale}">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -193,7 +214,7 @@ ${escapeHtml(preheader)}
             ${footerLogoHtml}
             ${footerHtml}
             <p style="margin:0;color:${LUMIO_MUTED_COLOR};font-size:12px;line-height:1.5;">
-              Verschickt von <a href="https://lumio-cloud.de" style="color:${LUMIO_MUTED_COLOR};text-decoration:underline;">Lumio</a> — Foto-Galerien für Profis, gehostet in Deutschland.
+              ${phrase(footerBrandPhrase, opts.locale)}
             </p>
           </td>
         </tr>

--- a/apps/api/src/services/mail-print.ts
+++ b/apps/api/src/services/mail-print.ts
@@ -251,6 +251,7 @@ ${phrase(P.regards, l)}
 ${studioName}`;
 
   const html = renderMailLayout({
+    locale: l,
     branding,
     bodyHtml: `
   <p>${escapeHtml(phrase(P.greeting, l, vars))}</p>
@@ -324,6 +325,7 @@ ${phrase(S.openOrder, l)}
 ${orderUrl}`;
 
   const html = renderMailLayout({
+    locale: l,
     branding,
     bodyHtml: `
   <p>${escapeHtml(phrase(S.intro, l))}</p>
@@ -392,6 +394,7 @@ ${studioName}
 ${printSupport(supportEmail) ? phrase(P.questions, l, { contact: printSupport(supportEmail)! }) : ""}`;
 
   const html = renderMailLayout({
+    locale: l,
     branding,
     bodyHtml: `
   <p>${escapeHtml(phrase(P.greeting, l, vars))}</p>

--- a/apps/api/src/services/mail.ts
+++ b/apps/api/src/services/mail.ts
@@ -291,6 +291,7 @@ export function tmplNewComment(opts: {
       `${phrase(common.viewGallery, l)}: ${opts.galleryUrl}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       branding: opts.branding,
       preheader: phrase(newCommentPhrases.preheader, l, vars),
       bodyHtml:
@@ -348,6 +349,7 @@ export function tmplSelectionFinished(opts: {
       `${phrase(common.viewGallery, l)}: ${opts.galleryUrl}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       branding: opts.branding,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
@@ -412,6 +414,7 @@ export function tmplZipReady(opts: {
       `${phrase(zipReadyPhrases.validity, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       branding: opts.branding,
       preheader: phrase(zipReadyPhrases.preheader, l, vars),
       bodyHtml:
@@ -474,6 +477,7 @@ export function tmplStorageWarning(opts: {
       `${phrase(P.consequence, l)}\n\n` +
       `${opts.billingUrl}\n\n${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       branding: opts.branding,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
@@ -535,6 +539,7 @@ export function tmplOwnerSetup(opts: {
       `${phrase(P.validity, l, vars)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.greeting, l, vars)) +
@@ -612,6 +617,7 @@ export function tmplPasswordReset(opts: {
       `${phrase(P.notYou, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.greeting, l, vars)) +
@@ -686,6 +692,7 @@ export function tmplEmailChangeConfirm(opts: {
       `${phrase(P.notYou, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.greeting, l, vars)) +
@@ -754,6 +761,7 @@ export function tmplEmailChangeNotice(opts: {
       `${phrase(P.ifNotYouText, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.greeting, l, vars)) +
@@ -877,6 +885,7 @@ export function tmplGalleryInvite(opts: {
       `\n` +
       `${phrase(galleryInvitePhrases.sentVia, l)}`,
     html: renderMailLayout({
+      locale: l,
       branding: {
         ...(opts.branding ?? {}),
         brandName: opts.studioName,
@@ -972,6 +981,7 @@ export function tmplWelcome(opts: {
       (supportHint() ? `${supportHint()}\n\n` : "") +
       `${phrase(P.seeYouSoon, l)}\n${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -1089,6 +1099,7 @@ export function tmplDeletionRequested(opts: {
       `${urgentSupportHint(phrase(P.notRequested, l))}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -1168,6 +1179,7 @@ export function tmplDeletionCancelled(opts: {
       `${phrase(P.billingText, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -1285,6 +1297,7 @@ export function tmplDeletionExecuted(opts: {
         : "") +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -1368,6 +1381,7 @@ export function tmplDeletionReminder(opts: {
       `${phrase(P.irreversible, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -1467,6 +1481,7 @@ export function tmplBillingArchived(opts: {
       `${phrase(P.reactivateLine, l)}\n${opts.reactivateUrl}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -1543,6 +1558,7 @@ export function tmplBillingPurgeReminder(opts: {
       `${phrase(P.noRestoreText, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -1599,6 +1615,7 @@ export function tmplSuperNewTenant(opts: {
       `\n\n${phrase(P.superAdmin, l)}: ${opts.superUrl}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -1695,6 +1712,7 @@ export function tmplSuperDigest(opts: {
     subject: phrase(P.subject, l, { date: opts.dateLabel, n: newCount }),
     text: textParts.join("\n"),
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, {
         n: newCount,
         gib: opts.totalStorageGib,
@@ -1750,6 +1768,7 @@ export function tmplTeamMemberJoined(opts: {
       `${phrase(P.button, l)}: ${opts.teamUrl}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       branding: opts.branding,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
@@ -1804,6 +1823,7 @@ export function tmplGalleryExpiring(opts: {
       `${phrase(common.openGallery, l)}: ${opts.galleryUrl}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       branding: opts.branding,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
@@ -1853,6 +1873,7 @@ export function tmplUploadReceived(opts: {
       `${phrase(common.openGallery, l)}: ${opts.galleryUrl}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       branding: opts.branding,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
@@ -1970,6 +1991,7 @@ export function tmplTrialReminder(opts: {
       `${phrase(common.signature, l)}\n\n` +
       `---\n${phrase(P.unsubText, l)} ${opts.unsubscribeUrl}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(greeting) +
@@ -2056,6 +2078,7 @@ export function tmplTrialCancelled(opts: {
       `${phrase(common.signature, l)}\n\n` +
       `---\n${phrase(P.unsubText, l)} ${opts.unsubscribeUrl}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(greeting) +
@@ -2151,6 +2174,7 @@ export function tmplWinback(opts: {
       `${phrase(common.signature, l)}\n\n` +
       `---\n${phrase(P.unsubText, l)} ${opts.unsubscribeUrl}`,
     html: renderMailLayout({
+      locale: l,
       preheader: isChurn
         ? phrase(P.preheaderChurn, l)
         : phrase(P.preheaderExpired, l),
@@ -2235,6 +2259,11 @@ export function tmplSupportRequest(
       facts.map((f) => `  ${f}`).join("\n") +
       `\n\nNachricht:\n${ctx.message}\n`,
     html: renderMailLayout({
+      // Interne Mail ans Lumio-Support-Team, kein Recipient mit eigener
+      // Sprachwahl — der Body oben ist durchgehend Deutsch und nicht Teil
+      // des Phrase-Systems. locale spiegelt das ehrlich statt eine
+      // Instance-Locale zu behaupten, die der Text nicht einloest.
+      locale: "de",
       preheader: `${who} — ${ctx.message.slice(0, 80)}`,
       bodyHtml:
         mailHeading(`Support-Anfrage`) +
@@ -2324,6 +2353,7 @@ export function tmplImpersonationNotice(opts: {
       `${phrase(P.notRequested, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -2448,6 +2478,7 @@ export function tmplPreArchiveNotice(opts: {
         `${phrase(P.reminderQuestions, l)}\n\n` +
         `${phrase(common.signature, l)}`,
       html: renderMailLayout({
+        locale: l,
         preheader: phrase(P.reminderPreheader, l, vars),
         bodyHtml:
           mailHeading(phrase(P.reminderHeading, l)) +
@@ -2471,6 +2502,7 @@ export function tmplPreArchiveNotice(opts: {
       `${phrase(P.reminderAnnounce, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.noticePreheader, l, vars),
       bodyHtml:
         mailHeading(phrase(P.noticeHeading, l)) +
@@ -2537,6 +2569,7 @@ export function tmplExportReady(opts: {
       `${phrase(P.questions, l)}\n\n` +
       `${phrase(common.signature, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +
@@ -2567,6 +2600,7 @@ export function tmplSupportRequestConfirmation(opts: {
       `${opts.message}\n\n` +
       `${phrase(P.team, l)}`,
     html: renderMailLayout({
+      locale: l,
       preheader: phrase(P.preheader, l),
       bodyHtml:
         mailHeading(phrase(P.heading, l)) +


### PR DESCRIPTION
## Summary

- The mail footer ("Verschickt von Lumio ... gehostet in Deutschland") was a raw German literal in `mail-layout.ts`, appearing on every outgoing email regardless of the recipient's locale — the last hardcoded string in an otherwise fully templated mail layer. It also claimed the service is hosted in Germany (false for a self-hosted instance) and linked to `lumio-cloud.de` instead of the project.
- Turned the footer into a `Phrase` (de/en, matching `MAIL_LOCALES`), pointed the link at the repository, dropped the hosting claim, and made `<html lang>` follow the actual locale instead of always `"de"`.
- `RenderMailOpts.locale` is now required, so a future template can't omit it silently. All 33 `renderMailLayout()` call sites across `mail.ts`, `mail-print.ts` and `broadcast.ts` now pass their resolved locale — from the recipient where one exists (broadcast audience members via `User.locale`, the direct admin-to-user email), and from the instance default where there is no specific recipient (broadcast preview/test-send/archival) or the content is inherently untranslated internal tooling (the support-request notification to the Lumio team, now explicitly `locale: "de"` with a comment explaining why).
- Added the locale-helper unit tests flagged as missing in #12 — `localeTag()` and `normalizeLocale()` had no coverage at all, which is how they broke twice in two days per the issue thread.

Refs #12 — this was the "PR 2" footer + tests work still open after the locale-drift fixes landed.

## Test plan

- [x] `npx tsc --noEmit` clean in `apps/api` and `apps/frontend`
- [x] `node apps/api/scripts/check-mail-i18n.mjs` — passes
- [x] `node apps/frontend/scripts/check-i18n.mjs` — passes
- [x] `npx vitest run` in `apps/api` — 170/170 tests pass (11 new)