### PR TITLE
feat(mail): extend MAIL_LOCALES with Italian

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ These stay German-first, on purpose:
   of a studio, not the studio operator, so their language follows the studio
   rather than our default. That is now implemented: `mail-i18n.ts` resolves
   `Tenant.locale` for customer mail and `User.locale` for team mail, and every
-  template carries a `de`/`en` pair. What stays deliberate is that
+  template carries a `de`/`en`/`it` set. What stays deliberate is that
   `DEFAULT_MAIL_LOCALE` defaults to `de`, so an instance that sets nothing
   keeps writing German.
 

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -99,7 +99,10 @@ const envSchema = z.object({
   // Cookie des jeweiligen Browsers und wird hiervon nicht beeinflusst.
   // Optional mit Default, also kein Breaking Change fuer Self-Hoster:
   // ohne Eintrag bleibt alles auf Deutsch wie bisher.
-  DEFAULT_MAIL_LOCALE: z.enum(["de", "en"]).default("de"),
+  // Literal-Liste statt Import aus mail-i18n.ts (das wuerde config.ts
+  // <-> mail-i18n.ts zirkulaer machen, mail-i18n.ts importiert config
+  // bereits) — MUSS mit MAIL_LOCALES dort synchron gehalten werden.
+  DEFAULT_MAIL_LOCALE: z.enum(["de", "en", "it"]).default("de"),
 
   /**
    * Fusszeile der Mails: "Verschickt von Lumio".

--- a/apps/api/src/services/mail-footer.render.test.ts
+++ b/apps/api/src/services/mail-footer.render.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MAIL_LOCALES } from "./mail-i18n.js";
 
 /**
  * Prueft die gerenderte Fusszeile, nicht nur die Helfer darunter. Der Fehler,
@@ -28,11 +29,14 @@ describe("mail footer rendering", () => {
       "Verschickt von"
     );
     expect(render({ bodyHtml: "<p>x</p>", locale: "en" })).toContain("Sent via");
+    expect(render({ bodyHtml: "<p>x</p>", locale: "it" })).toContain(
+      "Inviato tramite"
+    );
   });
 
   it("no longer claims German hosting", async () => {
     const render = await load();
-    for (const locale of ["de", "en"] as const) {
+    for (const locale of MAIL_LOCALES) {
       const html = render({ bodyHtml: "<p>x</p>", locale });
       expect(html).not.toContain("gehostet in Deutschland");
       expect(html).not.toContain("lumio-cloud.de");

--- a/apps/api/src/services/mail-i18n.test.ts
+++ b/apps/api/src/services/mail-i18n.test.ts
@@ -15,13 +15,16 @@ import {
   normalizeLocale,
   phrase,
   interpolate,
+  MAIL_LOCALES,
   type MailLocale,
   type Phrase,
 } from "./mail-i18n.js";
 
-// Kept in sync with MailLocale by the compiler: adding a locale to the type
-// without adding it here makes this array fail to satisfy MailLocale[].
-const LOCALES: MailLocale[] = ["de", "en"];
+// MAIL_LOCALES itself, not a re-typed literal. A manually kept-in-sync array
+// only "fails to satisfy MailLocale[]" in a comment, never in the compiler:
+// a plain MailLocale[] happily accepts any subset of the union, which is how
+// this stayed at two locales silently after "it" was added to the type.
+const LOCALES: readonly MailLocale[] = MAIL_LOCALES;
 
 const LONG_DATE = {
   day: "2-digit",
@@ -82,6 +85,7 @@ describe("phrase / interpolate", () => {
   const p: Phrase = {
     de: "Hallo {name}, {count} Bilder",
     en: "Hello {name}, {count} photos",
+    it: "Ciao {name}, {count} foto",
   };
 
   it("returns the text for the requested locale", () => {
@@ -126,7 +130,11 @@ describe("mail footer configuration", () => {
   });
 
   it("translates the default footer per locale", () => {
-    const sentVia: Phrase = { de: "Verschickt von {link}", en: "Sent via {link}" };
+    const sentVia: Phrase = {
+      de: "Verschickt von {link}",
+      en: "Sent via {link}",
+      it: "Inviato tramite {link}",
+    };
     for (const l of LOCALES) {
       const out = phrase(sentVia, l, { link: "L" });
       expect(out).toContain("L");

--- a/apps/api/src/services/mail-i18n.ts
+++ b/apps/api/src/services/mail-i18n.ts
@@ -41,7 +41,7 @@ import { logger } from "../logger.js";
  * nicht uebersetzten Template zu. Das ist Absicht — eine halb uebersetzte
  * Mail ist schlimmer als eine, die ehrlich in der Default-Sprache kommt.
  */
-export const MAIL_LOCALES = ["de", "en"] as const;
+export const MAIL_LOCALES = ["de", "en", "it"] as const;
 
 export type MailLocale = (typeof MAIL_LOCALES)[number];
 
@@ -59,6 +59,7 @@ export function localeTag(locale: MailLocale): string {
   const TAGS: Record<MailLocale, string> = {
     de: "de-DE",
     en: "en-GB",
+    it: "it-IT",
   };
   return TAGS[locale];
 }
@@ -149,7 +150,15 @@ export function phrase(
  * Lesen nicht suchen muss.
  */
 export const common = {
-  signature: { de: "— Lumio", en: "— Lumio" },
-  openGallery: { de: "Galerie öffnen", en: "Open gallery" },
-  viewGallery: { de: "Galerie ansehen", en: "View gallery" },
+  signature: { de: "— Lumio", en: "— Lumio", it: "— Lumio" },
+  openGallery: {
+    de: "Galerie öffnen",
+    en: "Open gallery",
+    it: "Apri galleria",
+  },
+  viewGallery: {
+    de: "Galerie ansehen",
+    en: "View gallery",
+    it: "Visualizza galleria",
+  },
 } satisfies Record<string, Phrase>;

--- a/apps/api/src/services/mail-layout.ts
+++ b/apps/api/src/services/mail-layout.ts
@@ -113,6 +113,7 @@ const layoutPhrases = {
   sentVia: {
     de: "Verschickt von {link}",
     en: "Sent via {link}",
+    it: "Inviato tramite {link}",
   },
 } satisfies Record<string, Phrase>;
 

--- a/apps/api/src/services/mail-print.ts
+++ b/apps/api/src/services/mail-print.ts
@@ -144,44 +144,79 @@ const printGuestPhrases = {
   confirmSubject: {
     de: "Deine Bestellung {order} bei {studio}",
     en: "Your order {order} with {studio}",
+    it: "Il tuo ordine {order} presso {studio}",
   },
-  greeting: { de: "Hallo {name},", en: "Hello {name}," },
+  greeting: {
+    de: "Hallo {name},",
+    en: "Hello {name},",
+    it: "Ciao {name},",
+  },
   thanks: {
     de: "vielen Dank für deine Bestellung bei {studio}.",
     en: "thank you for your order with {studio}.",
+    it: "grazie per il tuo ordine presso {studio}.",
   },
-  orderNumber: { de: "Bestellnummer", en: "Order number" },
-  items: { de: "Artikel", en: "Items" },
-  subtotal: { de: "Zwischensumme", en: "Subtotal" },
-  shipping: { de: "Versand", en: "Shipping" },
-  tax: { de: "MwSt", en: "VAT" },
-  total: { de: "Gesamtsumme", en: "Total" },
-  deliveryAddress: { de: "Lieferadresse", en: "Delivery address" },
+  orderNumber: {
+    de: "Bestellnummer",
+    en: "Order number",
+    it: "Numero d'ordine",
+  },
+  items: { de: "Artikel", en: "Items", it: "Articoli" },
+  subtotal: { de: "Zwischensumme", en: "Subtotal", it: "Subtotale" },
+  shipping: { de: "Versand", en: "Shipping", it: "Spedizione" },
+  tax: { de: "MwSt", en: "VAT", it: "IVA" },
+  total: { de: "Gesamtsumme", en: "Total", it: "Totale" },
+  deliveryAddress: {
+    de: "Lieferadresse",
+    en: "Delivery address",
+    it: "Indirizzo di consegna",
+  },
   offlineInvoice: {
     de: "Du bekommst von {studio} in Kürze eine Rechnung. Sobald die Zahlung eingeht, wird deine Bestellung produziert und verschickt.",
     en: "{studio} will send you an invoice shortly. Once payment arrives, your order goes into production and ships.",
+    it: "Riceverai a breve una fattura da {studio}. Non appena arriva il pagamento, il tuo ordine va in produzione e viene spedito.",
   },
   inProduction: {
     de: "Wir bereiten deine Bestellung jetzt zur Produktion vor. Du bekommst eine weitere Mail sobald sie versendet wird.",
     en: "We are preparing your order for production now. You will get another email once it ships.",
+    it: "Stiamo preparando il tuo ordine per la produzione. Riceverai un'altra email non appena verrà spedito.",
   },
-  questions: { de: "Bei Fragen: {contact}", en: "Questions? {contact}" },
-  questionsLabel: { de: "Bei Fragen:", en: "Questions?" },
+  questions: {
+    de: "Bei Fragen: {contact}",
+    en: "Questions? {contact}",
+    it: "Domande? {contact}",
+  },
+  questionsLabel: {
+    de: "Bei Fragen:",
+    en: "Questions?",
+    it: "Domande?",
+  },
   shippedSubject: {
     de: "Deine Bestellung {order} ist auf dem Weg",
     en: "Your order {order} is on its way",
+    it: "Il tuo ordine {order} è in arrivo",
   },
   shippedBody: {
     de: "deine Bestellung {order} ist auf dem Weg zu dir.",
     en: "your order {order} is on its way to you.",
+    it: "il tuo ordine {order} è in arrivo.",
   },
-  tracking: { de: "Sendungsverfolgung:", en: "Tracking:" },
-  trackPackage: { de: "Paket verfolgen", en: "Track package" },
+  tracking: {
+    de: "Sendungsverfolgung:",
+    en: "Tracking:",
+    it: "Tracciamento:",
+  },
+  trackPackage: {
+    de: "Paket verfolgen",
+    en: "Track package",
+    it: "Traccia il pacco",
+  },
   noTracking: {
     de: "Wir haben leider noch keine Tracking-Nummer, deine Bestellung wurde aber verschickt.",
     en: "We do not have a tracking number yet, but your order has shipped.",
+    it: "Non abbiamo ancora un numero di tracciamento, ma il tuo ordine è stato spedito.",
   },
-  regards: { de: "Viele Grüße,", en: "Kind regards," },
+  regards: { de: "Viele Grüße,", en: "Kind regards,", it: "Cordiali saluti," },
 } satisfies Record<string, Phrase>;
 
 /** Empfaenger: das Studio -> persoenliche Sprache des Owners. */
@@ -189,18 +224,52 @@ const printStudioPhrases = {
   subject: {
     de: "Neue Print-Bestellung: {order}",
     en: "New print order: {order}",
+    it: "Nuovo ordine di stampa: {order}",
   },
-  intro: { de: "Neue Bestellung im Print-Shop:", en: "New order in the print shop:" },
-  orderNumber: { de: "Bestellnummer", en: "Order number" },
-  customer: { de: "Kunde", en: "Customer" },
-  paymentMode: { de: "Bezahlmodus", en: "Payment" },
-  payOnline: { de: "Online (Stripe)", en: "Online (Stripe)" },
-  payOffline: { de: "Offline-Rechnung", en: "Offline invoice" },
-  total: { de: "Gesamtsumme", en: "Total" },
-  items: { de: "Artikel", en: "Items" },
-  deliveryAddress: { de: "Lieferadresse", en: "Delivery address" },
-  customerNote: { de: "Hinweis vom Kunden:", en: "Note from the customer:" },
-  openOrder: { de: "Zur Bestellung im Studio:", en: "Open the order in the studio:" },
+  intro: {
+    de: "Neue Bestellung im Print-Shop:",
+    en: "New order in the print shop:",
+    it: "Nuovo ordine nel print shop:",
+  },
+  orderNumber: {
+    de: "Bestellnummer",
+    en: "Order number",
+    it: "Numero d'ordine",
+  },
+  customer: { de: "Kunde", en: "Customer", it: "Cliente" },
+  paymentMode: { de: "Bezahlmodus", en: "Payment", it: "Pagamento" },
+  payOnline: {
+    de: "Online (Stripe)",
+    en: "Online (Stripe)",
+    it: "Online (Stripe)",
+  },
+  payOffline: {
+    de: "Offline-Rechnung",
+    en: "Offline invoice",
+    it: "Fattura offline",
+  },
+  total: { de: "Gesamtsumme", en: "Total", it: "Totale" },
+  items: { de: "Artikel", en: "Items", it: "Articoli" },
+  deliveryAddress: {
+    de: "Lieferadresse",
+    en: "Delivery address",
+    it: "Indirizzo di consegna",
+  },
+  customerNote: {
+    de: "Hinweis vom Kunden:",
+    en: "Note from the customer:",
+    it: "Nota del cliente:",
+  },
+  openOrder: {
+    de: "Zur Bestellung im Studio:",
+    en: "Open the order in the studio:",
+    it: "Apri l'ordine nello studio:",
+  },
+  openOrderButton: {
+    de: "Bestellung öffnen",
+    en: "Open order",
+    it: "Apri l'ordine",
+  },
 } satisfies Record<string, Phrase>;
 
 export function tmplPrintOrderConfirmGuest(opts: {
@@ -341,9 +410,9 @@ ${orderUrl}`;
   </table>
   <h3 style="margin-top:20px;">${escapeHtml(phrase(S.deliveryAddress, l))}</h3>
   <pre style="font-family:inherit;white-space:pre-wrap;margin:0;color:#444;">${escapeHtml(formatAddress(order.shippingAddress))}</pre>
-  ${order.guestNote ? `<h3 style="margin-top:20px;">Hinweis vom Kunden</h3><blockquote style="border-left:3px solid #ddd;padding-left:12px;margin:0;color:#444;">${escapeHtml(order.guestNote)}</blockquote>` : ""}
+  ${order.guestNote ? `<h3 style="margin-top:20px;">${escapeHtml(phrase(S.customerNote, l))}</h3><blockquote style="border-left:3px solid #ddd;padding-left:12px;margin:0;color:#444;">${escapeHtml(order.guestNote)}</blockquote>` : ""}
   <p style="margin-top:24px;">
-    ${mailButton(orderUrl, "Bestellung öffnen", branding?.accentColor)}
+    ${mailButton(orderUrl, phrase(S.openOrderButton, l), branding?.accentColor)}
   </p>
 `,
   });

--- a/apps/api/src/services/mail.ts
+++ b/apps/api/src/services/mail.ts
@@ -258,18 +258,22 @@ const newCommentPhrases = {
   subject: {
     de: 'Neuer Kommentar in "{title}"',
     en: 'New comment in "{title}"',
+    it: 'Nuovo commento in "{title}"',
   },
   preheader: {
     de: '{author} hat in "{title}" kommentiert',
     en: '{author} commented in "{title}"',
+    it: '{author} ha commentato in "{title}"',
   },
   heading: {
     de: "Neuer Kommentar in „{title}“",
     en: "New comment in “{title}”",
+    it: "Nuovo commento in «{title}»",
   },
   intro: {
     de: "{author} hat einen Kommentar hinterlassen:",
     en: "{author} left a comment:",
+    it: "{author} ha lasciato un commento:",
   },
 } satisfies Record<string, Phrase>;
 
@@ -308,23 +312,38 @@ export function tmplNewComment(opts: {
 }
 
 const selectionFinishedPhrases = {
-  subject: { de: 'Auswahl fertig: "{title}"', en: 'Selection finished: "{title}"' },
+  subject: {
+    de: 'Auswahl fertig: "{title}"',
+    en: 'Selection finished: "{title}"',
+    it: 'Selezione completata: "{title}"',
+  },
   preheader: {
     de: "{who} hat {files} ausgewählt",
     en: "{who} selected {files}",
+    it: "{who} ha selezionato {files}",
   },
-  heading: { de: "Auswahl abgeschlossen", en: "Selection finished" },
+  heading: {
+    de: "Auswahl abgeschlossen",
+    en: "Selection finished",
+    it: "Selezione completata",
+  },
   bodyText: {
     de: "{who} hat die Auswahl abgeschlossen ({files}).",
     en: "{who} finished their selection ({files}).",
+    it: "{who} ha completato la selezione ({files}).",
   },
   bodyHtml: {
     de: "{who} hat die Auswahl in „{title}“ abgeschlossen — {files} markiert.",
     en: "{who} finished the selection in “{title}” — {files} marked.",
+    it: "{who} ha completato la selezione in «{title}» — {files} contrassegnati.",
   },
-  button: { de: "Auswahl ansehen", en: "View selection" },
-  fileOne: { de: "1 Datei", en: "1 file" },
-  fileMany: { de: "{n} Dateien", en: "{n} files" },
+  button: {
+    de: "Auswahl ansehen",
+    en: "View selection",
+    it: "Visualizza selezione",
+  },
+  fileOne: { de: "1 Datei", en: "1 file", it: "1 file" },
+  fileMany: { de: "{n} Dateien", en: "{n} files", it: "{n} file" },
 } satisfies Record<string, Phrase>;
 
 export function tmplSelectionFinished(opts: {
@@ -368,27 +387,36 @@ const zipReadyPhrases = {
   subject: {
     de: 'Download bereit: "{title}"',
     en: 'Download ready: "{title}"',
+    it: 'Download pronto: "{title}"',
   },
   preheader: {
     de: "Dein ZIP-Download ({files}) ist fertig",
     en: "Your ZIP download ({files}) is ready",
+    it: "Il tuo download ZIP ({files}) è pronto",
   },
-  heading: { de: "Download bereit", en: "Download ready" },
+  heading: {
+    de: "Download bereit",
+    en: "Download ready",
+    it: "Download pronto",
+  },
   bodyText: {
     de: "Dein ZIP-Download mit {files} ist fertig:",
     en: "Your ZIP download with {files} is ready:",
+    it: "Il tuo download ZIP con {files} è pronto:",
   },
   bodyHtml: {
     de: "Dein ZIP-Download mit {files} aus „{title}“ ist fertig.",
     en: "Your ZIP download with {files} from “{title}” is ready.",
+    it: "Il tuo download ZIP con {files} da «{title}» è pronto.",
   },
-  button: { de: "ZIP herunterladen", en: "Download ZIP" },
+  button: { de: "ZIP herunterladen", en: "Download ZIP", it: "Scarica ZIP" },
   validity: {
     de: "Der Link ist 7 Tage gültig.",
     en: "The link is valid for 7 days.",
+    it: "Il link è valido per 7 giorni.",
   },
-  fileOne: { de: "1 Datei", en: "1 file" },
-  fileMany: { de: "{n} Dateien", en: "{n} files" },
+  fileOne: { de: "1 Datei", en: "1 file", it: "1 file" },
+  fileMany: { de: "{n} Dateien", en: "{n} files", it: "{n} file" },
 } satisfies Record<string, Phrase>;
 
 export function tmplZipReady(opts: {
@@ -434,25 +462,34 @@ const storageWarningPhrases = {
   subject: {
     de: "Speicher fast voll: {percent}% belegt",
     en: "Storage almost full: {percent}% used",
+    it: "Spazio quasi esaurito: {percent}% utilizzato",
   },
   preheader: {
     de: "Dein Speicher ist zu {percent}% belegt",
     en: "Your storage is {percent}% used",
+    it: "Il tuo spazio è utilizzato al {percent}%",
   },
-  heading: { de: "Speicher fast voll", en: "Storage almost full" },
+  heading: {
+    de: "Speicher fast voll",
+    en: "Storage almost full",
+    it: "Spazio quasi esaurito",
+  },
   bodyText: {
     de: "Dein Lumio-Speicher ist zu {percent}% belegt ({used} von {limit} GB).",
     en: "Your Lumio storage is {percent}% used ({used} of {limit} GB).",
+    it: "Il tuo spazio Lumio è utilizzato al {percent}% ({used} di {limit} GB).",
   },
   bodyHtml: {
     de: "Dein belegter Speicher liegt bei {percent}% — {used} von {limit} GB.",
     en: "Your used storage is at {percent}% — {used} of {limit} GB.",
+    it: "Il tuo spazio utilizzato è al {percent}% — {used} di {limit} GB.",
   },
   consequence: {
     de: "Ist das Limit erreicht, sind keine neuen Uploads mehr möglich. Du kannst alte Galerien aufräumen oder deinen Speicher erweitern.",
     en: "Once the limit is reached, no new uploads are possible. You can clear out old galleries or increase your storage.",
+    it: "Una volta raggiunto il limite, non sarà più possibile caricare nuovi file. Puoi eliminare vecchie gallerie o aumentare il tuo spazio.",
   },
-  button: { de: "Speicher & Tarif", en: "Storage & plan" },
+  button: { de: "Speicher & Tarif", en: "Storage & plan", it: "Spazio e piano" },
 } satisfies Record<string, Phrase>;
 
 export function tmplStorageWarning(opts: {
@@ -493,24 +530,29 @@ const ownerSetupPhrases = {
   subject: {
     de: 'Dein Lumio-Studio "{tenant}" ist bereit',
     en: 'Your Lumio studio "{tenant}" is ready',
+    it: 'Il tuo studio Lumio "{tenant}" è pronto',
   },
   preheader: {
     de: "Dein Studio „{tenant}“ wartet auf dich",
     en: "Your studio “{tenant}” is waiting for you",
+    it: "Il tuo studio «{tenant}» ti aspetta",
   },
-  greeting: { de: "Hallo {name},", en: "Hello {name}," },
+  greeting: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
   bodyText: {
     de: "{by} hat ein Lumio-Studio für dich angelegt:\n  {tenant}\n\nKlick auf den folgenden Link, um dein Passwort zu setzen und direkt loszulegen:",
     en: "{by} created a Lumio studio for you:\n  {tenant}\n\nUse the link below to set your password and get started:",
+    it: "{by} ha creato uno studio Lumio per te:\n  {tenant}\n\nClicca sul link seguente per impostare la password e iniziare subito:",
   },
   bodyHtml: {
     de: "{by} hat ein Lumio-Studio für dich angelegt: „{tenant}“. Setze jetzt dein Passwort und leg los.",
     en: "{by} created a Lumio studio for you: “{tenant}”. Set your password now and get started.",
+    it: "{by} ha creato uno studio Lumio per te: «{tenant}». Imposta subito la tua password e inizia.",
   },
-  button: { de: "Passwort setzen", en: "Set password" },
+  button: { de: "Passwort setzen", en: "Set password", it: "Imposta password" },
   validity: {
     de: "Der Link ist {hours} Stunden gültig. Falls die Frist abläuft, melde dich bei {by}.",
     en: "The link is valid for {hours} hours. If it expires, get in touch with {by}.",
+    it: "Il link è valido per {hours} ore. Se scade, contatta {by}.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -554,36 +596,48 @@ const passwordResetPhrases = {
   subject: {
     de: "Passwort zurücksetzen für „{tenant}“",
     en: "Reset your password for “{tenant}”",
+    it: "Reimposta la password per «{tenant}»",
   },
   preheader: {
     de: "Passwort-Reset für „{tenant}“",
     en: "Password reset for “{tenant}”",
+    it: "Reimpostazione password per «{tenant}»",
   },
-  greeting: { de: "Hallo {name},", en: "Hello {name}," },
+  greeting: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
   body: {
     de: "Du (oder jemand mit deiner E-Mail-Adresse) hat ein neues Passwort für dein Lumio-Studio „{tenant}“ angefordert.",
     en: "You (or someone with your email address) requested a new password for your Lumio studio “{tenant}”.",
+    it: "Tu (o qualcuno con il tuo indirizzo email) hai richiesto una nuova password per il tuo studio Lumio «{tenant}».",
   },
   instruction: {
     de: "Klick auf den folgenden Link, um ein neues Passwort zu setzen:",
     en: "Use the link below to set a new password:",
+    it: "Clicca sul link seguente per impostare una nuova password:",
   },
-  button: { de: "Neues Passwort setzen", en: "Set a new password" },
+  button: {
+    de: "Neues Passwort setzen",
+    en: "Set a new password",
+    it: "Imposta una nuova password",
+  },
   validity: {
     de: "Der Link ist {hours} Stunden gültig.",
     en: "The link is valid for {hours} hours.",
+    it: "Il link è valido per {hours} ore.",
   },
   requestedFromIp: {
     de: "Angefordert von IP-Adresse: {ip}",
     en: "Requested from IP address: {ip}",
+    it: "Richiesto dall'indirizzo IP: {ip}",
   },
   notYou: {
     de: "Falls du das NICHT angefordert hast, kannst du diese Mail ignorieren — dein aktuelles Passwort bleibt gültig. Bei verdächtiger Aktivität melde dich bitte beim Studio-Owner.",
     en: "If you did NOT request this, you can ignore this email — your current password stays valid. If anything looks suspicious, please contact the studio owner.",
+    it: "Se NON hai richiesto tu questa modifica, puoi ignorare questa email — la tua password attuale resta valida. In caso di attività sospetta, contatta il titolare dello studio.",
   },
   notYouShort: {
     de: "Falls du das NICHT angefordert hast, kannst du diese Mail ignorieren — dein aktuelles Passwort bleibt gültig.",
     en: "If you did NOT request this, you can ignore this email — your current password stays valid.",
+    it: "Se NON hai richiesto tu questa modifica, puoi ignorare questa email — la tua password attuale resta valida.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -638,29 +692,43 @@ const emailChangeConfirmPhrases = {
   subject: {
     de: "Bestätige deine neue E-Mail-Adresse für „{tenant}“",
     en: "Confirm your new email address for “{tenant}”",
+    it: "Conferma il tuo nuovo indirizzo email per «{tenant}»",
   },
   preheader: {
     de: "Bestätige den Wechsel zu {newEmail}",
     en: "Confirm the change to {newEmail}",
+    it: "Conferma il cambio verso {newEmail}",
   },
-  greeting: { de: "Hallo {name},", en: "Hello {name}," },
+  greeting: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
   body: {
     de: "Du hast deine E-Mail-Adresse für dein Lumio-Studio „{tenant}“ geändert:",
     en: "You changed the email address for your Lumio studio “{tenant}”:",
+    it: "Hai modificato l'indirizzo email per il tuo studio Lumio «{tenant}»:",
   },
-  fromTo: { de: "  von: {old}\n  zu:  {new}", en: "  from: {old}\n  to:   {new}" },
+  fromTo: {
+    de: "  von: {old}\n  zu:  {new}",
+    en: "  from: {old}\n  to:   {new}",
+    it: "  da: {old}\n  a:  {new}",
+  },
   instruction: {
     de: "Klick auf den folgenden Link, um die Änderung zu bestätigen:",
     en: "Use the link below to confirm the change:",
+    it: "Clicca sul link seguente per confermare la modifica:",
   },
-  button: { de: "Wechsel bestätigen", en: "Confirm change" },
+  button: {
+    de: "Wechsel bestätigen",
+    en: "Confirm change",
+    it: "Conferma modifica",
+  },
   validity: {
     de: "Der Link ist {hours} Stunden gültig. Bis du klickst, bleibt deine alte E-Mail-Adresse aktiv.",
     en: "The link is valid for {hours} hours. Until you click it, your old address stays active.",
+    it: "Il link è valido per {hours} ore. Fino a quando non lo clicchi, il tuo vecchio indirizzo resta attivo.",
   },
   notYou: {
     de: "Bis du den Link klickst, bleibt deine alte E-Mail-Adresse aktiv. Falls du diesen Wechsel NICHT angefordert hast, ignoriere die Mail einfach.",
     en: "Until you click the link, your old address stays active. If you did NOT request this change, simply ignore this email.",
+    it: "Fino a quando non clicchi il link, il tuo vecchio indirizzo resta attivo. Se NON hai richiesto tu questa modifica, ignora semplicemente questa email.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -711,31 +779,38 @@ const emailChangeNoticePhrases = {
   subject: {
     de: "E-Mail-Wechsel für „{tenant}“ angefordert",
     en: "Email change requested for “{tenant}”",
+    it: "Richiesto cambio email per «{tenant}»",
   },
   preheader: {
     de: "E-Mail-Wechsel auf {newEmail} angefordert",
     en: "Email change to {newEmail} requested",
+    it: "Richiesto cambio email a {newEmail}",
   },
-  greeting: { de: "Hallo {name},", en: "Hello {name}," },
+  greeting: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
   bodyText: {
     de: "Es wurde ein Wechsel deiner E-Mail-Adresse für dein Lumio-Studio „{tenant}“ angefordert. Die neue Adresse lautet:\n\n  {newEmail}",
     en: "A change of your email address for your Lumio studio “{tenant}” was requested. The new address is:\n\n  {newEmail}",
+    it: "È stata richiesta una modifica del tuo indirizzo email per il tuo studio Lumio «{tenant}». Il nuovo indirizzo è:\n\n  {newEmail}",
   },
   bodyHtml: {
     de: "Es wurde ein Wechsel deiner E-Mail-Adresse für dein Lumio-Studio „{tenant}“ angefordert. Neue Adresse: {newEmail}.",
     en: "A change of your email address for your Lumio studio “{tenant}” was requested. New address: {newEmail}.",
+    it: "È stata richiesta una modifica del tuo indirizzo email per il tuo studio Lumio «{tenant}». Nuovo indirizzo: {newEmail}.",
   },
   linkSent: {
     de: "An die neue Adresse haben wir einen Bestätigungslink geschickt. Erst nach Klick darauf ist der Wechsel vollzogen.",
     en: "We sent a confirmation link to the new address. The change only takes effect once it is clicked.",
+    it: "Abbiamo inviato un link di conferma al nuovo indirizzo. La modifica avrà effetto solo dopo averlo cliccato.",
   },
   ifNotYouText: {
     de: "Wenn du das selbst angefordert hast, brauchst du nichts weiter zu tun. Wenn NICHT, melde dich umgehend beim Studio-Owner und ändere dein Passwort — möglicherweise hat jemand Fremdes Zugriff auf deinen Account.",
     en: "If you requested this yourself, there is nothing more to do. If NOT, contact the studio owner immediately and change your password — someone else may have access to your account.",
+    it: "Se sei stato tu a richiederlo, non devi fare nient'altro. Se NON sei stato tu, contatta immediatamente il titolare dello studio e cambia la tua password — qualcun altro potrebbe avere accesso al tuo account.",
   },
   ifNotYouBox: {
     de: "Wenn du das selbst angefordert hast, ist alles in Ordnung. Wenn NICHT, melde dich beim Studio-Owner und ändere dein Passwort — möglicherweise hat jemand Fremdes Zugriff auf deinen Account.",
     en: "If you requested this yourself, all is well. If NOT, contact the studio owner and change your password — someone else may have access to your account.",
+    it: "Se sei stato tu a richiederlo, va tutto bene. Se NON sei stato tu, contatta il titolare dello studio e cambia la tua password — qualcun altro potrebbe avere accesso al tuo account.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -786,39 +861,63 @@ const galleryInvitePhrases = {
   subject: {
     de: "Deine Galerie „{title}“ von {studio}",
     en: "Your gallery “{title}” from {studio}",
+    it: "La tua galleria «{title}» da {studio}",
   },
   preheader: {
     de: "Deine Galerie „{title}“ ist bereit",
     en: "Your gallery “{title}” is ready",
+    it: "La tua galleria «{title}» è pronta",
   },
-  greetingFallback: { de: "Hallo", en: "Hello" },
+  greetingFallback: { de: "Hallo", en: "Hello", it: "Ciao" },
   introText: {
     de: "{name},\n\ndeine Galerie „{title}“ ist da. Über den folgenden Link kannst du:\n\n",
     en: "{name},\n\nyour gallery “{title}” is ready. Using the link below you can:\n\n",
+    it: "{name},\n\nla tua galleria «{title}» è pronta. Tramite il link seguente puoi:\n\n",
   },
   introHtml: {
     de: "{name}, deine Galerie „{title}“ ist da.",
     en: "{name}, your gallery “{title}” is ready.",
+    it: "{name}, la tua galleria «{title}» è pronta.",
   },
   whatYouCanDo: {
     de: "Was du in der Galerie tun kannst:",
     en: "What you can do in the gallery:",
+    it: "Cosa puoi fare nella galleria:",
   },
-  capView: { de: "Bilder ansehen", en: "View the photos" },
+  capView: {
+    de: "Bilder ansehen",
+    en: "View the photos",
+    it: "Visualizzare le foto",
+  },
   capSelect: {
     de: "Lieblings-Bilder markieren",
     en: "Mark your favourites",
+    it: "Contrassegnare le tue preferite",
   },
-  capDownload: { de: "Bilder herunterladen", en: "Download the photos" },
-  openGalleryLine: { de: "Galerie öffnen:", en: "Open the gallery:" },
+  capDownload: {
+    de: "Bilder herunterladen",
+    en: "Download the photos",
+    it: "Scaricare le foto",
+  },
+  openGalleryLine: {
+    de: "Galerie öffnen:",
+    en: "Open the gallery:",
+    it: "Apri la galleria:",
+  },
   expiry: {
     de: "Der Link ist gültig bis {date}.",
     en: "The link is valid until {date}.",
+    it: "Il link è valido fino al {date}.",
   },
-  sentVia: { de: "(verschickt via Lumio)", en: "(sent via Lumio)" },
+  sentVia: {
+    de: "(verschickt via Lumio)",
+    en: "(sent via Lumio)",
+    it: "(inviata tramite Lumio)",
+  },
   footerNote: {
     de: "Diese Mail wurde von {studio} über Lumio verschickt.",
     en: "This email was sent by {studio} via Lumio.",
+    it: "Questa email è stata inviata da {studio} tramite Lumio.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -910,39 +1009,62 @@ const welcomePhrases = {
   subject: {
     de: "Willkommen bei Lumio — dein Studio „{studio}“ ist startklar",
     en: "Welcome to Lumio — your studio “{studio}” is ready",
+    it: "Benvenuto su Lumio — il tuo studio «{studio}» è pronto",
   },
   preheader: {
     de: "Dein Studio „{studio}“ ist startklar",
     en: "Your studio “{studio}” is ready",
+    it: "Il tuo studio «{studio}» è pronto",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
-  heading: { de: "Willkommen bei Lumio", en: "Welcome to Lumio" },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  heading: {
+    de: "Willkommen bei Lumio",
+    en: "Welcome to Lumio",
+    it: "Benvenuto su Lumio",
+  },
   bodyText: {
     de: "dein Lumio-Studio „{studio}“ ist angelegt und einsatzbereit. Du bist im {plan}-Plan mit einem 14-tägigen Trial — kostenlos bis zum {date}, kein Risiko.",
     en: "your Lumio studio “{studio}” is set up and ready. You are on the {plan} plan with a 14-day trial — free until {date}, no risk.",
+    it: "il tuo studio Lumio «{studio}» è stato creato ed è pronto all'uso. Sei nel piano {plan} con una prova gratuita di 14 giorni — gratis fino al {date}, senza rischi.",
   },
   bodyHtml: {
     de: "{prefix}dein Studio „{studio}“ ist angelegt und einsatzbereit. Du bist im {plan}-Plan mit einem 14-tägigen Trial — kostenlos bis zum {date}.",
     en: "{prefix}your studio “{studio}” is set up and ready. You are on the {plan} plan with a 14-day trial — free until {date}.",
+    it: "{prefix}il tuo studio «{studio}» è stato creato ed è pronto all'uso. Sei nel piano {plan} con una prova gratuita di 14 giorni — gratis fino al {date}.",
   },
-  loginAt: { de: "Einloggen kannst du dich jederzeit unter:", en: "You can sign in any time at:" },
-  firstSteps: { de: "Erste Schritte für dein Studio:", en: "First steps for your studio:" },
-  firstStepsHeading: { de: "Erste Schritte", en: "First steps" },
+  loginAt: {
+    de: "Einloggen kannst du dich jederzeit unter:",
+    en: "You can sign in any time at:",
+    it: "Puoi accedere in qualsiasi momento su:",
+  },
+  firstSteps: {
+    de: "Erste Schritte für dein Studio:",
+    en: "First steps for your studio:",
+    it: "Primi passi per il tuo studio:",
+  },
+  firstStepsHeading: {
+    de: "Erste Schritte",
+    en: "First steps",
+    it: "Primi passi",
+  },
   step1: {
     de: "Branding anpassen (Logo, Farben, eigene Domain)",
     en: "Set up your branding (logo, colours, custom domain)",
+    it: "Personalizza il branding (logo, colori, dominio personalizzato)",
   },
   step2: {
     de: "Eine erste Galerie anlegen und ein paar Bilder hochladen",
     en: "Create a first gallery and upload a few photos",
+    it: "Crea una prima galleria e carica alcune foto",
   },
   step3: {
     de: "Test-Share-Link an dich selbst schicken, um den Endkunden-Workflow zu durchlaufen",
     en: "Send yourself a test share link to walk through the customer flow",
+    it: "Invia a te stesso un link di condivisione di prova per seguire il flusso del cliente",
   },
-  button: { de: "Studio öffnen", en: "Open studio" },
-  seeYouSoon: { de: "Bis bald", en: "See you soon" },
+  button: { de: "Studio öffnen", en: "Open studio", it: "Apri studio" },
+  seeYouSoon: { de: "Bis bald", en: "See you soon", it: "A presto" },
 } satisfies Record<string, Phrase>;
 
 export function tmplWelcome(opts: {
@@ -1009,61 +1131,94 @@ const deletionRequestedPhrases = {
   subject: {
     de: "Löschung deines Studios „{studio}“ geplant",
     en: "Deletion of your studio “{studio}” is scheduled",
+    it: "Cancellazione del tuo studio «{studio}» pianificata",
   },
   preheader: {
     de: "Endgültige Löschung am {date} — bis dahin rücknehmbar",
     en: "Permanent deletion on {date} — reversible until then",
+    it: "Cancellazione definitiva il {date} — revocabile fino ad allora",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
-  heading: { de: "Studio-Löschung geplant", en: "Studio deletion scheduled" },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  heading: {
+    de: "Studio-Löschung geplant",
+    en: "Studio deletion scheduled",
+    it: "Cancellazione dello studio pianificata",
+  },
   intro: {
     de: "wir haben deine Anfrage zur Löschung deines Lumio-Studios „{studio}“ erhalten.",
     en: "we have received your request to delete your Lumio studio “{studio}”.",
+    it: "abbiamo ricevuto la tua richiesta di cancellazione del tuo studio Lumio «{studio}».",
   },
   introHtml: {
     de: "{greeting} — wir haben deine Anfrage zur Löschung von „{studio}“ erhalten.",
     en: "{greeting} — we have received your request to delete “{studio}”.",
+    it: "{greeting} — abbiamo ricevuto la tua richiesta di cancellazione di «{studio}».",
   },
-  whatHappens: { de: "Was jetzt passiert", en: "What happens now" },
-  whatHappensText: { de: "Was jetzt passiert:", en: "What happens now:" },
+  whatHappens: {
+    de: "Was jetzt passiert",
+    en: "What happens now",
+    it: "Cosa succede ora",
+  },
+  whatHappensText: {
+    de: "Was jetzt passiert:",
+    en: "What happens now:",
+    it: "Cosa succede ora:",
+  },
   step1: {
     de: "Deine Stripe-Subscription wurde sofort gekündigt — keine weitere Abrechnung.",
     en: "Your Stripe subscription was cancelled immediately — no further billing.",
+    it: "Il tuo abbonamento Stripe è stato annullato immediatamente — nessun ulteriore addebito.",
   },
   step2Text: {
     de: "Alle Galerien, Freigabe- und Upload-Links sind ab sofort offline. Deine Kundinnen und Kunden haben keinen Zugriff mehr.",
     en: "All galleries, share links and upload links are offline as of now. Your customers no longer have access.",
+    it: "Tutte le gallerie, i link di condivisione e di caricamento sono offline a partire da ora. I tuoi clienti non hanno più accesso.",
   },
   step2Html: {
     de: "Alle Galerien, Freigabe- und Upload-Links sind ab sofort offline — deine Kundinnen und Kunden haben keinen Zugriff mehr.",
     en: "All galleries, share links and upload links are offline as of now — your customers no longer have access.",
+    it: "Tutte le gallerie, i link di condivisione e di caricamento sono offline a partire da ora — i tuoi clienti non hanno più accesso.",
   },
   step3Text: {
     de: "Das Studio bleibt für 60 Tage in der Karenzphase. Die Daten bleiben in dieser Zeit vollständig erhalten.",
     en: "The studio stays in a 60-day grace period. During that time all data is retained in full.",
+    it: "Lo studio resta per 60 giorni in un periodo di tolleranza. Durante questo periodo tutti i dati vengono conservati integralmente.",
   },
   step3Html: {
     de: "Das Studio bleibt für 60 Tage in der Karenzphase. Die Daten bleiben in dieser Zeit vollständig erhalten; nimmst du die Löschung zurück, sind alle Galerien sofort wieder erreichbar.",
     en: "The studio stays in a 60-day grace period. During that time all data is retained in full; if you reverse the deletion, every gallery is reachable again immediately.",
+    it: "Lo studio resta per 60 giorni in un periodo di tolleranza. Durante questo periodo tutti i dati vengono conservati integralmente; se annulli la cancellazione, tutte le gallerie tornano immediatamente accessibili.",
   },
   step4: {
     de: "Du kannst die Löschung bis zum {date} jederzeit zurücknehmen.",
     en: "You can reverse the deletion at any time until {date}.",
+    it: "Puoi annullare la cancellazione in qualsiasi momento fino al {date}.",
   },
   step5: {
     de: "Am {date} werden alle Daten endgültig gelöscht.",
     en: "On {date} all data will be permanently deleted.",
+    it: "Il {date} tutti i dati verranno cancellati definitivamente.",
   },
-  cancelLine: { de: "Löschung zurücknehmen:", en: "Reverse the deletion:" },
-  button: { de: "Löschung zurücknehmen", en: "Reverse deletion" },
+  cancelLine: {
+    de: "Löschung zurücknehmen:",
+    en: "Reverse the deletion:",
+    it: "Annulla la cancellazione:",
+  },
+  button: {
+    de: "Löschung zurücknehmen",
+    en: "Reverse deletion",
+    it: "Annulla cancellazione",
+  },
   notRequested: {
     de: "Wenn du die Löschung NICHT angefordert hast,",
     en: "If you did NOT request this deletion,",
+    it: "Se NON hai richiesto tu questa cancellazione,",
   },
   strangerAccess: {
     de: "Möglicherweise hat jemand Fremdes Zugriff auf deinen Account.",
     en: "Someone else may have access to your account.",
+    it: "Qualcun altro potrebbe avere accesso al tuo account.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -1129,33 +1284,44 @@ const deletionCancelledPhrases = {
   subject: {
     de: "Löschung deines Studios „{studio}“ zurückgenommen",
     en: "Deletion of your studio “{studio}” has been reversed",
+    it: "Cancellazione del tuo studio «{studio}» annullata",
   },
   preheader: {
     de: "Dein Studio „{studio}“ ist wieder aktiv",
     en: "Your studio “{studio}” is active again",
+    it: "Il tuo studio «{studio}» è di nuovo attivo",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
-  heading: { de: "Löschung zurückgenommen", en: "Deletion reversed" },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  heading: {
+    de: "Löschung zurückgenommen",
+    en: "Deletion reversed",
+    it: "Cancellazione annullata",
+  },
   bodyText: {
     de: "du hast die Löschung deines Studios „{studio}“ zurückgenommen. Dein Studio ist wieder aktiv und voll nutzbar.",
     en: "you reversed the deletion of your studio “{studio}”. Your studio is active and fully usable again.",
+    it: "hai annullato la cancellazione del tuo studio «{studio}». Il tuo studio è di nuovo attivo e pienamente utilizzabile.",
   },
   bodyHtml: {
     de: "{greeting} — du hast die Löschung deines Studios „{studio}“ zurückgenommen. Dein Studio ist wieder aktiv und voll nutzbar.",
     en: "{greeting} — you reversed the deletion of your studio “{studio}”. Your studio is active and fully usable again.",
+    it: "{greeting} — hai annullato la cancellazione del tuo studio «{studio}». Il tuo studio è di nuovo attivo e pienamente utilizzabile.",
   },
   billingTitle: {
     de: "Wichtiger Hinweis zur Abrechnung:",
     en: "Important note about billing:",
+    it: "Nota importante sulla fatturazione:",
   },
   billingText: {
     de: "Deine Stripe-Subscription wurde bei der Lösch-Anfrage gekündigt und wird NICHT automatisch reaktiviert. Wenn du Lumio weiter nutzen willst, musst du im Studio unter „Billing“ eine neue Subscription starten.",
     en: "Your Stripe subscription was cancelled when the deletion was requested and will NOT be reactivated automatically. If you want to keep using Lumio, you have to start a new subscription in the studio under “Billing”.",
+    it: "Il tuo abbonamento Stripe è stato annullato al momento della richiesta di cancellazione e NON verrà riattivato automaticamente. Se vuoi continuare a usare Lumio, devi avviare un nuovo abbonamento nello studio sotto «Fatturazione».",
   },
   billingBox: {
     de: "Wichtig zur Abrechnung: Deine Stripe-Subscription wurde bei der Lösch-Anfrage gekündigt und wird NICHT automatisch reaktiviert. Wenn du Lumio weiter nutzen willst, starte im Studio unter „Billing“ eine neue Subscription.",
     en: "Important about billing: your Stripe subscription was cancelled when the deletion was requested and will NOT be reactivated automatically. If you want to keep using Lumio, start a new subscription in the studio under “Billing”.",
+    it: "Importante sulla fatturazione: il tuo abbonamento Stripe è stato annullato al momento della richiesta di cancellazione e NON verrà riattivato automaticamente. Se vuoi continuare a usare Lumio, avvia un nuovo abbonamento nello studio sotto «Fatturazione».",
   },
 } satisfies Record<string, Phrase>;
 
@@ -1204,58 +1370,94 @@ const deletionExecutedPhrases = {
   subject: {
     de: "Dein Lumio-Studio „{studio}“ wurde gelöscht",
     en: "Your Lumio studio “{studio}” has been deleted",
+    it: "Il tuo studio Lumio «{studio}» è stato cancellato",
   },
   preheader: {
     de: "Bestätigung der endgültigen Löschung von „{studio}“",
     en: "Confirmation of the permanent deletion of “{studio}”",
+    it: "Conferma della cancellazione definitiva di «{studio}»",
   },
-  greeting: { de: "Hallo,", en: "Hello," },
-  heading: { de: "Studio gelöscht", en: "Studio deleted" },
+  greeting: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  heading: { de: "Studio gelöscht", en: "Studio deleted", it: "Studio cancellato" },
   introText: {
     de: "wie angekündigt haben wir dein Lumio-Studio „{studio}“ und alle zugehörigen Daten endgültig gelöscht.",
     en: "as announced, we have permanently deleted your Lumio studio “{studio}” and all associated data.",
+    it: "come annunciato, abbiamo cancellato definitivamente il tuo studio Lumio «{studio}» e tutti i dati associati.",
   },
   introHtml: {
     de: "Wie angekündigt haben wir dein Lumio-Studio „{studio}“ und alle zugehörigen Daten endgültig gelöscht.",
     en: "As announced, we have permanently deleted your Lumio studio “{studio}” and all associated data.",
+    it: "Come annunciato, abbiamo cancellato definitivamente il tuo studio Lumio «{studio}» e tutti i dati associati.",
   },
-  deletedHeading: { de: "Gelöscht wurden", en: "What was deleted" },
-  deletedText: { de: "Gelöscht wurden:", en: "What was deleted:" },
+  deletedHeading: {
+    de: "Gelöscht wurden",
+    en: "What was deleted",
+    it: "Cosa è stato cancellato",
+  },
+  deletedText: {
+    de: "Gelöscht wurden:",
+    en: "What was deleted:",
+    it: "Cosa è stato cancellato:",
+  },
   del1: {
     de: "Alle Bilder und Videos in deinen Galerien",
     en: "All photos and videos in your galleries",
+    it: "Tutte le foto e i video nelle tue gallerie",
   },
   del2: {
     de: "Alle Galerien und ihre Konfiguration",
     en: "All galleries and their configuration",
+    it: "Tutte le gallerie e la loro configurazione",
   },
   del3: {
     de: "Dein Account und alle Team-Accounts",
     en: "Your account and all team accounts",
+    it: "Il tuo account e tutti gli account del team",
   },
-  del4: { de: "Branding, Watermarks, Templates", en: "Branding, watermarks, templates" },
+  del4: {
+    de: "Branding, Watermarks, Templates",
+    en: "Branding, watermarks, templates",
+    it: "Branding, filigrane, template",
+  },
   del5: {
     de: "Audit-Logs (nur die Tenant-spezifischen)",
     en: "Audit logs (the tenant-specific ones only)",
+    it: "Log di controllo (solo quelli specifici del tenant)",
   },
-  keptHeading: { de: "Behalten", en: "What was kept" },
-  keptText: { de: "Behalten:", en: "What was kept:" },
+  keptHeading: {
+    de: "Behalten",
+    en: "What was kept",
+    it: "Cosa è stato conservato",
+  },
+  keptText: {
+    de: "Behalten:",
+    en: "What was kept:",
+    it: "Cosa è stato conservato:",
+  },
   keptItem: {
     de: "Stripe-Customer-Datensatz (für Rechnungs-Audit-Trail in Stripe).",
     en: "The Stripe customer record (for the invoicing audit trail in Stripe).",
+    it: "Il record cliente Stripe (per la tracciabilità di fatturazione in Stripe).",
   },
   keptContact: {
     de: "Wenn du den auch endgültig gelöscht haben möchtest, schreibe an {address}.",
     en: "If you want that deleted permanently as well, write to {address}.",
+    it: "Se vuoi che venga cancellato definitivamente anche questo, scrivi a {address}.",
   },
   keepThisMail: {
     de: "Diese Mail ist deine Löschungs-Bestätigung — bitte aufbewahren, falls du sie später für dein eigenes Verarbeitungsverzeichnis brauchst.",
     en: "This email is your deletion confirmation — please keep it in case you need it for your own record of processing activities.",
+    it: "Questa email è la tua conferma di cancellazione — conservala nel caso ti serva in futuro per il tuo registro dei trattamenti.",
   },
-  sorryToSeeYouGo: { de: "Schade dass du gehst.", en: "Sorry to see you go." },
+  sorryToSeeYouGo: {
+    de: "Schade dass du gehst.",
+    en: "Sorry to see you go.",
+    it: "Ci dispiace vederti andare via.",
+  },
   feedbackInvite: {
     de: "Falls es technische Gründe waren oder ein Feature gefehlt hat: {address} — wir lesen das.",
     en: "If it was for technical reasons or a missing feature: {address} — we do read it.",
+    it: "Se il motivo sono stati problemi tecnici o una funzione mancante: {address} — lo leggiamo davvero.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -1323,34 +1525,45 @@ const deletionReminderPhrases = {
   subject: {
     de: "Erinnerung: dein Studio „{studio}“ wird in 7 Tagen gelöscht",
     en: "Reminder: your studio “{studio}” will be deleted in 7 days",
+    it: "Promemoria: il tuo studio «{studio}» verrà cancellato tra 7 giorni",
   },
   preheader: {
     de: "Letzte 7 Tage — endgültige Löschung am {date}",
     en: "Last 7 days — permanent deletion on {date}",
+    it: "Ultimi 7 giorni — cancellazione definitiva il {date}",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
-  heading: { de: "Letzte Erinnerung", en: "Final reminder" },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  heading: {
+    de: "Letzte Erinnerung",
+    en: "Final reminder",
+    it: "Ultimo promemoria",
+  },
   bodyText: {
     de: "am {date} löschen wir dein Lumio-Studio „{studio}“ endgültig — wie von dir angefragt.",
     en: "on {date} we will permanently delete your Lumio studio “{studio}” — as you requested.",
+    it: "il {date} cancelleremo definitivamente il tuo studio Lumio «{studio}» — come da te richiesto.",
   },
   bodyHtml: {
     de: "{greeting} — am {date} löschen wir dein Lumio-Studio „{studio}“ endgültig, wie von dir angefragt.",
     en: "{greeting} — on {date} we will permanently delete your Lumio studio “{studio}”, as you requested.",
+    it: "{greeting} — il {date} cancelleremo definitivamente il tuo studio Lumio «{studio}», come da te richiesto.",
   },
   lastChanceText: {
     de: "Das ist deine letzte Erinnerung. Wenn du es dir anders überlegt hast, kannst du die Löschung jetzt noch zurücknehmen:",
     en: "This is your final reminder. If you have changed your mind, you can still reverse the deletion now:",
+    it: "Questo è il tuo ultimo promemoria. Se hai cambiato idea, puoi ancora annullare la cancellazione ora:",
   },
   lastChanceHtml: {
     de: "Wenn du es dir anders überlegt hast, kannst du die Löschung jetzt noch zurücknehmen:",
     en: "If you have changed your mind, you can still reverse the deletion now:",
+    it: "Se hai cambiato idea, puoi ancora annullare la cancellazione ora:",
   },
-  button: { de: "Löschung zurücknehmen", en: "Reverse deletion" },
+  button: { de: "Löschung zurücknehmen", en: "Reverse deletion", it: "Annulla cancellazione" },
   irreversible: {
     de: "Nach dem Stichtag sind die Daten unwiderruflich weg.",
     en: "After that date the data is irretrievably gone.",
+    it: "Dopo tale data i dati saranno persi in modo irrevocabile.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -1411,45 +1624,62 @@ const billingArchivedPhrases = {
   subject: {
     de: "Dein Studio „{studio}“ wurde archiviert",
     en: "Your studio “{studio}” has been archived",
+    it: "Il tuo studio «{studio}» è stato archiviato",
   },
   preheader: {
     de: "Galerien offline — endgültige Löschung am {date}, bis dahin reaktivierbar",
     en: "Galleries offline — permanent deletion on {date}, reactivatable until then",
+    it: "Gallerie offline — cancellazione definitiva il {date}, riattivabile fino ad allora",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
-  heading: { de: "Studio archiviert", en: "Studio archived" },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  heading: {
+    de: "Studio archiviert",
+    en: "Studio archived",
+    it: "Studio archiviato",
+  },
   introText: {
     de: "dein Lumio-Studio „{studio}“ war länger ohne aktives Abo und wurde jetzt archiviert.",
     en: "your Lumio studio “{studio}” has been without an active subscription for a while and has now been archived.",
+    it: "il tuo studio Lumio «{studio}» era senza abbonamento attivo da tempo ed è stato ora archiviato.",
   },
   introHtml: {
     de: "{greeting} — dein Studio „{studio}“ war länger ohne aktives Abo und wurde jetzt archiviert.",
     en: "{greeting} — your studio “{studio}” has been without an active subscription for a while and has now been archived.",
+    it: "{greeting} — il tuo studio «{studio}» era senza abbonamento attivo da tempo ed è stato ora archiviato.",
   },
-  meansText: { de: "Was das bedeutet:", en: "What that means:" },
+  meansText: { de: "Was das bedeutet:", en: "What that means:", it: "Cosa significa:" },
   point1: {
     de: "Deine Kunden-Galerien sind vorübergehend offline.",
     en: "Your customer galleries are temporarily offline.",
+    it: "Le tue gallerie clienti sono temporaneamente offline.",
   },
   point2: {
     de: "Die Original-Dateien bleiben gespeichert — nur die Vorschauen werden entfernt und bei Reaktivierung neu erzeugt.",
     en: "The original files stay stored — only the previews are removed and regenerated on reactivation.",
+    it: "I file originali restano archiviati — vengono rimosse solo le anteprime, che verranno rigenerate alla riattivazione.",
   },
   point3: {
     de: "Mit einem neuen Abo ist alles wieder da.",
     en: "With a new subscription everything is back.",
+    it: "Con un nuovo abbonamento tutto torna disponibile.",
   },
   deadlineText: {
     de: "Wichtig: Wenn du bis zum {date} kein Abo abschließt, werden alle Daten an diesem Tag endgültig gelöscht.",
     en: "Important: if you do not take out a subscription by {date}, all data will be permanently deleted on that day.",
+    it: "Importante: se non attivi un abbonamento entro il {date}, tutti i dati verranno cancellati definitivamente in quella data.",
   },
   deadlineBox: {
     de: "Ohne neues Abo werden am {date} alle Daten endgültig gelöscht.",
     en: "Without a new subscription all data will be permanently deleted on {date}.",
+    it: "Senza un nuovo abbonamento, tutti i dati verranno cancellati definitivamente il {date}.",
   },
-  reactivateLine: { de: "Studio reaktivieren:", en: "Reactivate studio:" },
-  button: { de: "Studio reaktivieren", en: "Reactivate studio" },
+  reactivateLine: {
+    de: "Studio reaktivieren:",
+    en: "Reactivate studio:",
+    it: "Riattiva studio:",
+  },
+  button: { de: "Studio reaktivieren", en: "Reactivate studio", it: "Riattiva studio" },
 } satisfies Record<string, Phrase>;
 
 export function tmplBillingArchived(opts: {
@@ -1500,34 +1730,45 @@ const billingPurgeReminderPhrases = {
   subject: {
     de: "Letzte Erinnerung: „{studio}“ wird am {date} gelöscht",
     en: "Final reminder: “{studio}” will be deleted on {date}",
+    it: "Ultimo promemoria: «{studio}» verrà cancellato il {date}",
   },
   preheader: {
     de: "Endgültige Löschung am {date} — jetzt noch reaktivierbar",
     en: "Permanent deletion on {date} — still reactivatable now",
+    it: "Cancellazione definitiva il {date} — ancora riattivabile ora",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
-  heading: { de: "Letzte Erinnerung", en: "Final reminder" },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  heading: {
+    de: "Letzte Erinnerung",
+    en: "Final reminder",
+    it: "Ultimo promemoria",
+  },
   bodyText: {
     de: "dein archiviertes Lumio-Studio „{studio}“ wird am {date} endgültig gelöscht — inklusive aller Original-Dateien und Galerien.",
     en: "your archived Lumio studio “{studio}” will be permanently deleted on {date} — including all original files and galleries.",
+    it: "il tuo studio Lumio archiviato «{studio}» verrà cancellato definitivamente il {date} — inclusi tutti i file originali e le gallerie.",
   },
   bodyHtml: {
     de: "{greeting} — dein archiviertes Studio „{studio}“ wird am {date} endgültig gelöscht, inklusive aller Original-Dateien und Galerien.",
     en: "{greeting} — your archived studio “{studio}” will be permanently deleted on {date}, including all original files and galleries.",
+    it: "{greeting} — il tuo studio archiviato «{studio}» verrà cancellato definitivamente il {date}, inclusi tutti i file originali e le gallerie.",
   },
   keepData: {
     de: "Wenn du deine Daten behalten möchtest, schließe bis dahin ein Abo ab — dann wird alles wiederhergestellt:",
     en: "If you want to keep your data, take out a subscription before then — everything will be restored:",
+    it: "Se vuoi mantenere i tuoi dati, attiva un abbonamento entro quella data — tutto verrà ripristinato:",
   },
-  button: { de: "Studio reaktivieren", en: "Reactivate studio" },
+  button: { de: "Studio reaktivieren", en: "Reactivate studio", it: "Riattiva studio" },
   noRestoreText: {
     de: "Nach dem Stichtag ist eine Wiederherstellung nicht mehr möglich.",
     en: "After that date restoration is no longer possible.",
+    it: "Dopo tale data il ripristino non sarà più possibile.",
   },
   noRestoreBox: {
     de: "Nach dem Stichtag ist keine Wiederherstellung mehr möglich.",
     en: "After that date no restoration is possible.",
+    it: "Dopo tale data non sarà più possibile alcun ripristino.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -1578,16 +1819,36 @@ export function tmplBillingPurgeReminder(opts: {
 
 /** Empfaenger: Super-Admins -> Sprache der Instanz. */
 const superNewTenantPhrases = {
-  subject: { de: "Neuer Tenant: {name} ({plan})", en: "New tenant: {name} ({plan})" },
-  preheader: { de: "Neuer Tenant: {name}", en: "New tenant: {name}" },
-  heading: { de: "Neuer Tenant registriert", en: "New tenant registered" },
-  intro: { de: "Neuer Tenant registriert:", en: "New tenant registered:" },
-  fieldName: { de: "Name", en: "Name" },
-  fieldSlug: { de: "Slug", en: "Slug" },
-  fieldPlan: { de: "Plan", en: "Plan" },
-  fieldOwner: { de: "Owner", en: "Owner" },
-  superAdmin: { de: "Super-Admin", en: "Super admin" },
-  button: { de: "Im Super-Admin öffnen", en: "Open in super admin" },
+  subject: {
+    de: "Neuer Tenant: {name} ({plan})",
+    en: "New tenant: {name} ({plan})",
+    it: "Nuovo tenant: {name} ({plan})",
+  },
+  preheader: {
+    de: "Neuer Tenant: {name}",
+    en: "New tenant: {name}",
+    it: "Nuovo tenant: {name}",
+  },
+  heading: {
+    de: "Neuer Tenant registriert",
+    en: "New tenant registered",
+    it: "Nuovo tenant registrato",
+  },
+  intro: {
+    de: "Neuer Tenant registriert:",
+    en: "New tenant registered:",
+    it: "Nuovo tenant registrato:",
+  },
+  fieldName: { de: "Name", en: "Name", it: "Nome" },
+  fieldSlug: { de: "Slug", en: "Slug", it: "Slug" },
+  fieldPlan: { de: "Plan", en: "Plan", it: "Piano" },
+  fieldOwner: { de: "Owner", en: "Owner", it: "Titolare" },
+  superAdmin: { de: "Super-Admin", en: "Super admin", it: "Super admin" },
+  button: {
+    de: "Im Super-Admin öffnen",
+    en: "Open in super admin",
+    it: "Apri nel super admin",
+  },
 } satisfies Record<string, Phrase>;
 
 export function tmplSuperNewTenant(opts: {
@@ -1630,25 +1891,60 @@ const superDigestPhrases = {
   subject: {
     de: "Lumio Report {date} — {n} neue Tenant(s)",
     en: "Lumio report {date} — {n} new tenant(s)",
+    it: "Report Lumio {date} — {n} nuovi tenant",
   },
   preheader: {
     de: "{n} neue Tenants · {gib} GB gesamt",
     en: "{n} new tenants · {gib} GB total",
+    it: "{n} nuovi tenant · {gib} GB totali",
   },
-  titleText: { de: "Lumio Täglicher Report — {date}", en: "Lumio daily report — {date}" },
-  heading: { de: "Täglicher Report — {date}", en: "Daily report — {date}" },
-  newTenants: { de: "Neue Tenants (24h): {n}", en: "New tenants (24h): {n}" },
+  titleText: {
+    de: "Lumio Täglicher Report — {date}",
+    en: "Lumio daily report — {date}",
+    it: "Report giornaliero Lumio — {date}",
+  },
+  heading: {
+    de: "Täglicher Report — {date}",
+    en: "Daily report — {date}",
+    it: "Report giornaliero — {date}",
+  },
+  newTenants: {
+    de: "Neue Tenants (24h): {n}",
+    en: "New tenants (24h): {n}",
+    it: "Nuovi tenant (24h): {n}",
+  },
   noNewTenants: {
     de: "Keine neuen Tenants in den letzten 24 Stunden.",
     en: "No new tenants in the last 24 hours.",
+    it: "Nessun nuovo tenant nelle ultime 24 ore.",
   },
-  activeTenants: { de: "Aktive Tenants: {n}", en: "Active tenants: {n}" },
-  totalUsers: { de: "User gesamt: {n}", en: "Users total: {n}" },
-  totalStorage: { de: "Speicher gesamt: {n} GB", en: "Storage total: {n} GB" },
-  topStorage: { de: "Top-Speicher:", en: "Top storage:" },
-  nearLimit: { de: "Nahe am Limit (>=90%): {n}", en: "Near the limit (>=90%): {n}" },
-  superAdmin: { de: "Super-Admin", en: "Super admin" },
-  button: { de: "Super-Admin öffnen", en: "Open super admin" },
+  activeTenants: {
+    de: "Aktive Tenants: {n}",
+    en: "Active tenants: {n}",
+    it: "Tenant attivi: {n}",
+  },
+  totalUsers: {
+    de: "User gesamt: {n}",
+    en: "Users total: {n}",
+    it: "Utenti totali: {n}",
+  },
+  totalStorage: {
+    de: "Speicher gesamt: {n} GB",
+    en: "Storage total: {n} GB",
+    it: "Spazio totale: {n} GB",
+  },
+  topStorage: { de: "Top-Speicher:", en: "Top storage:", it: "Spazio maggiore:" },
+  nearLimit: {
+    de: "Nahe am Limit (>=90%): {n}",
+    en: "Near the limit (>=90%): {n}",
+    it: "Vicino al limite (>=90%): {n}",
+  },
+  superAdmin: { de: "Super-Admin", en: "Super admin", it: "Super admin" },
+  button: {
+    de: "Super-Admin öffnen",
+    en: "Open super admin",
+    it: "Apri super admin",
+  },
 } satisfies Record<string, Phrase>;
 
 export function tmplSuperDigest(opts: {
@@ -1732,21 +2028,32 @@ function mailHeading2sub(text: string): string {
 // =============================================================================
 
 const teamMemberJoinedPhrases = {
-  subject: { de: "Neues Team-Mitglied: {who}", en: "New team member: {who}" },
+  subject: {
+    de: "Neues Team-Mitglied: {who}",
+    en: "New team member: {who}",
+    it: "Nuovo membro del team: {who}",
+  },
   preheader: {
     de: "{who} ist deinem Team beigetreten",
     en: "{who} joined your team",
+    it: "{who} si è unito al tuo team",
   },
-  heading: { de: "Neues Team-Mitglied", en: "New team member" },
+  heading: {
+    de: "Neues Team-Mitglied",
+    en: "New team member",
+    it: "Nuovo membro del team",
+  },
   bodyText: {
     de: "{who} ({email}, Rolle: {role}) hat das Konto eingerichtet und ist deinem Team beigetreten.",
     en: "{who} ({email}, role: {role}) set up their account and joined your team.",
+    it: "{who} ({email}, ruolo: {role}) ha creato il proprio account ed è entrato a far parte del tuo team.",
   },
   bodyHtml: {
     de: "{who} ({email}) hat das Konto eingerichtet und ist deinem Team als „{role}“ beigetreten.",
     en: "{who} ({email}) set up their account and joined your team as “{role}”.",
+    it: "{who} ({email}) ha creato il proprio account ed è entrato a far parte del tuo team come «{role}».",
   },
-  button: { de: "Team verwalten", en: "Manage team" },
+  button: { de: "Team verwalten", en: "Manage team", it: "Gestisci team" },
 } satisfies Record<string, Phrase>;
 
 export function tmplTeamMemberJoined(opts: {
@@ -1783,22 +2090,30 @@ const galleryExpiringPhrases = {
   subject: {
     de: "Galerie läuft ab: „{title}“ (in {days})",
     en: "Gallery expiring: “{title}” (in {days})",
+    it: "Galleria in scadenza: «{title}» (tra {days})",
   },
   preheader: {
     de: "„{title}“ läuft in {days} ab",
     en: "“{title}” expires in {days}",
+    it: "«{title}» scade tra {days}",
   },
-  heading: { de: "Galerie läuft bald ab", en: "Gallery expiring soon" },
+  heading: {
+    de: "Galerie läuft bald ab",
+    en: "Gallery expiring soon",
+    it: "Galleria in scadenza a breve",
+  },
   body: {
     de: "Die Galerie „{title}“ läuft am {date} ab (in {days}). Danach ist sie für Kunden nicht mehr erreichbar.",
     en: "The gallery “{title}” expires on {date} (in {days}). After that your customers can no longer reach it.",
+    it: "La galleria «{title}» scade il {date} (tra {days}). Dopo tale data non sarà più raggiungibile dai clienti.",
   },
   hint: {
     de: "Falls du sie länger online halten möchtest, kannst du das Ablaufdatum in den Galerie-Einstellungen anpassen.",
     en: "If you want to keep it online for longer, you can change the expiry date in the gallery settings.",
+    it: "Se vuoi mantenerla online più a lungo, puoi modificare la data di scadenza nelle impostazioni della galleria.",
   },
-  dayOne: { de: "1 Tag", en: "1 day" },
-  dayMany: { de: "{n} Tagen", en: "{n} days" },
+  dayOne: { de: "1 Tag", en: "1 day", it: "1 giorno" },
+  dayMany: { de: "{n} Tagen", en: "{n} days", it: "{n} giorni" },
 } satisfies Record<string, Phrase>;
 
 export function tmplGalleryExpiring(opts: {
@@ -1840,19 +2155,30 @@ export function tmplGalleryExpiring(opts: {
 }
 
 const uploadReceivedPhrases = {
-  subject: { de: "Neue Uploads: „{title}“", en: "New uploads: “{title}”" },
+  subject: {
+    de: "Neue Uploads: „{title}“",
+    en: "New uploads: “{title}”",
+    it: "Nuovi caricamenti: «{title}»",
+  },
   preheader: {
     de: "Neue Uploads in „{title}“",
     en: "New uploads in “{title}”",
+    it: "Nuovi caricamenti in «{title}»",
   },
-  heading: { de: "Neue Uploads eingegangen", en: "New uploads received" },
+  heading: {
+    de: "Neue Uploads eingegangen",
+    en: "New uploads received",
+    it: "Nuovi caricamenti ricevuti",
+  },
   bodyText: {
     de: "Es sind neue Uploads über den Link „{link}“ in der Galerie „{title}“ eingegangen.",
     en: "New uploads arrived through the link “{link}” in the gallery “{title}”.",
+    it: "Sono arrivati nuovi caricamenti tramite il link «{link}» nella galleria «{title}».",
   },
   bodyHtml: {
     de: "Über den Upload-Link „{link}“ sind neue Dateien in „{title}“ eingegangen.",
     en: "New files arrived in “{title}” through the upload link “{link}”.",
+    it: "Tramite il link di caricamento «{link}» sono arrivati nuovi file in «{title}».",
   },
 } satisfies Record<string, Phrase>;
 
@@ -1897,56 +2223,75 @@ export function tmplUploadReceived(opts: {
  * Ton: hilfreich, kein Druck. Zeigt kurz was noch drin steckt, CTA Studio.
  */
 const trialReminderPhrases = {
-  subject: { de: "Dein Lumio-Trial endet {when}", en: "Your Lumio trial ends {when}" },
+  subject: {
+    de: "Dein Lumio-Trial endet {when}",
+    en: "Your Lumio trial ends {when}",
+    it: "La tua prova Lumio termina {when}",
+  },
   preheader: {
     de: "Dein Trial endet am {date} — hier ein kurzer Überblick.",
     en: "Your trial ends on {date} — here is a quick overview.",
+    it: "La tua prova termina il {date} — ecco una breve panoramica.",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
-  tomorrow: { de: "morgen", en: "tomorrow" },
-  inDays: { de: "in {n} Tagen", en: "in {n} days" },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  tomorrow: { de: "morgen", en: "tomorrow", it: "domani" },
+  inDays: { de: "in {n} Tagen", en: "in {n} days", it: "tra {n} giorni" },
   bodyText: {
     de: "Dein kostenloser Trial im {plan}-Plan läuft am {date} ab.",
     en: "Your free trial on the {plan} plan ends on {date}.",
+    it: "La tua prova gratuita nel piano {plan} termina il {date}.",
   },
   bodyHtml: {
     de: "Dein kostenloser Trial im <strong>{plan}</strong>-Plan läuft am <strong>{date}</strong> ab.",
     en: "Your free trial on the <strong>{plan}</strong> plan ends on <strong>{date}</strong>.",
+    it: "La tua prova gratuita nel piano <strong>{plan}</strong> termina il <strong>{date}</strong>.",
   },
   tryText: {
     de: "Falls du noch nicht alles ausprobiert hast — hier ein paar Dinge, die sich lohnen:",
     en: "If you have not tried everything yet, these are worth a look:",
+    it: "Se non hai ancora provato tutto, ecco alcune cose che vale la pena esplorare:",
   },
   tryHtml: {
     de: "Falls du noch nicht alles ausprobiert hast, lohnen sich besonders:",
     en: "If you have not tried everything yet, these are especially worth it:",
+    it: "Se non hai ancora provato tutto, vale particolarmente la pena:",
   },
   tip1: {
     de: "Galerie erstellen und mit einem Kunden teilen",
     en: "Create a gallery and share it with a customer",
+    it: "Creare una galleria e condividerla con un cliente",
   },
   tip2: {
     de: "Kundenauswahl aktivieren (dein Kunde markiert Favoriten)",
     en: "Enable customer selection (your customer marks favourites)",
+    it: "Attivare la selezione cliente (il tuo cliente contrassegna le preferite)",
   },
   tip3: {
     de: "Branding anpassen (Logo, Farben, eigene Domain)",
     en: "Set up your branding (logo, colours, custom domain)",
+    it: "Personalizzare il branding (logo, colori, dominio personalizzato)",
   },
   continues: {
     de: "Wenn du danach weiter bei Lumio bleibst, läuft dein Abo einfach weiter — ohne Unterbrechung, keine Daten gehen verloren.",
     en: "If you stay with Lumio afterwards, your subscription simply continues — no interruption, no data lost.",
+    it: "Se dopo continui a restare su Lumio, il tuo abbonamento prosegue semplicemente — senza interruzioni, nessun dato viene perso.",
   },
   continuesHtml: {
     de: "Wenn du nach dem Trial weiter bei Lumio bleibst, läuft dein Abo einfach weiter — ohne Unterbrechung, keine Daten gehen verloren.",
     en: "If you stay with Lumio after the trial, your subscription simply continues — no interruption, no data lost.",
+    it: "Se dopo la prova continui a restare su Lumio, il tuo abbonamento prosegue semplicemente — senza interruzioni, nessun dato viene perso.",
   },
-  openStudio: { de: "Studio öffnen", en: "Open studio" },
-  unsubText: { de: "Diese Mail abbestellen:", en: "Unsubscribe from this email:" },
+  openStudio: { de: "Studio öffnen", en: "Open studio", it: "Apri studio" },
+  unsubText: {
+    de: "Diese Mail abbestellen:",
+    en: "Unsubscribe from this email:",
+    it: "Annulla iscrizione a questa email:",
+  },
   unsubHtml: {
     de: "Keine weiteren Produkt-Mails erhalten",
     en: "Stop receiving product emails",
+    it: "Non ricevere più email di prodotto",
   },
 } satisfies Record<string, Phrase>;
 
@@ -2018,34 +2363,49 @@ const trialCancelledPhrases = {
   subject: {
     de: "Du hast abgebrochen — dein Studio ist noch bis {date} offen",
     en: "You cancelled — your studio stays open until {date}",
+    it: "Hai annullato — il tuo studio resta aperto fino al {date}",
   },
   preheader: {
     de: "Dein Studio ist noch bis {date} zugänglich.",
     en: "Your studio stays accessible until {date}.",
+    it: "Il tuo studio resta accessibile fino al {date}.",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
   bodyText: {
     de: "Du hast dein Lumio-Abo während des Trials storniert. Dein Studio bleibt noch bis zum {date} voll zugänglich.",
     en: "You cancelled your Lumio subscription during the trial. Your studio stays fully accessible until {date}.",
+    it: "Hai annullato il tuo abbonamento Lumio durante la prova. Il tuo studio resta pienamente accessibile fino al {date}.",
   },
   bodyHtml: {
     de: "Du hast dein Lumio-Abo während des Trials storniert. Dein Studio bleibt noch bis zum <strong>{date}</strong> voll zugänglich.",
     en: "You cancelled your Lumio subscription during the trial. Your studio stays fully accessible until <strong>{date}</strong>.",
+    it: "Hai annullato il tuo abbonamento Lumio durante la prova. Il tuo studio resta pienamente accessibile fino al <strong>{date}</strong>.",
   },
   reactivateText: {
     de: "Falls du es dir anders überlegt hast, kannst du dein Abo jederzeit im Studio reaktivieren:",
     en: "If you change your mind, you can reactivate your subscription in the studio at any time:",
+    it: "Se cambi idea, puoi riattivare il tuo abbonamento nello studio in qualsiasi momento:",
   },
   reactivateHtml: {
     de: "Falls du es dir anders überlegt hast, kannst du dein Abo jederzeit reaktivieren.",
     en: "If you change your mind, you can reactivate your subscription at any time.",
+    it: "Se cambi idea, puoi riattivare il tuo abbonamento in qualsiasi momento.",
   },
-  button: { de: "Abo reaktivieren", en: "Reactivate subscription" },
-  unsubText: { de: "Diese Mail abbestellen:", en: "Unsubscribe from this email:" },
+  button: {
+    de: "Abo reaktivieren",
+    en: "Reactivate subscription",
+    it: "Riattiva abbonamento",
+  },
+  unsubText: {
+    de: "Diese Mail abbestellen:",
+    en: "Unsubscribe from this email:",
+    it: "Annulla iscrizione a questa email:",
+  },
   unsubHtml: {
     de: "Keine weiteren Mails von uns — versprochen.",
     en: "No further emails from us — promised.",
+    it: "Nessuna altra email da parte nostra — promesso.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -2101,45 +2461,62 @@ const winbackPhrases = {
   subjectChurn: {
     de: "Schade, dass du gehst — Lumio wartet noch auf dich",
     en: "Sorry to see you go — Lumio is still here",
+    it: "Ci dispiace vederti andare via — Lumio ti aspetta ancora",
   },
   subjectExpired: {
     de: "Lumio wartet noch auf dich",
     en: "Lumio is still here for you",
+    it: "Lumio ti aspetta ancora",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
   introChurn: {
     de: "Dein Lumio-Abo für „{studio}“ ist ausgelaufen. Schade, dass du gegangen bist.",
     en: "Your Lumio subscription for “{studio}” has ended. Sorry to see you go.",
+    it: "Il tuo abbonamento Lumio per «{studio}» è terminato. Ci dispiace vederti andare via.",
   },
   introExpired: {
     de: "Dein Lumio-Trial für „{studio}“ ist abgelaufen, ohne dass du ein Abo gestartet hast.",
     en: "Your Lumio trial for “{studio}” expired without a subscription being started.",
+    it: "La tua prova Lumio per «{studio}» è scaduta senza che tu abbia attivato un abbonamento.",
   },
   preheaderChurn: {
     de: "Deine Daten sind noch da — falls du doch zurückkommst.",
     en: "Your data is still here — in case you come back.",
+    it: "I tuoi dati sono ancora qui — nel caso tu voglia tornare.",
   },
   preheaderExpired: {
     de: "Dein Trial ist abgelaufen — du kannst jederzeit zurück.",
     en: "Your trial has expired — you can come back any time.",
+    it: "La tua prova è scaduta — puoi tornare in qualsiasi momento.",
   },
   bodyText: {
     de: "Wenn der Zeitpunkt gerade einfach nicht gepasst hat — kein Problem. Du kannst jederzeit wieder einsteigen; deine Daten sind noch da.",
     en: "If the timing simply was not right — no problem. You can come back any time; your data is still here.",
+    it: "Se semplicemente il momento non era quello giusto — nessun problema. Puoi tornare quando vuoi; i tuoi dati sono ancora qui.",
   },
   bodyHtml: {
     de: "Wenn der Zeitpunkt gerade einfach nicht gepasst hat — kein Problem. Du kannst jederzeit wieder einsteigen, deine Daten sind noch da.",
     en: "If the timing simply was not right — no problem. You can come back any time, your data is still here.",
+    it: "Se semplicemente il momento non era quello giusto — nessun problema. Puoi tornare quando vuoi, i tuoi dati sono ancora qui.",
   },
-  openStudio: { de: "Studio öffnen", en: "Open studio" },
-  button: { de: "Jetzt einsteigen", en: "Come back now" },
+  openStudio: { de: "Studio öffnen", en: "Open studio", it: "Apri studio" },
+  button: { de: "Jetzt einsteigen", en: "Come back now", it: "Torna ora" },
   onlyOnce: {
     de: "Das ist die einzige Mail dieser Art, die du von uns bekommst.",
     en: "This is the only email of its kind you will get from us.",
+    it: "Questa è l'unica email di questo tipo che riceverai da noi.",
   },
-  unsubText: { de: "Diese Mail abbestellen:", en: "Unsubscribe from this email:" },
-  unsubHtml: { de: "Keine weiteren Mails erhalten", en: "Stop receiving emails" },
+  unsubText: {
+    de: "Diese Mail abbestellen:",
+    en: "Unsubscribe from this email:",
+    it: "Annulla iscrizione a questa email:",
+  },
+  unsubHtml: {
+    de: "Keine weiteren Mails erhalten",
+    en: "Stop receiving emails",
+    it: "Non ricevere più email",
+  },
 } satisfies Record<string, Phrase>;
 
 export function tmplWinback(opts: {
@@ -2278,24 +2655,35 @@ export function tmplSupportRequest(
 }
 
 const supportConfirmPhrases = {
-  subject: { de: "Deine Support-Anfrage ist angekommen", en: "We received your support request" },
+  subject: {
+    de: "Deine Support-Anfrage ist angekommen",
+    en: "We received your support request",
+    it: "La tua richiesta di supporto è arrivata",
+  },
   preheader: {
     de: "Wir haben deine Anfrage erhalten und melden uns innerhalb eines Werktags.",
     en: "We received your request and will reply within one working day.",
+    it: "Abbiamo ricevuto la tua richiesta e ti risponderemo entro un giorno lavorativo.",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
-  heading: { de: "Anfrage angekommen", en: "Request received" },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  heading: {
+    de: "Anfrage angekommen",
+    en: "Request received",
+    it: "Richiesta ricevuta",
+  },
   body: {
     de: "danke für deine Nachricht. Wir haben sie erhalten und melden uns innerhalb eines Werktags bei dir.",
     en: "thank you for your message. We received it and will get back to you within one working day.",
+    it: "grazie per il tuo messaggio. Lo abbiamo ricevuto e ti risponderemo entro un giorno lavorativo.",
   },
   recap: {
     de: "Zur Sicherheit hier noch einmal, was du uns geschickt hast:",
     en: "For your records, here is what you sent us:",
+    it: "Per tua sicurezza, ecco di nuovo ciò che ci hai inviato:",
   },
-  yourMessage: { de: "Deine Nachricht", en: "Your message" },
-  team: { de: "— Dein Lumio-Team", en: "— Your Lumio team" },
+  yourMessage: { de: "Deine Nachricht", en: "Your message", it: "Il tuo messaggio" },
+  team: { de: "— Dein Lumio-Team", en: "— Your Lumio team", it: "— Il tuo team Lumio" },
 } satisfies Record<string, Phrase>;
 
 /**
@@ -2310,22 +2698,30 @@ const impersonationNoticePhrases = {
   subject: {
     de: 'Support-Zugriff auf dein Studio "{studio}"',
     en: 'Support access to your studio "{studio}"',
+    it: 'Accesso di supporto al tuo studio "{studio}"',
   },
   preheader: {
     de: "Ein Support-Mitglied hat auf „{studio}“ zugegriffen",
     en: "A support member accessed “{studio}”",
+    it: "Un membro del supporto ha effettuato l'accesso a «{studio}»",
   },
-  greetingNamed: { de: "Hallo {name},", en: "Hello {name}," },
-  greetingPlain: { de: "Hallo,", en: "Hello," },
-  heading: { de: "Support-Zugriff auf dein Studio", en: "Support access to your studio" },
+  greetingNamed: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  greetingPlain: { de: "Hallo,", en: "Hello,", it: "Ciao," },
+  heading: {
+    de: "Support-Zugriff auf dein Studio",
+    en: "Support access to your studio",
+    it: "Accesso di supporto al tuo studio",
+  },
   body: {
     de: 'ein Mitglied des Lumio-Supports ({admin}) hat sich gerade in dein Studio "{studio}" eingeloggt, um ein Problem zu untersuchen. Der Zugriff ist auf maximal 60 Minuten begrenzt und wird vollständig im Audit-Log dokumentiert.',
     en: 'a member of Lumio support ({admin}) has just signed in to your studio "{studio}" to investigate an issue. The access is limited to 60 minutes at most and is fully recorded in the audit log.',
+    it: 'un membro del supporto Lumio ({admin}) ha appena effettuato l\'accesso al tuo studio "{studio}" per verificare un problema. L\'accesso è limitato a un massimo di 60 minuti ed è documentato integralmente nel log di controllo.',
   },
-  reason: { de: "Grund: {reason}", en: "Reason: {reason}" },
+  reason: { de: "Grund: {reason}", en: "Reason: {reason}", it: "Motivo: {reason}" },
   notRequested: {
     de: "Falls du KEINEN Support-Zugriff angefragt hast und das ungewöhnlich findest, antworte auf diese Mail.",
     en: "If you did NOT request support access and this seems unusual, reply to this email.",
+    it: "Se NON hai richiesto tu l'accesso di supporto e questo ti sembra insolito, rispondi a questa email.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -2377,67 +2773,98 @@ const preArchivePhrases = {
   noticeSubject: {
     de: "Wichtig: Dein Lumio-Konto „{studio}“ wird am {date} archiviert",
     en: "Important: your Lumio account “{studio}” will be archived on {date}",
+    it: "Importante: il tuo account Lumio «{studio}» verrà archiviato il {date}",
   },
   reminderSubject: {
     de: "Erinnerung: Dein Lumio-Konto „{studio}“ wird in {days} Tagen archiviert",
     en: "Reminder: your Lumio account “{studio}” will be archived in {days} days",
+    it: "Promemoria: il tuo account Lumio «{studio}» verrà archiviato tra {days} giorni",
   },
   noticePreheader: {
     de: "Archivierung am {date} — bitte Daten vorher exportieren",
     en: "Archiving on {date} — please export your data beforehand",
+    it: "Archiviazione il {date} — esporta prima i tuoi dati",
   },
   reminderPreheader: {
     de: "Noch {days} Tage bis zur Archivierung",
     en: "{days} days until archiving",
+    it: "Ancora {days} giorni all'archiviazione",
   },
-  greeting: { de: "Hallo {name},", en: "Hello {name}," },
-  noticeHeading: { de: "Archivierung angekündigt", en: "Archiving announced" },
-  reminderHeading: { de: "Erinnerung: Archivierung", en: "Reminder: archiving" },
+  greeting: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  noticeHeading: {
+    de: "Archivierung angekündigt",
+    en: "Archiving announced",
+    it: "Archiviazione annunciata",
+  },
+  reminderHeading: {
+    de: "Erinnerung: Archivierung",
+    en: "Reminder: archiving",
+    it: "Promemoria: archiviazione",
+  },
   noticeBody: {
     de: "wir möchten dich informieren, dass dein Lumio-Konto „{studio}“ am {date} archiviert wird.",
     en: "we would like to inform you that your Lumio account “{studio}” will be archived on {date}.",
+    it: "vogliamo informarti che il tuo account Lumio «{studio}» verrà archiviato il {date}.",
   },
   reminderBody: {
     de: "dies ist eine Erinnerung: Dein Lumio-Konto „{studio}“ wird am {date} archiviert (in {days} Tagen).",
     en: "this is a reminder: your Lumio account “{studio}” will be archived on {date} (in {days} days).",
+    it: "questo è un promemoria: il tuo account Lumio «{studio}» verrà archiviato il {date} (tra {days} giorni).",
   },
-  meansHeading: { de: "Was bedeutet das?", en: "What does that mean?" },
+  meansHeading: {
+    de: "Was bedeutet das?",
+    en: "What does that mean?",
+    it: "Cosa significa?",
+  },
   means1: {
     de: "Ab diesem Datum kannst du dich nicht mehr einloggen",
     en: "From that date on you can no longer sign in",
+    it: "Da questa data non potrai più accedere",
   },
   means2: {
     de: "Deine Daten bleiben 30 Tage in Karenz erhalten",
     en: "Your data is retained for a 30-day grace period",
+    it: "I tuoi dati vengono conservati per un periodo di tolleranza di 30 giorni",
   },
   means3: {
     de: "Danach werden alle Daten endgültig gelöscht",
     en: "After that all data is permanently deleted",
+    it: "Successivamente tutti i dati verranno cancellati definitivamente",
   },
-  todoHeading: { de: "Was solltest du jetzt tun?", en: "What should you do now?" },
+  todoHeading: {
+    de: "Was solltest du jetzt tun?",
+    en: "What should you do now?",
+    it: "Cosa dovresti fare ora?",
+  },
   todoBody: {
     de: "Logg dich ein und exportiere deine Daten über die Sidebar → „Datenexport“. Pro Galerie wird ein ZIP-Archiv mit Originaldateien und Metadaten erstellt.",
     en: "Sign in and export your data via the sidebar → “Data export”. One ZIP archive with original files and metadata is created per gallery.",
+    it: "Accedi ed esporta i tuoi dati tramite la barra laterale → «Esportazione dati». Per ogni galleria viene creato un archivio ZIP con i file originali e i metadati.",
   },
   reminderTodo: {
     de: "Falls du deine Daten noch herunterladen möchtest, logg dich bitte zeitnah ein und nutze die Sidebar → „Datenexport“. Pro Galerie wird ein ZIP-Archiv mit Originalen und Metadaten erstellt.",
     en: "If you still want to download your data, please sign in soon and use the sidebar → “Data export”. One ZIP archive with originals and metadata is created per gallery.",
+    it: "Se vuoi ancora scaricare i tuoi dati, accedi al più presto e usa la barra laterale → «Esportazione dati». Per ogni galleria viene creato un archivio ZIP con gli originali e i metadati.",
   },
   afterArchive: {
     de: "Nach der Archivierung kannst du dich nicht mehr einloggen. Ein direkter Download-Link wird dir dann automatisch per Mail zugeschickt (30 Tage gültig), aber der Self-Service-Export im Studio ist ab dann nicht mehr verfügbar.",
     en: "After archiving you can no longer sign in. A direct download link is then emailed to you automatically (valid for 30 days), but the self-service export in the studio is no longer available from that point.",
+    it: "Dopo l'archiviazione non potrai più accedere. Un link di download diretto ti verrà inviato automaticamente via email (valido 30 giorni), ma l'esportazione self-service nello studio non sarà più disponibile da quel momento.",
   },
   questions: {
     de: "Falls du das Archivierungsdatum für ein Missverständnis hältst oder Fragen hast, antworte bitte zeitnah auf diese Mail.",
     en: "If you believe the archiving date is a misunderstanding, or you have questions, please reply to this email promptly.",
+    it: "Se ritieni che la data di archiviazione sia un errore o hai domande, rispondi tempestivamente a questa email.",
   },
   reminderQuestions: {
     de: "Falls die Archivierung nicht wie geplant erfolgen soll, antworte bitte zeitnah auf diese Mail.",
     en: "If the archiving should not go ahead as planned, please reply to this email promptly.",
+    it: "Se l'archiviazione non deve procedere come previsto, rispondi tempestivamente a questa email.",
   },
   reminderAnnounce: {
     de: "Wir senden dir 7 Tage vor dem Stichtag noch eine Erinnerung.",
     en: "We will send you another reminder 7 days before the date.",
+    it: "Ti invieremo un altro promemoria 7 giorni prima della data.",
   },
 } satisfies Record<string, Phrase>;
 
@@ -2524,26 +2951,35 @@ const exportReadyPhrases = {
   subject: {
     de: "Dein Datenexport von Lumio ist bereit – {studio}",
     en: "Your Lumio data export is ready – {studio}",
+    it: "La tua esportazione dati di Lumio è pronta – {studio}",
   },
   preheader: {
     de: "Download-Link 30 Tage gültig",
     en: "Download link valid for 30 days",
+    it: "Link di download valido 30 giorni",
   },
-  greeting: { de: "Hallo {name},", en: "Hello {name}," },
-  heading: { de: "Datenexport bereit", en: "Data export ready" },
+  greeting: { de: "Hallo {name},", en: "Hello {name},", it: "Ciao {name}," },
+  heading: {
+    de: "Datenexport bereit",
+    en: "Data export ready",
+    it: "Esportazione dati pronta",
+  },
   body: {
     de: "Dein Lumio-Konto „{studio}“ wurde archiviert und deine Daten werden in Kürze endgültig gelöscht. Du kannst deine Galerien (Originaldateien + Metadaten) als ZIP-Archiv unter folgendem Link herunterladen — der Link ist 30 Tage gültig:",
     en: "Your Lumio account “{studio}” has been archived and your data will be permanently deleted shortly. You can download your galleries (original files + metadata) as ZIP archives from the link below — the link is valid for 30 days:",
+    it: "Il tuo account Lumio «{studio}» è stato archiviato e i tuoi dati verranno cancellati definitivamente a breve. Puoi scaricare le tue gallerie (file originali + metadati) come archivi ZIP dal link seguente — il link è valido 30 giorni:",
   },
   inProgress: {
     de: "Der Export wird gerade erstellt. Pro Galerie dauert das je nach Größe einige Sekunden bis Minuten. Auf der Download-Seite siehst du den jeweiligen Status und kannst fertige Galerien direkt herunterladen.",
     en: "The export is being generated right now. Depending on size it takes seconds to minutes per gallery. The download page shows the status of each and lets you download finished galleries straight away.",
+    it: "L'esportazione è in corso di creazione. A seconda delle dimensioni, richiede da alcuni secondi a qualche minuto per galleria. Nella pagina di download vedrai lo stato di ciascuna e potrai scaricare subito le gallerie pronte.",
   },
   questions: {
     de: "Falls du weitere Fragen hast, antworte auf diese Mail.",
     en: "If you have further questions, reply to this email.",
+    it: "Se hai altre domande, rispondi a questa email.",
   },
-  button: { de: "Export herunterladen", en: "Download export" },
+  button: { de: "Export herunterladen", en: "Download export", it: "Scarica esportazione" },
 } satisfies Record<string, Phrase>;
 
 export function tmplExportReady(opts: {

--- a/apps/frontend/src/app/studio/settings/page.tsx
+++ b/apps/frontend/src/app/studio/settings/page.tsx
@@ -579,11 +579,7 @@ export default function StudioSettingsPage() {
               // entstehen serverseitig, wenn kein Browser beteiligt ist.
               // Best-effort: ein Fehler darf die Umstellung nicht
               // blockieren, das Cookie ist bereits gesetzt.
-              // Mail-Sprache unterstuetzt serverseitig aktuell nur de/en
-              // (siehe MailLocale) — fuer it daher kein Aufruf.
-              if (next !== "it") {
-                void api.updateMyMailLocale(next).catch(() => {});
-              }
+              void api.updateMyMailLocale(next).catch(() => {});
             }}
             className="text-sm rounded-md border border-line-subtle px-2 py-1 bg-surface-raised"
           >
@@ -610,7 +606,7 @@ export default function StudioSettingsPage() {
               value={settings.locale ?? ""}
               onChange={async (e) => {
                 const raw = e.target.value;
-                const next = raw === "" ? null : (raw as "en" | "de");
+                const next = raw === "" ? null : (raw as "en" | "de" | "it");
                 // Optimistisch setzen, damit das Feld nicht zurueckspringt.
                 setSettings({ ...settings, locale: next });
                 try {
@@ -629,6 +625,7 @@ export default function StudioSettingsPage() {
               <option value="">{t("settings.mailLocaleDefault")}</option>
               <option value="de">Deutsch</option>
               <option value="en">English</option>
+              <option value="it">Italiano</option>
             </select>
           </section>
         )}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1949,8 +1949,8 @@ export const api = {
 
   /** Persoenliche Mail-Sprache. Best-effort: Fehler duerfen die
    *  Sprachumstellung der Oberflaeche nicht blockieren. */
-  updateMyMailLocale: (locale: "de" | "en" | null) =>
-    request<{ locale: "de" | "en" | null }>("/settings/my-locale", {
+  updateMyMailLocale: (locale: "de" | "en" | "it" | null) =>
+    request<{ locale: "de" | "en" | "it" | null }>("/settings/my-locale", {
       method: "PUT",
       body: JSON.stringify({ locale }),
     }),
@@ -2015,7 +2015,7 @@ export const api = {
   updateTenantSettings: (patch: {
     displayName?: string | null;
     /** Sprache der Mails an die Kunden. Null = Instanz-Default. */
-    mailLocale?: "de" | "en" | null;
+    mailLocale?: "de" | "en" | "it" | null;
     slug?: string;
     watermarkText?: string | null;
     customDomain?: string | null;
@@ -4137,7 +4137,7 @@ export interface TenantSettings {
    *  fallen alle Caller auf 'name' zurueck. */
   displayName: string | null;
   /** Sprache der Mails an die Kunden dieses Studios. Null = Instanz-Default. */
-  locale: "de" | "en" | null;
+  locale: "de" | "en" | "it" | null;
   watermarkText: string | null;
   watermarkImageKey: string | null;
   customDomain?: string | null;


### PR DESCRIPTION
## Summary

- Adds `"it"` to `MAIL_LOCALES` in `mail-i18n.ts` — the single source of truth for supported mail languages. `Phrase = Record<MailLocale, string>` is all-or-nothing by design, so this required a reviewed Italian value for every mail template: 307 phrases in `mail.ts`, 33 in `mail-print.ts`, 3 in the shared `common` block, plus `localeTag()`'s BCP-47 mapping (`it` → `it-IT`). All translated natively — no machine translation, per the standard set in #12.
- Frontend: the `"de" | "en"` unions for the personal mail-locale endpoint and the tenant customer-mail-locale setting now include `"it"` end to end (`api.ts`, `studio/settings/page.tsx`). Removed the write-through special-case that skipped `/settings/my-locale` for `"it"` — it existed only because the server used to reject that value, and it doesn't anymore.
- `DEFAULT_MAIL_LOCALE` stays `de` — no behavior change for instances that configure nothing, same guarantee given for prior locale additions. Its zod schema is a literal list (kept manually in sync with `MAIL_LOCALES`, documented in place) rather than an import, since importing from `mail-i18n.ts` would make it circular with `config.ts`.
- Two hardcoded German strings found in `mail-print.ts` while working through its templates (a heading and a button label that never went through `phrase()` for *any* language, not just Italian) — translated alongside the Italian work since they were sitting right there.

Rebased onto current `main` after #15 landed and the mail layer moved further (configurable footer, required `locale` on every `renderMailLayout()` call). Two things fell out of that rebase, not just conflict resolution:

- `mail-layout.ts` grew its own `layoutPhrases.sentVia` Phrase for the new configurable-footer default text — needed its Italian value too.
- `mail-i18n.test.ts`'s `LOCALES` array was a hand-written `["de", "en"]` with a comment claiming the compiler keeps it in sync with `MailLocale` — not true for a plain array type, so it was silently only testing two locales. Now imports `MAIL_LOCALES` directly (same fix in `mail-footer.render.test.ts`), so the Finnish locale lands with test coverage for free instead of needing its own follow-up patch to these files.

Refs #12, #16

## Test plan

- [x] `npx tsc --noEmit` clean in `apps/api` and `apps/frontend`
- [x] `node apps/api/scripts/check-mail-i18n.mjs` — passes
- [x] `node apps/frontend/scripts/check-i18n.mjs` — passes (2567 keys)
- [x] `npx vitest run` in `apps/api` — 184/184 tests pass across 23 files, including the new `mail-locale-endtoend.test.ts`, `mail-footer.render.test.ts`, `mail-footer-precedence.test.ts`, `config.footer.test.ts`