### PR TITLE
feat(gallery): permanent delete for archived galleries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Changes werden trotzdem klar als solche markiert. Details: `docs/VERSIONING.md`.
 
 ## [Unreleased]
 
+### Added
+
+- Galleries can now be permanently deleted. A gallery must be archived first, deletion respects studio roles (admins can delete any gallery they can see, owners only their own, members not at all), and any gallery with print orders is protected so order records are never lost.
+
 ## [0.74.1] - 2026-08-27
 
 A pull is enough. Only the main server is affected.

--- a/apps/api/src/lib/gallery-access.ts
+++ b/apps/api/src/lib/gallery-access.ts
@@ -8,8 +8,11 @@
  *   3. Er ist Studio-Inhaber (Rolle "owner") — Sicherheitsnetz, damit
  *      keine Galerien verwaisen, wenn ein Mitarbeiter das Studio verlässt
  *
- * "Zugriff" bedeutet volle Rechte: sehen, bearbeiten, löschen, freigeben.
- * Wer keinen Zugriff hat, sieht die Galerie gar nicht (404).
+ * "Zugriff" bedeutet volle Rechte: sehen, bearbeiten, freigeben. Wer keinen
+ * Zugriff hat, sieht die Galerie gar nicht (404).
+ *
+ * Ausnahme: das endgueltige Loeschen einer Galerie folgt einer eigenen,
+ * strengeren Regel — siehe canDeleteGallery() weiter unten.
  *
  * WICHTIG: Diese Helper sind die EINZIGE Stelle, an der das Modell
  * definiert ist. Alle Routen, die auf Galerien (oder deren Dateien,
@@ -55,6 +58,8 @@ export const galleryRelationAccessWhere = galleryAccessWhere;
  * Erwartet `ownerId` und — sofern relevant — die `collaborators` als
  * `{ userId }[]`. Fehlt `collaborators`, zählt nur Ersteller + Owner-Rolle
  * (der Aufrufer muss die Relation dann mitladen, wenn Freigaben zählen).
+ *
+ * Deckt NICHT das Loeschen ab — dafuer gilt canDeleteGallery().
  */
 export function canAccessGallery(
   s: SessionContext,
@@ -71,3 +76,25 @@ export function canAccessGallery(
  * das auch — die Prüfung ist daher identisch zu canAccessGallery.
  */
 export const canManageGalleryCollaborators = canAccessGallery;
+
+/**
+ * Delete-Berechtigung — bewusst STRENGER als canAccessGallery, das sonst
+ * fuer alle Aktionen gilt (siehe Modul-Kommentar oben). Produktentscheidung:
+ *
+ *   - Admin darf jede Galerie loeschen, die er ohnehin sehen darf
+ *     (galleryAccessWhere bleibt unveraendert — keine Ausweitung der
+ *     Sichtbarkeit, nur der Loesch-Berechtigung innerhalb dessen).
+ *   - Owner darf nur eigene Galerien loeschen (ownerId === eigene id) —
+ *     auch eine Collaborator-Freigabe auf eine fremde Galerie reicht
+ *     dafuer NICHT, obwohl sie fuer canAccessGallery genuegen wuerde.
+ *   - Member darf nie loeschen, unabhaengig von Ersteller- oder
+ *     Freigabe-Status.
+ */
+export function canDeleteGallery(
+  s: SessionContext,
+  gallery: { ownerId: string }
+): boolean {
+  if (s.user.role === "admin") return true;
+  if (s.user.role === "owner") return gallery.ownerId === s.user.id;
+  return false;
+}

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -18,6 +18,7 @@ import {
   smartCollectionFilterSchema,
   buildWhereClause,
 } from "../services/smart-collection-filter.js";
+import { canDeleteGallery } from "../lib/gallery-access.js";
 
 const createSchema = z.object({
   name: z.string().min(1).max(120),
@@ -201,6 +202,7 @@ export async function registerCollectionRoutes(app: FastifyInstance) {
           watermarkEnabled: true,
           createdAt: true,
           updatedAt: true,
+          ownerId: true,
           _count: { select: { files: true } },
           tags: {
             select: {
@@ -223,6 +225,7 @@ export async function registerCollectionRoutes(app: FastifyInstance) {
           createdAt: g.createdAt,
           updatedAt: g.updatedAt,
           fileCount: g._count.files,
+          canDelete: canDeleteGallery(s, g),
           tags: g.tags.map((gt) => gt.tag),
         })),
       };

--- a/apps/api/src/routes/galleries.delete.test.ts
+++ b/apps/api/src/routes/galleries.delete.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests für die Delete-Guards von DELETE /galleries/:id.
+ *
+ * canDeleteGallery() wird direkt aus gallery-access.ts importiert — die
+ * Datei hat nur Typ-Imports (Prisma, SessionContext), also keine
+ * Laufzeit-Abhängigkeit auf db.ts/config.ts (die beim Import fail-fast
+ * echte Env-Vars/eine DB-Verbindung brauchen). Die Guard-Reihenfolge
+ * (Berechtigung → archiviert → Druckbestellungen) selbst lebt inline in
+ * der Route und wird hier als Kopie geprüft — Synchronisation per
+ * Code-Review, gleiches Vorgehen wie in sections.test.ts/audit.test.ts.
+ */
+import { describe, it, expect } from "vitest";
+import { canDeleteGallery } from "../lib/gallery-access.js";
+import type { SessionContext } from "../services/auth.js";
+
+const OWNER_ID = "11111111-2222-3333-4444-555555555555";
+const OTHER_ID = "11111111-2222-3333-4444-666666666666";
+
+function session(role: "owner" | "admin" | "member", userId: string) {
+  return { user: { id: userId, role } } as unknown as SessionContext;
+}
+
+describe("canDeleteGallery", () => {
+  it("admin may delete any gallery", () => {
+    expect(
+      canDeleteGallery(session("admin", OTHER_ID), { ownerId: OWNER_ID })
+    ).toBe(true);
+  });
+
+  it("owner may delete their own gallery", () => {
+    expect(
+      canDeleteGallery(session("owner", OWNER_ID), { ownerId: OWNER_ID })
+    ).toBe(true);
+  });
+
+  it("owner may not delete someone else's gallery", () => {
+    expect(
+      canDeleteGallery(session("owner", OTHER_ID), { ownerId: OWNER_ID })
+    ).toBe(false);
+  });
+
+  it("member may never delete, even their own gallery", () => {
+    expect(
+      canDeleteGallery(session("member", OWNER_ID), { ownerId: OWNER_ID })
+    ).toBe(false);
+  });
+});
+
+// Guard-Reihenfolge aus der Route kopiert: Berechtigung zuerst, dann
+// archiviert-Status, dann Druckbestellungen. Reihenfolge ist bewusst so,
+// nicht vertauschbar — Test haelt das fest.
+function evaluateDeleteGuards(
+  s: SessionContext,
+  gallery: { ownerId: string; status: string },
+  printOrderCount: number
+): "ok" | "delete_not_allowed" | "gallery_not_archived" | "gallery_has_print_orders" {
+  if (!canDeleteGallery(s, gallery)) return "delete_not_allowed";
+  if (gallery.status !== "archived") return "gallery_not_archived";
+  if (printOrderCount > 0) return "gallery_has_print_orders";
+  return "ok";
+}
+
+describe("DELETE /galleries/:id guard order", () => {
+  it("allows deletion when archived, permitted and no print orders", () => {
+    const s = session("owner", OWNER_ID);
+    const gallery = { ownerId: OWNER_ID, status: "archived" };
+    expect(evaluateDeleteGuards(s, gallery, 0)).toBe("ok");
+  });
+
+  it("rejects a live gallery even if otherwise deletable", () => {
+    const s = session("owner", OWNER_ID);
+    const gallery = { ownerId: OWNER_ID, status: "live" };
+    expect(evaluateDeleteGuards(s, gallery, 0)).toBe("gallery_not_archived");
+  });
+
+  it("rejects an archived gallery with print orders", () => {
+    const s = session("admin", OTHER_ID);
+    const gallery = { ownerId: OWNER_ID, status: "archived" };
+    expect(evaluateDeleteGuards(s, gallery, 1)).toBe("gallery_has_print_orders");
+  });
+
+  it("permission is checked before archived-state or print orders", () => {
+    const s = session("owner", OTHER_ID); // not the gallery owner
+    const gallery = { ownerId: OWNER_ID, status: "live" };
+    expect(evaluateDeleteGuards(s, gallery, 5)).toBe("delete_not_allowed");
+  });
+
+  it("member is rejected regardless of ownership, status or orders", () => {
+    const s = session("member", OWNER_ID);
+    const gallery = { ownerId: OWNER_ID, status: "archived" };
+    expect(evaluateDeleteGuards(s, gallery, 0)).toBe("delete_not_allowed");
+  });
+});

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -27,7 +27,7 @@ import { resolveGalleryBranding } from "../services/branding.js";
 import { logEvent } from "../services/audit.js";
 import { checkActiveGalleriesLimit, checkFeatureAvailable } from "../services/usage.js";
 import { publishEvent } from "../services/webhooks.js";
-import { galleryAccessWhere } from "../lib/gallery-access.js";
+import { galleryAccessWhere, canDeleteGallery } from "../lib/gallery-access.js";
 import {
   createVisitorToken,
   verifyVisitorToken,
@@ -417,6 +417,7 @@ export async function registerGalleryRoutes(app: FastifyInstance) {
           heroFileId: true,
           createdAt: true,
           updatedAt: true,
+          ownerId: true,
           _count: { select: { files: true } },
           tags: {
             select: {
@@ -520,6 +521,7 @@ export async function registerGalleryRoutes(app: FastifyInstance) {
           createdAt: g.createdAt,
           updatedAt: g.updatedAt,
           fileCount: g._count.files,
+          canDelete: canDeleteGallery(s, g),
           tags: g.tags.map((gt) => gt.tag),
           coverThumbUrl: coverUrlByGallery.get(g.id) ?? null,
           stats: {
@@ -1048,8 +1050,18 @@ export async function registerGalleryRoutes(app: FastifyInstance) {
   // -------------------------------------------------------------------------
   // DELETE /galleries/:id
   // -------------------------------------------------------------------------
-  // Soft-Delete via status=archived ist auch sinnvoll, aber für jetzt:
-  // Hard-Delete. S3-Aufräumen läuft als Worker-Job (TODO).
+  // Hard-Delete. S3-Aufräumen läuft als Worker-Job. Vor dem eigentlichen
+  // Löschen greifen drei Guards, in dieser Reihenfolge:
+  //   1. Rollen-Berechtigung (canDeleteGallery) — strenger als der normale
+  //      Zugriff, siehe gallery-access.ts.
+  //   2. Galerie muss archiviert sein — verhindert das versehentliche
+  //      Löschen einer live-Galerie, der Kunde könnte gerade drauf sein.
+  //      Server-seitig statt nur im UI, weil die Route auch direkt vom
+  //      Lightroom-Plugin/Skripten angesprochen wird.
+  //   3. Keine Druckbestellungen — PrintOrderItem.fileId ist als
+  //      onDelete: Restrict modelliert, ein Hard-Delete würde sonst
+  //      Bestell-/Zahlungsdaten mitreissen oder an der DB-Constraint
+  //      scheitern.
   app.delete<{ Params: { id: string } }>(
     "/galleries/:id",
     async (req, reply) => {
@@ -1060,9 +1072,22 @@ export async function registerGalleryRoutes(app: FastifyInstance) {
           tenantId: req.tenantId,
           ...galleryAccessWhere(s),
         },
-        select: { id: true, slug: true },
+        select: { id: true, slug: true, status: true, ownerId: true },
       });
       if (!existing) return reply.status(404).send({ error: "not_found" });
+
+      if (!canDeleteGallery(s, existing)) {
+        return reply.status(403).send({ error: "delete_not_allowed" });
+      }
+      if (existing.status !== "archived") {
+        return reply.status(409).send({ error: "gallery_not_archived" });
+      }
+      const printOrderCount = await prisma.printOrder.count({
+        where: { galleryId: existing.id },
+      });
+      if (printOrderCount > 0) {
+        return reply.status(409).send({ error: "gallery_has_print_orders" });
+      }
 
       const tenantId = req.tenantId;
       await prisma.gallery.delete({ where: { id: existing.id } });

--- a/apps/frontend/src/app/studio/page.tsx
+++ b/apps/frontend/src/app/studio/page.tsx
@@ -17,7 +17,7 @@ import { PageHeader } from "@/components/studio/PageHeader";
 import { Button, Input, Textarea, Select } from "@/components/ui";
 import { TagChip } from "@/components/studio/TagPicker";
 import { useErrorText } from "@/lib/error-i18n";
-import { useConfirm, useNotify} from "@/components/ui/dialogs";
+import { useConfirm, useNotify, usePrompt } from "@/components/ui/dialogs";
 
 export default function StudioPage() {
   const confirm = useConfirm();
@@ -855,6 +855,7 @@ function GalleryCard({
 }) {
   const notify = useNotify();
   const errText = useErrorText();
+  const ask = usePrompt();
   const t = useT();
   const [menuOpen, setMenuOpen] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -892,6 +893,30 @@ function GalleryCard({
     setMenuOpen(false);
     try {
       await api.updateGallery(g.id, { status });
+      onChanged();
+    } catch (err) {
+      notify(errText(err, t("common.error")));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function deleteForever() {
+    setMenuOpen(false);
+    const typed = await ask({
+      title: t("studio.deleteConfirmTitle"),
+      message: t("studio.deleteConfirmMessage", { title: g.title }),
+      placeholder: g.title,
+      confirmLabel: t("common.delete"),
+    });
+    if (typed === null) return;
+    if (typed.trim().toLowerCase() !== g.title.trim().toLowerCase()) {
+      notify(t("studio.deleteTitleMismatch"));
+      return;
+    }
+    setBusy(true);
+    try {
+      await api.deleteGallery(g.id);
       onChanged();
     } catch (err) {
       notify(errText(err, t("common.error")));
@@ -1049,16 +1074,30 @@ function GalleryCard({
                 {t("studio.tabShare")}
               </button>
               {g.status === "archived" ? (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    void setStatus("live");
-                  }}
-                  className="w-full text-left px-3 py-1.5 text-ink-secondary hover:text-ink-primary hover:bg-surface-sunken"
-                >
-                  {t("studio.reactivate")}
-                </button>
+                <>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      void setStatus("live");
+                    }}
+                    className="w-full text-left px-3 py-1.5 text-ink-secondary hover:text-ink-primary hover:bg-surface-sunken"
+                  >
+                    {t("studio.reactivate")}
+                  </button>
+                  {g.canDelete && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        void deleteForever();
+                      }}
+                      className="w-full text-left px-3 py-1.5 text-semantic-danger/90 hover:text-semantic-danger hover:bg-surface-sunken"
+                    >
+                      {t("studio.deletePermanently")}
+                    </button>
+                  )}
+                </>
               ) : (
                 <button
                   type="button"

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -105,6 +105,10 @@ export interface Gallery {
   coverThumbUrl?: string | null;
   /** Aggregierte Kennzahlen für die Übersichtskarte. */
   stats?: { visits: number; likes: number; selected: number };
+  /** Darf der eingeloggte User diese Galerie endgültig löschen? Vom
+   *  Backend rollenbasiert berechnet (canDeleteGallery) — nur in den
+   *  Listen-Endpunkten (listGalleries/runCollection) gesetzt. */
+  canDelete?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/apps/frontend/src/lib/i18n/de.ts
+++ b/apps/frontend/src/lib/i18n/de.ts
@@ -67,6 +67,7 @@ export const de: LocaleDict = {
     captchaFailed:
       "CAPTCHA-Prüfung fehlgeschlagen. Bitte lade die Seite neu und versuche es erneut.",
     customerMismatch: "Session gehört nicht zu diesem Tenant.",
+    deleteNotAllowed: "Du hast keine Berechtigung, diese Galerie zu löschen.",
     emailTaken: "Diese E-Mail-Adresse ist im Studio bereits vergeben.",
     galleryHasPrintOrders:
       "Diese Galerie hat Druckbestellungen und kann nicht gelöscht werden.",

--- a/apps/frontend/src/lib/i18n/de.ts
+++ b/apps/frontend/src/lib/i18n/de.ts
@@ -68,6 +68,10 @@ export const de: LocaleDict = {
       "CAPTCHA-Prüfung fehlgeschlagen. Bitte lade die Seite neu und versuche es erneut.",
     customerMismatch: "Session gehört nicht zu diesem Tenant.",
     emailTaken: "Diese E-Mail-Adresse ist im Studio bereits vergeben.",
+    galleryHasPrintOrders:
+      "Diese Galerie hat Druckbestellungen und kann nicht gelöscht werden.",
+    galleryNotArchived:
+      "Die Galerie muss vor dem endgültigen Löschen archiviert werden.",
     inUse:
       "Es gibt Bestellungen mit dieser Variante. Deaktiviere stattdessen.",
     invalidChallenge: "Bitte erneut anmelden.",
@@ -706,6 +710,12 @@ export const de: LocaleDict = {
     lbActualSizeTitle: "Originalgröße (0)",
       reactivate: "Reaktivieren",
     archive: "Archivieren",
+    deletePermanently: "Endgültig löschen",
+    deleteConfirmTitle: "Galerie endgültig löschen",
+    deleteConfirmMessage:
+      "Damit werden „{title}“ und alles darin — Dateien, Freigabe-Links, Kommentare und Bewertungen — endgültig gelöscht. Das kann nicht rückgängig gemacht werden.\n\nZum Bestätigen den Galerie-Titel eingeben.",
+    deleteTitleMismatch:
+      "Der eingegebene Text stimmt nicht mit dem Galerie-Titel überein. Es wurde nichts gelöscht.",
     deleteActive: "Aktive löschen",
     saveFilterHint:
       "Speichere einen Filter unter einem Namen. Er erscheint dann oben in der Galerien-Liste als Schnellzugriff.",

--- a/apps/frontend/src/lib/i18n/en.ts
+++ b/apps/frontend/src/lib/i18n/en.ts
@@ -68,6 +68,7 @@ export const en = {
     captchaFailed:
       "CAPTCHA check failed. Please reload the page and try again.",
     customerMismatch: "This session does not belong to this tenant.",
+    deleteNotAllowed: "You don't have permission to delete this gallery.",
     emailTaken: "That email address is already in use in this studio.",
     galleryHasPrintOrders:
       "This gallery has print orders and cannot be deleted.",

--- a/apps/frontend/src/lib/i18n/en.ts
+++ b/apps/frontend/src/lib/i18n/en.ts
@@ -69,6 +69,9 @@ export const en = {
       "CAPTCHA check failed. Please reload the page and try again.",
     customerMismatch: "This session does not belong to this tenant.",
     emailTaken: "That email address is already in use in this studio.",
+    galleryHasPrintOrders:
+      "This gallery has print orders and cannot be deleted.",
+    galleryNotArchived: "Archive the gallery before deleting it permanently.",
     inUse:
       "There are orders using this variant. Deactivate it instead.",
     invalidChallenge: "Please sign in again.",
@@ -707,6 +710,12 @@ export const en = {
     lbActualSizeTitle: "Actual size (0)",
       reactivate: "Reactivate",
     archive: "Archive",
+    deletePermanently: "Delete permanently",
+    deleteConfirmTitle: "Delete gallery permanently",
+    deleteConfirmMessage:
+      "This permanently deletes “{title}” and everything in it — files, share links, comments and ratings. This cannot be undone.\n\nType the gallery title to confirm.",
+    deleteTitleMismatch:
+      "The text you typed doesn't match the gallery title. Nothing was deleted.",
     deleteActive: "Delete active",
     saveFilterHint:
       "Save a filter under a name. It then appears above the gallery list as a shortcut.",

--- a/apps/frontend/src/lib/i18n/fi.ts
+++ b/apps/frontend/src/lib/i18n/fi.ts
@@ -69,6 +69,9 @@ export const fi = {
       "CAPTCHA-tarkistus epäonnistui. Lataa sivu uudelleen ja yritä uudestaan.",
     customerMismatch: "Tämä istunto ei kuulu tälle studiolle.",
     emailTaken: "Tämä sähköpostiosoite on jo käytössä tässä studiossa.",
+    galleryHasPrintOrders:
+      "Tällä gallerialla on tulostustilauksia, eikä sitä voi poistaa.",
+    galleryNotArchived: "Arkistoi galleria ennen sen pysyvää poistamista.",
     inUse:
       "Tähän varianttiin liittyy tilauksia. Poista se sen sijaan käytöstä.",
     invalidChallenge: "Kirjaudu sisään uudelleen.",
@@ -707,6 +710,12 @@ export const fi = {
     lbActualSizeTitle: "Todellinen koko (0)",
       reactivate: "Aktivoi uudelleen",
     archive: "Arkistoi",
+    deletePermanently: "Poista pysyvästi",
+    deleteConfirmTitle: "Poista galleria pysyvästi",
+    deleteConfirmMessage:
+      "Tämä poistaa pysyvästi galleria ”{title}” ja kaiken sen sisällön — tiedostot, jakolinkit, kommentit ja arvostelut. Toimintoa ei voi perua.\n\nVahvista kirjoittamalla gallerian nimi.",
+    deleteTitleMismatch:
+      "Kirjoittamasi teksti ei vastaa gallerian nimeä. Mitään ei poistettu.",
     deleteActive: "Poista aktiiviset",
     saveFilterHint:
       "Tallenna suodatin nimellä. Se näkyy tämän jälkeen pikavalintana gallerialistan yläpuolella.",

--- a/apps/frontend/src/lib/i18n/fi.ts
+++ b/apps/frontend/src/lib/i18n/fi.ts
@@ -714,7 +714,7 @@ export const fi = {
     deletePermanently: "Poista pysyvästi",
     deleteConfirmTitle: "Poista galleria pysyvästi",
     deleteConfirmMessage:
-      "Tämä poistaa pysyvästi galleria ”{title}” ja kaiken sen sisällön — tiedostot, jakolinkit, kommentit ja arvostelut. Toimintoa ei voi perua.\n\nVahvista kirjoittamalla gallerian nimi.",
+      "Tämä poistaa pysyvästi gallerian ”{title}” ja kaiken sen sisällön — tiedostot, jakolinkit, kommentit ja arvostelut. Toimintoa ei voi perua.\n\nVahvista kirjoittamalla gallerian nimi.",
     deleteTitleMismatch:
       "Kirjoittamasi teksti ei vastaa gallerian nimeä. Mitään ei poistettu.",
     deleteActive: "Poista aktiiviset",

--- a/apps/frontend/src/lib/i18n/fi.ts
+++ b/apps/frontend/src/lib/i18n/fi.ts
@@ -68,6 +68,7 @@ export const fi = {
     captchaFailed:
       "CAPTCHA-tarkistus epäonnistui. Lataa sivu uudelleen ja yritä uudestaan.",
     customerMismatch: "Tämä istunto ei kuulu tälle studiolle.",
+    deleteNotAllowed: "Sinulla ei ole oikeutta poistaa tätä galleriaa.",
     emailTaken: "Tämä sähköpostiosoite on jo käytössä tässä studiossa.",
     galleryHasPrintOrders:
       "Tällä gallerialla on tulostustilauksia, eikä sitä voi poistaa.",

--- a/apps/frontend/src/lib/i18n/it.ts
+++ b/apps/frontend/src/lib/i18n/it.ts
@@ -65,6 +65,7 @@ export const it: LocaleDict = {
     captchaFailed:
       "Verifica CAPTCHA non riuscita. Ricarica la pagina e riprova.",
     customerMismatch: "Questa sessione non appartiene a questo tenant.",
+    deleteNotAllowed: "Non hai il permesso di eliminare questa galleria.",
     emailTaken: "Questo indirizzo email è già in uso in questo studio.",
     galleryHasPrintOrders:
       "Questa galleria ha ordini di stampa e non può essere eliminata.",

--- a/apps/frontend/src/lib/i18n/it.ts
+++ b/apps/frontend/src/lib/i18n/it.ts
@@ -66,6 +66,10 @@ export const it: LocaleDict = {
       "Verifica CAPTCHA non riuscita. Ricarica la pagina e riprova.",
     customerMismatch: "Questa sessione non appartiene a questo tenant.",
     emailTaken: "Questo indirizzo email è già in uso in questo studio.",
+    galleryHasPrintOrders:
+      "Questa galleria ha ordini di stampa e non può essere eliminata.",
+    galleryNotArchived:
+      "Archivia la galleria prima di eliminarla definitivamente.",
     inUse:
       "Ci sono ordini che usano questa variante. Disattivala invece di eliminarla.",
     invalidChallenge: "Accedi di nuovo.",
@@ -706,6 +710,12 @@ export const it: LocaleDict = {
     lbActualSizeTitle: "Dimensione reale (0)",
     reactivate: "Riattiva",
     archive: "Archivia",
+    deletePermanently: "Elimina definitivamente",
+    deleteConfirmTitle: "Elimina definitivamente la galleria",
+    deleteConfirmMessage:
+      "Questo elimina definitivamente “{title}” e tutto il suo contenuto — file, link di condivisione, commenti e valutazioni. L'operazione non può essere annullata.\n\nDigita il titolo della galleria per confermare.",
+    deleteTitleMismatch:
+      "Il testo digitato non corrisponde al titolo della galleria. Non è stato eliminato nulla.",
     deleteActive: "Elimina attive",
     saveFilterHint:
       "Salva un filtro con un nome. Comparirà poi sopra l'elenco delle gallerie come scorciatoia.",


### PR DESCRIPTION
## Summary

- Add "Delete permanently" to the dashboard gallery card menu, wiring up the
  existing (previously unused) `api.deleteGallery` client and the existing
  `DELETE /galleries/:id` route.
- Require the gallery to be archived first, enforced both in the menu and
  server-side (409 `gallery_not_archived`) — the API is also used outside this
  UI, so the guard lives in the API itself.
- Add a server-side guard against deleting a gallery with any print orders
  (409 `gallery_has_print_orders`) — `PrintOrderItem` rows reference `File` via
  a `Restrict` FK, so this also prevents an unfriendly DB constraint error.
- Add role-based delete authorization (`canDeleteGallery` in
  `gallery-access.ts`, deliberately stricter than the general access model):
  Admin → any visible gallery, Owner → only their own, Member → never. Exposed
  to the frontend as a `canDelete` field on each gallery, so the UI never
  computes permission logic itself.
- Confirmation requires typing the gallery's exact title via the shared
  `usePrompt()` primitive.
- New `apiError.*` i18n keys for the two new error cases.

Closes #24.

## Test plan

- [x] `npm run type-check` and `npm run check:i18n` in `apps/frontend`
- [x] `npm run test` in `apps/api` (9 new tests covering the permission +
      guard-order logic, 200/200 total passing)
- [x] Manual: archive + delete a gallery with no print orders as its owner,
      confirm it disappears and an audit log entry / cleanup job appear
- [x] Manual: wrong typed title → no request sent, inline error shown
- [ ] Manual: as owner, confirm the option is absent on a gallery you don't own
- [ ] Manual: as member, confirm the option never appears
- [ ] Manual: as admin, confirm delete works on any visible gallery
- [ ] Manual: direct API call on a live (non-archived) gallery → 409
- [ ] Manual: archived gallery with a print order → 409, gallery not deleted

Note: `npm run lint` (`next lint`) currently fails on this repo's Next.js 16
regardless of branch — pre-existing tooling issue, not introduced here.