### PR TITLE
feat(galleries): allow owner to set a custom gallery slug

### DIFF
--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -881,15 +881,18 @@ export async function registerGalleryRoutes(app: FastifyInstance) {
       });
       if (!existing) return reply.status(404).send({ error: "not_found" });
 
-      // Custom slug: owner-only, because changing it breaks any link
-      // already shared with clients (same tradeoff as the tenant
-      // subdomain change in routes/settings.ts).
+      // Custom slug: owner or admin, not member. Changing it breaks any
+      // link already shared with clients (same tradeoff as the tenant
+      // subdomain change in routes/settings.ts), but the REACH is already
+      // limited by galleryAccessWhere() above — an admin only ever gets
+      // here for a gallery they own or collaborate on, an owner for any
+      // gallery in the studio. Same "not a member" rule as canDeleteGallery.
       let newGallerySlug: string | undefined;
       if (body.slug !== undefined) {
-        if (s.user.role !== "owner") {
+        if (s.user.role !== "owner" && s.user.role !== "admin") {
           return reply.status(403).send({
-            error: "gallery_slug_owner_only",
-            message: "Nur der Owner kann die Galerie-URL ändern.",
+            error: "gallery_slug_forbidden",
+            message: "Nur Owner oder Admin können die Galerie-URL ändern.",
           });
         }
         const candidate = body.slug.trim().toLowerCase();
@@ -932,109 +935,130 @@ export async function registerGalleryRoutes(app: FastifyInstance) {
         };
       }
 
-      const gallery = await prisma.gallery.update({
-        where: { id: existing.id },
-        data: {
-          ...(passwordHashUpdate ?? {}),
-          ...(newGallerySlug !== undefined ? { slug: newGallerySlug } : {}),
-          ...(body.title !== undefined ? { title: body.title } : {}),
-          ...(body.description !== undefined
-            ? { description: body.description }
-            : {}),
-          ...(body.mode !== undefined ? { mode: body.mode } : {}),
-          ...(body.status !== undefined ? { status: body.status } : {}),
-          ...(body.brandingId !== undefined
-            ? { brandingId: body.brandingId }
-            : {}),
-          ...(body.downloadEnabled !== undefined
-            ? { downloadEnabled: body.downloadEnabled }
-            : {}),
-          ...(body.downloadOriginalsEnabled !== undefined
-            ? { downloadOriginalsEnabled: body.downloadOriginalsEnabled }
-            : {}),
-          ...(body.watermarkEnabled !== undefined
-            ? { watermarkEnabled: body.watermarkEnabled }
-            : {}),
-          ...(body.commentsEnabled !== undefined
-            ? { commentsEnabled: body.commentsEnabled }
-            : {}),
-          ...(body.ratingsEnabled !== undefined
-            ? { ratingsEnabled: body.ratingsEnabled }
-            : {}),
-          ...(body.customerTagFilterEnabled !== undefined
-            ? { customerTagFilterEnabled: body.customerTagFilterEnabled }
-            : {}),
-          ...(body.customerLabelMode !== undefined
-            ? { customerLabelMode: body.customerLabelMode }
-            : {}),
-          ...(body.customerLabelToggleEnabled !== undefined
-            ? { customerLabelToggleEnabled: body.customerLabelToggleEnabled }
-            : {}),
-          ...(body.publicAccess !== undefined
-            ? { publicAccess: body.publicAccess }
-            : {}),
-          ...(body.selectionLimit !== undefined
-            ? { selectionLimit: body.selectionLimit }
-            : {}),
-          ...(body.expiresAt !== undefined
-            ? {
-                expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
-              }
-            : {}),
-          // Header-Customization — durchreichen wenn explizit gesetzt
-          // (auch null → Feld leeren ist erlaubt).
-          ...(body.heroFileId !== undefined ? { heroFileId: body.heroFileId } : {}),
-          ...(body.heroUrl !== undefined ? { heroUrl: body.heroUrl } : {}),
-          ...(body.heroOverlayColor !== undefined
-            ? { heroOverlayColor: body.heroOverlayColor }
-            : {}),
-          ...(body.heroOverlayBlur !== undefined
-            ? { heroOverlayBlur: body.heroOverlayBlur }
-            : {}),
-          ...(body.heroBackgroundColor !== undefined
-            ? { heroBackgroundColor: body.heroBackgroundColor }
-            : {}),
-          ...(body.eventLogoUrl !== undefined
-            ? { eventLogoUrl: body.eventLogoUrl }
-            : {}),
-          ...(body.eventLogoSize !== undefined
-            ? { eventLogoSize: body.eventLogoSize }
-            : {}),
-          ...(body.welcomeMarkdown !== undefined
-            ? { welcomeMarkdown: body.welcomeMarkdown }
-            : {}),
-          ...(body.heroLayout !== undefined
-            ? { heroLayout: body.heroLayout }
-            : {}),
-          ...(body.fontHeading !== undefined
-            ? { fontHeading: body.fontHeading }
-            : {}),
-          ...(body.fontBody !== undefined
-            ? { fontBody: body.fontBody }
-            : {}),
-          ...(body.gridLayout !== undefined
-            ? { gridLayout: body.gridLayout }
-            : {}),
-          ...(body.slideshowTransition !== undefined
-            ? { slideshowTransition: body.slideshowTransition }
-            : {}),
-          ...(body.slideshowAudioUrl !== undefined
-            ? { slideshowAudioUrl: body.slideshowAudioUrl }
-            : {}),
-          ...(body.footerMarkdown !== undefined
-            ? { footerMarkdown: body.footerMarkdown }
-            : {}),
-          ...(body.colorBackground !== undefined
-            ? { colorBackground: body.colorBackground }
-            : {}),
-          ...(body.colorAccent !== undefined
-            ? { colorAccent: body.colorAccent }
-            : {}),
-          ...(body.printShopEnabled !== undefined
-            ? { printShopEnabled: body.printShopEnabled }
-            : {}),
-        },
-      });
+      // findFirst above and this update aren't atomic — two concurrent
+      // PATCHes claiming the same slug can both pass the availability
+      // check and race to the DB unique index. Catch that as P2002 and
+      // report it the same way as the pre-check above, instead of a 500.
+      let gallery;
+      try {
+        gallery = await prisma.gallery.update({
+          where: { id: existing.id },
+          data: {
+            ...(passwordHashUpdate ?? {}),
+            ...(newGallerySlug !== undefined ? { slug: newGallerySlug } : {}),
+            ...(body.title !== undefined ? { title: body.title } : {}),
+            ...(body.description !== undefined
+              ? { description: body.description }
+              : {}),
+            ...(body.mode !== undefined ? { mode: body.mode } : {}),
+            ...(body.status !== undefined ? { status: body.status } : {}),
+            ...(body.brandingId !== undefined
+              ? { brandingId: body.brandingId }
+              : {}),
+            ...(body.downloadEnabled !== undefined
+              ? { downloadEnabled: body.downloadEnabled }
+              : {}),
+            ...(body.downloadOriginalsEnabled !== undefined
+              ? { downloadOriginalsEnabled: body.downloadOriginalsEnabled }
+              : {}),
+            ...(body.watermarkEnabled !== undefined
+              ? { watermarkEnabled: body.watermarkEnabled }
+              : {}),
+            ...(body.commentsEnabled !== undefined
+              ? { commentsEnabled: body.commentsEnabled }
+              : {}),
+            ...(body.ratingsEnabled !== undefined
+              ? { ratingsEnabled: body.ratingsEnabled }
+              : {}),
+            ...(body.customerTagFilterEnabled !== undefined
+              ? { customerTagFilterEnabled: body.customerTagFilterEnabled }
+              : {}),
+            ...(body.customerLabelMode !== undefined
+              ? { customerLabelMode: body.customerLabelMode }
+              : {}),
+            ...(body.customerLabelToggleEnabled !== undefined
+              ? { customerLabelToggleEnabled: body.customerLabelToggleEnabled }
+              : {}),
+            ...(body.publicAccess !== undefined
+              ? { publicAccess: body.publicAccess }
+              : {}),
+            ...(body.selectionLimit !== undefined
+              ? { selectionLimit: body.selectionLimit }
+              : {}),
+            ...(body.expiresAt !== undefined
+              ? {
+                  expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+                }
+              : {}),
+            // Header-Customization — durchreichen wenn explizit gesetzt
+            // (auch null → Feld leeren ist erlaubt).
+            ...(body.heroFileId !== undefined ? { heroFileId: body.heroFileId } : {}),
+            ...(body.heroUrl !== undefined ? { heroUrl: body.heroUrl } : {}),
+            ...(body.heroOverlayColor !== undefined
+              ? { heroOverlayColor: body.heroOverlayColor }
+              : {}),
+            ...(body.heroOverlayBlur !== undefined
+              ? { heroOverlayBlur: body.heroOverlayBlur }
+              : {}),
+            ...(body.heroBackgroundColor !== undefined
+              ? { heroBackgroundColor: body.heroBackgroundColor }
+              : {}),
+            ...(body.eventLogoUrl !== undefined
+              ? { eventLogoUrl: body.eventLogoUrl }
+              : {}),
+            ...(body.eventLogoSize !== undefined
+              ? { eventLogoSize: body.eventLogoSize }
+              : {}),
+            ...(body.welcomeMarkdown !== undefined
+              ? { welcomeMarkdown: body.welcomeMarkdown }
+              : {}),
+            ...(body.heroLayout !== undefined
+              ? { heroLayout: body.heroLayout }
+              : {}),
+            ...(body.fontHeading !== undefined
+              ? { fontHeading: body.fontHeading }
+              : {}),
+            ...(body.fontBody !== undefined
+              ? { fontBody: body.fontBody }
+              : {}),
+            ...(body.gridLayout !== undefined
+              ? { gridLayout: body.gridLayout }
+              : {}),
+            ...(body.slideshowTransition !== undefined
+              ? { slideshowTransition: body.slideshowTransition }
+              : {}),
+            ...(body.slideshowAudioUrl !== undefined
+              ? { slideshowAudioUrl: body.slideshowAudioUrl }
+              : {}),
+            ...(body.footerMarkdown !== undefined
+              ? { footerMarkdown: body.footerMarkdown }
+              : {}),
+            ...(body.colorBackground !== undefined
+              ? { colorBackground: body.colorBackground }
+              : {}),
+            ...(body.colorAccent !== undefined
+              ? { colorAccent: body.colorAccent }
+              : {}),
+            ...(body.printShopEnabled !== undefined
+              ? { printShopEnabled: body.printShopEnabled }
+              : {}),
+          },
+        });
+      } catch (err) {
+        if (
+          newGallerySlug !== undefined &&
+          err &&
+          typeof err === "object" &&
+          "code" in err &&
+          err.code === "P2002"
+        ) {
+          return reply.status(409).send({
+            error: "gallery_slug_taken",
+            message: "Diese Galerie-URL ist bereits vergeben.",
+          });
+        }
+        throw err;
+      }
 
       // Watermark gerade eingeschaltet → für alle Files Watermark-Rendition
       // generieren (fire-and-forget — der Worker macht den Rest)

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -19,7 +19,7 @@ import { randomBytes, createHash } from "node:crypto";
 import { prisma } from "../db.js";
 import { config } from "../config.js";
 import { generateGallerySlug } from "../services/ids.js";
-import { validateGallerySlugFormat } from "../services/slugs.js";
+import { validateGallerySlugFormat, GALLERY_SLUG_MAX_LENGTH } from "../services/slugs.js";
 import { presignGet, presignPut, getObjectStream } from "../services/storage.js";
 import { verifyPassword, hashPassword } from "../services/auth.js";
 import { isTenantPubliclyVisible } from "../services/tenant.js";
@@ -175,11 +175,12 @@ const HEX_RGB_OR_RGBA = /^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 
 const updateGallerySchema = createGallerySchema.partial().extend({
   status: z.enum(["draft", "live", "archived"]).optional(),
-  // Custom gallery slug (the /g/<slug> path segment). Accepted loosely
-  // here; format/reserved-word/uniqueness checks happen in the route
+  // Custom gallery slug (the /g/<slug> path segment). Max length matches
+  // GALLERY_SLUG_MAX_LENGTH so the schema fails fast on oversized input;
+  // format/reserved-word/uniqueness checks still happen in the route
   // handler via validateGallerySlugFormat, same pattern as the tenant
   // slug in routes/settings.ts.
-  slug: z.string().max(80).optional(),
+  slug: z.string().max(GALLERY_SLUG_MAX_LENGTH).optional(),
   // Passwortschutz: String = setzen, null = entfernen, weglassen =
   // unverändert. Wird serverseitig gehasht.
   password: z.string().min(1).max(200).nullable().optional(),

--- a/apps/api/src/routes/galleries.ts
+++ b/apps/api/src/routes/galleries.ts
@@ -19,6 +19,7 @@ import { randomBytes, createHash } from "node:crypto";
 import { prisma } from "../db.js";
 import { config } from "../config.js";
 import { generateGallerySlug } from "../services/ids.js";
+import { validateGallerySlugFormat } from "../services/slugs.js";
 import { presignGet, presignPut, getObjectStream } from "../services/storage.js";
 import { verifyPassword, hashPassword } from "../services/auth.js";
 import { isTenantPubliclyVisible } from "../services/tenant.js";
@@ -174,6 +175,11 @@ const HEX_RGB_OR_RGBA = /^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 
 const updateGallerySchema = createGallerySchema.partial().extend({
   status: z.enum(["draft", "live", "archived"]).optional(),
+  // Custom gallery slug (the /g/<slug> path segment). Accepted loosely
+  // here; format/reserved-word/uniqueness checks happen in the route
+  // handler via validateGallerySlugFormat, same pattern as the tenant
+  // slug in routes/settings.ts.
+  slug: z.string().max(80).optional(),
   // Passwortschutz: String = setzen, null = entfernen, weglassen =
   // unverändert. Wird serverseitig gehasht.
   password: z.string().min(1).max(200).nullable().optional(),
@@ -874,6 +880,43 @@ export async function registerGalleryRoutes(app: FastifyInstance) {
       });
       if (!existing) return reply.status(404).send({ error: "not_found" });
 
+      // Custom slug: owner-only, because changing it breaks any link
+      // already shared with clients (same tradeoff as the tenant
+      // subdomain change in routes/settings.ts).
+      let newGallerySlug: string | undefined;
+      if (body.slug !== undefined) {
+        if (s.user.role !== "owner") {
+          return reply.status(403).send({
+            error: "gallery_slug_owner_only",
+            message: "Nur der Owner kann die Galerie-URL ändern.",
+          });
+        }
+        const candidate = body.slug.trim().toLowerCase();
+        const fmt = validateGallerySlugFormat(candidate);
+        if (!fmt.ok) {
+          return reply.status(400).send({
+            error: "invalid_gallery_slug",
+            message: fmt.message ?? "Ungültige Galerie-URL.",
+          });
+        }
+        if (candidate !== existing.slug) {
+          // Global uniqueness, no tenantId filter — slugs are shared
+          // across all tenants (see the create-flow comment above on
+          // generateGallerySlug's collision-retry loop).
+          const taken = await prisma.gallery.findFirst({
+            where: { slug: candidate, NOT: { id: existing.id } },
+            select: { id: true },
+          });
+          if (taken) {
+            return reply.status(409).send({
+              error: "gallery_slug_taken",
+              message: "Diese Galerie-URL ist bereits vergeben.",
+            });
+          }
+        }
+        newGallerySlug = candidate;
+      }
+
       const turningOnWatermark =
         body.watermarkEnabled === true && !existing.watermarkEnabled;
       const goingLive = body.status === "live" && existing.status !== "live";
@@ -892,6 +935,7 @@ export async function registerGalleryRoutes(app: FastifyInstance) {
         where: { id: existing.id },
         data: {
           ...(passwordHashUpdate ?? {}),
+          ...(newGallerySlug !== undefined ? { slug: newGallerySlug } : {}),
           ...(body.title !== undefined ? { title: body.title } : {}),
           ...(body.description !== undefined
             ? { description: body.description }
@@ -1035,7 +1079,10 @@ export async function registerGalleryRoutes(app: FastifyInstance) {
           eventType: "gallery.live",
           payload: {
             galleryId: gallery.id,
-            slug: existing.slug,
+            // gallery.slug, not existing.slug: a single PATCH can change
+            // the slug and flip status to live at the same time, and the
+            // webhook should report the slug the gallery now actually has.
+            slug: gallery.slug,
             title: gallery.title,
           },
         });

--- a/apps/api/src/services/slugs.test.ts
+++ b/apps/api/src/services/slugs.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateSlugFormat,
+  validateGallerySlugFormat,
+  GALLERY_SLUG_MAX_LENGTH,
+} from "./slugs.js";
+
+describe("validateSlugFormat (tenant default: 3-30 chars)", () => {
+  it("accepts a normal slug", () => {
+    expect(validateSlugFormat("acme-studio")).toEqual({ ok: true });
+  });
+
+  it("rejects fewer than 3 chars", () => {
+    const res = validateSlugFormat("ab");
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("too_short");
+    expect(res.message).toContain("3");
+  });
+
+  it("rejects more than 30 chars", () => {
+    const res = validateSlugFormat("a".repeat(31));
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("too_long");
+    expect(res.message).toContain("30");
+  });
+
+  it("accepts exactly 30 chars", () => {
+    expect(validateSlugFormat("a".repeat(30))).toEqual({ ok: true });
+  });
+
+  it("rejects uppercase, spaces and underscores", () => {
+    expect(validateSlugFormat("Acme-Studio").error).toBe("invalid_chars");
+    expect(validateSlugFormat("acme studio").error).toBe("invalid_chars");
+    expect(validateSlugFormat("acme_studio").error).toBe("invalid_chars");
+  });
+
+  it("rejects leading or trailing hyphen", () => {
+    expect(validateSlugFormat("-acme").error).toBe("leading_or_trailing_hyphen");
+    expect(validateSlugFormat("acme-").error).toBe("leading_or_trailing_hyphen");
+  });
+
+  it("rejects double hyphen", () => {
+    expect(validateSlugFormat("acme--studio").error).toBe("double_hyphen");
+  });
+
+  it("rejects reserved words", () => {
+    expect(validateSlugFormat("studio").error).toBe("reserved");
+    expect(validateSlugFormat("admin").error).toBe("reserved");
+    expect(validateSlugFormat("www").error).toBe("reserved");
+  });
+});
+
+describe("validateGallerySlugFormat (60-char max, path segment not a DNS label)", () => {
+  it("shares the same min length as the tenant default", () => {
+    const res = validateGallerySlugFormat("ab");
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("too_short");
+  });
+
+  it("accepts up to 60 chars, where the tenant default would reject", () => {
+    const slug = "a".repeat(60);
+    expect(slug.length).toBe(GALLERY_SLUG_MAX_LENGTH);
+    expect(validateGallerySlugFormat(slug)).toEqual({ ok: true });
+    expect(validateSlugFormat(slug).error).toBe("too_long");
+  });
+
+  it("rejects 61 chars with a message reflecting the 60-char limit", () => {
+    const res = validateGallerySlugFormat("a".repeat(61));
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe("too_long");
+    expect(res.message).toContain("60");
+  });
+
+  it("still enforces the shared charset/hyphen rules", () => {
+    expect(validateGallerySlugFormat("Foo Bar").error).toBe("invalid_chars");
+    expect(validateGallerySlugFormat("-foo").error).toBe("leading_or_trailing_hyphen");
+    expect(validateGallerySlugFormat("foo--bar").error).toBe("double_hyphen");
+  });
+
+  it("still rejects reserved words shared with the tenant list", () => {
+    expect(validateGallerySlugFormat("admin").error).toBe("reserved");
+    expect(validateGallerySlugFormat("login").error).toBe("reserved");
+  });
+
+  it("accepts a realistic long gallery name", () => {
+    expect(validateGallerySlugFormat("smith-jones-wedding-photos-2026")).toEqual({
+      ok: true,
+    });
+  });
+});

--- a/apps/api/src/services/slugs.ts
+++ b/apps/api/src/services/slugs.ts
@@ -14,6 +14,11 @@
  * Reservierte Slugs sind Subdomains die wir für System-Zwecke
  * verwenden (studio = Login-Apex, api = API-Host etc.) oder die per
  * Konvention nicht für User reserviert sein sollten.
+ *
+ * Also reused for gallery slugs (the /g/<slug> path segment): same
+ * charset/reserved-word rules, but a longer max length since a gallery
+ * slug is just a path segment, not a DNS label — see
+ * validateGallerySlugFormat below.
  */
 
 export const RESERVED_SLUGS = new Set<string>([
@@ -59,12 +64,25 @@ export interface SlugValidationResult {
  * Synchrone Format- und Reserviert-Prüfung. Sagt NICHT ob der Slug
  * in der DB schon vergeben ist — dafür siehe isSlugAvailable.
  */
-export function validateSlugFormat(slug: string): SlugValidationResult {
-  if (slug.length < 3) {
-    return { ok: false, error: "too_short", message: "Mindestens 3 Zeichen." };
+export function validateSlugFormat(
+  slug: string,
+  opts: { minLength?: number; maxLength?: number } = {}
+): SlugValidationResult {
+  const minLength = opts.minLength ?? 3;
+  const maxLength = opts.maxLength ?? 30;
+  if (slug.length < minLength) {
+    return {
+      ok: false,
+      error: "too_short",
+      message: `Mindestens ${minLength} Zeichen.`,
+    };
   }
-  if (slug.length > 30) {
-    return { ok: false, error: "too_long", message: "Maximal 30 Zeichen." };
+  if (slug.length > maxLength) {
+    return {
+      ok: false,
+      error: "too_long",
+      message: `Maximal ${maxLength} Zeichen.`,
+    };
   }
   if (!/^[a-z0-9-]+$/.test(slug)) {
     return {
@@ -95,6 +113,18 @@ export function validateSlugFormat(slug: string): SlugValidationResult {
     };
   }
   return { ok: true };
+}
+
+/**
+ * Gallery slugs are just a /g/<slug> path segment, not a DNS label like
+ * the tenant subdomain — so they get a longer max length. Charset,
+ * hyphen and reserved-word rules stay identical (same RESERVED_SLUGS
+ * set, for brand-safety consistency across both use cases).
+ */
+export const GALLERY_SLUG_MAX_LENGTH = 60;
+
+export function validateGallerySlugFormat(slug: string): SlugValidationResult {
+  return validateSlugFormat(slug, { maxLength: GALLERY_SLUG_MAX_LENGTH });
 }
 
 /**

--- a/apps/frontend/src/app/studio/[id]/page.tsx
+++ b/apps/frontend/src/app/studio/[id]/page.tsx
@@ -1276,13 +1276,15 @@ export default function GalleryDetailPage() {
 
         {tab === "share" && (
           <>
-        {/* Custom gallery URL (/g/<slug>) — owner-only. Shown before
+        {/* Custom gallery URL (/g/<slug>) — owner or admin. Shown before
             SharePanel since the slug is the base the share links build
             on top of. */}
         <GallerySlugEditor
           galleryId={gallery.id}
           slug={gallery.slug}
-          isOwner={role === "owner"}
+          canEdit={role === "owner" || role === "admin"}
+          publicAccess={gallery.publicAccess ?? true}
+          hasPassword={gallery.hasPassword ?? false}
           onChanged={async () => {
             await load();
           }}

--- a/apps/frontend/src/app/studio/[id]/page.tsx
+++ b/apps/frontend/src/app/studio/[id]/page.tsx
@@ -16,6 +16,7 @@ import { useShowFilenames } from "@/lib/useShowFilenames";
 import { VideoPlayer } from "@/components/gallery/VideoPlayer";
 import { SharePanel } from "@/components/studio/SharePanel";
 import { GalleryHeaderEditor } from "@/components/studio/GalleryHeaderEditor";
+import { GallerySlugEditor } from "@/components/studio/GallerySlugEditor";
 import { GalleryShareSection } from "@/components/studio/GalleryShareSection";
 import { SectionsEditor } from "@/components/studio/SectionsEditor";
 import { UploadLinksSection } from "@/components/studio/UploadLinksSection";
@@ -129,12 +130,19 @@ export default function GalleryDetailPage() {
   // ob optionale UI-Bereiche (z.B. Print-Shop-Override-Toggle) gerendert
   // werden. Wenn null: noch nicht geladen, Toggle erstmal versteckt.
   const [tenantFeatures, setTenantFeatures] = useState<string[] | null>(null);
+  // Current user's tenant-wide role, fetched alongside tenantFeatures on
+  // the same api.me() call — used to gate the gallery-slug editor to
+  // owners only (changing it breaks previously shared links).
+  const [role, setRole] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         const r = await api.me();
-        if (!cancelled) setTenantFeatures(r.features ?? []);
+        if (!cancelled) {
+          setTenantFeatures(r.features ?? []);
+          setRole(r.user?.role ?? null);
+        }
       } catch {
         if (!cancelled) setTenantFeatures([]);
       }
@@ -1297,6 +1305,16 @@ export default function GalleryDetailPage() {
             }}
           />
         </section>
+
+        {/* Custom gallery URL (/g/<slug>) — owner-only */}
+        <GallerySlugEditor
+          galleryId={gallery.id}
+          slug={gallery.slug}
+          isOwner={role === "owner"}
+          onChanged={async () => {
+            await load();
+          }}
+        />
 
         {/* Header-Customization — Hero, Logo, Welcome-Text */}
         <GalleryHeaderEditor

--- a/apps/frontend/src/app/studio/[id]/page.tsx
+++ b/apps/frontend/src/app/studio/[id]/page.tsx
@@ -1275,12 +1275,25 @@ export default function GalleryDetailPage() {
         )}
 
         {tab === "share" && (
-          <SharePanel
-            galleryId={gallery.id}
-            gallerySlug={gallery.slug}
-            initialPublicAccess={gallery.publicAccess ?? true}
-            initialHasPassword={gallery.hasPassword ?? false}
-          />
+          <>
+        {/* Custom gallery URL (/g/<slug>) — owner-only. Shown before
+            SharePanel since the slug is the base the share links build
+            on top of. */}
+        <GallerySlugEditor
+          galleryId={gallery.id}
+          slug={gallery.slug}
+          isOwner={role === "owner"}
+          onChanged={async () => {
+            await load();
+          }}
+        />
+        <SharePanel
+          galleryId={gallery.id}
+          gallerySlug={gallery.slug}
+          initialPublicAccess={gallery.publicAccess ?? true}
+          initialHasPassword={gallery.hasPassword ?? false}
+        />
+          </>
         )}
 
         {tab === "settings" && (
@@ -1305,16 +1318,6 @@ export default function GalleryDetailPage() {
             }}
           />
         </section>
-
-        {/* Custom gallery URL (/g/<slug>) — owner-only */}
-        <GallerySlugEditor
-          galleryId={gallery.id}
-          slug={gallery.slug}
-          isOwner={role === "owner"}
-          onChanged={async () => {
-            await load();
-          }}
-        />
 
         {/* Header-Customization — Hero, Logo, Welcome-Text */}
         <GalleryHeaderEditor

--- a/apps/frontend/src/components/studio/GallerySlugEditor.tsx
+++ b/apps/frontend/src/components/studio/GallerySlugEditor.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+import { useT } from "@/lib/i18n";
+import { useErrorText } from "@/lib/error-i18n";
+
+/**
+ * Owner-only editor for the gallery's public share slug (/g/<slug>).
+ * Hidden entirely for non-owners, same pattern as the tenant subdomain
+ * editor in studio/settings/page.tsx — a disabled field would still leak
+ * the fact that the control exists.
+ */
+export function GallerySlugEditor({
+  galleryId,
+  slug,
+  isOwner,
+  onChanged,
+}: {
+  galleryId: string;
+  slug: string;
+  isOwner: boolean;
+  onChanged: () => Promise<void>;
+}) {
+  const t = useT();
+  const errText = useErrorText();
+  const [value, setValue] = useState(slug);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+
+  if (!isOwner) return null;
+
+  const cleaned = value.trim().toLowerCase();
+  const disabled = saving || !cleaned || cleaned === slug;
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      await api.updateGallery(galleryId, { slug: cleaned });
+      await onChanged();
+    } catch (err) {
+      setError(errText(err, t("studio.gallerySlugSaveError")));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="rounded-md border border-line-subtle bg-surface-raised p-5 space-y-3">
+      <div>
+        <h2 className="text-ui-md font-medium text-ink-primary">
+          {t("studio.gallerySlugHeading")}
+        </h2>
+        <p className="text-ui-sm text-ink-tertiary -mt-1">
+          {t("studio.gallerySlugDesc")}
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-ui-sm text-ink-tertiary font-mono whitespace-nowrap">
+          {origin}/g/
+        </span>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value.toLowerCase().replace(/\s/g, ""))}
+          maxLength={60}
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="flex-1 h-9 px-2.5 rounded bg-surface-sunken border border-line-subtle hover:border-line-strong focus:border-accent text-ui text-ink-primary focus:outline-none transition-colors duration-motion disabled:opacity-50"
+        />
+      </div>
+      <div className="rounded-sm bg-semantic-warning/10 border border-semantic-warning/30 px-3 py-2 text-xs text-ink-secondary leading-relaxed">
+        {t("studio.gallerySlugWarnPre")}{" "}
+        <span className="font-mono">
+          {origin}/g/{slug}
+        </span>{" "}
+        {t("studio.gallerySlugWarnPost")}
+      </div>
+      {error && <p className="text-ui-sm text-semantic-danger">{error}</p>}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={save}
+          disabled={disabled}
+          className="text-sm px-3 py-1.5 rounded-md border border-line-subtle hover:bg-surface-sunken disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {saving ? t("common.saving") : t("common.save")}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/components/studio/GallerySlugEditor.tsx
+++ b/apps/frontend/src/components/studio/GallerySlugEditor.tsx
@@ -7,9 +7,11 @@ import { useErrorText } from "@/lib/error-i18n";
 
 /**
  * Owner-only editor for the gallery's public share slug (/g/<slug>).
- * Hidden entirely for non-owners, same pattern as the tenant subdomain
- * editor in studio/settings/page.tsx — a disabled field would still leak
- * the fact that the control exists.
+ * Rendered above SharePanel in the "share" tab, styled to match its
+ * section convention (rounded-lg/p-4, div-wrapped heading+description)
+ * since the slug is the base the share links build on top of. Hidden
+ * entirely for non-owners — a disabled field would still leak the fact
+ * that the control exists.
  */
 export function GallerySlugEditor({
   galleryId,
@@ -48,15 +50,15 @@ export function GallerySlugEditor({
   }
 
   return (
-    <section className="rounded-md border border-line-subtle bg-surface-raised p-5 space-y-3">
-      <h2 className="text-ui-md font-medium text-ink-primary">
-        {t("studio.gallerySlugHeading")}
-      </h2>
-      <p className="text-ui-sm text-ink-tertiary -mt-1">
-        {t("studio.gallerySlugDesc")}
-      </p>
+    <section className="rounded-lg border border-line-subtle bg-surface-raised p-4 space-y-3">
+      <div>
+        <h2 className="text-sm font-medium">{t("studio.gallerySlugHeading")}</h2>
+        <p className="text-xs text-ink-tertiary mt-0.5">
+          {t("studio.gallerySlugDesc")}
+        </p>
+      </div>
       <div className="flex items-center gap-2">
-        <span className="text-ui-sm text-ink-tertiary font-mono whitespace-nowrap">
+        <span className="text-sm text-ink-tertiary font-mono whitespace-nowrap">
           {origin}/g/
         </span>
         <input
@@ -68,27 +70,25 @@ export function GallerySlugEditor({
           autoCapitalize="off"
           autoCorrect="off"
           spellCheck={false}
-          className="flex-1 h-9 px-2.5 rounded bg-surface-sunken border border-line-subtle hover:border-line-strong focus:border-accent text-ui text-ink-primary focus:outline-none transition-colors duration-motion disabled:opacity-50"
+          className="flex-1 rounded-md border border-line-subtle px-3 py-2 text-sm disabled:opacity-50"
         />
+        <button
+          type="button"
+          onClick={save}
+          disabled={disabled}
+          className="text-xs px-3 py-2 rounded-md bg-accent text-accent-contrast hover:bg-accent-hover disabled:opacity-50 whitespace-nowrap"
+        >
+          {saving ? t("common.saving") : t("common.save")}
+        </button>
       </div>
-      <div className="rounded-sm bg-semantic-warning/10 border border-semantic-warning/30 px-3 py-2 text-xs text-ink-secondary leading-relaxed">
+      <div className="rounded-md bg-semantic-warning/10 border border-semantic-warning/30 px-3 py-2 text-xs text-ink-secondary leading-relaxed">
         {t("studio.gallerySlugWarnPre")}{" "}
         <span className="font-mono">
           {origin}/g/{slug}
         </span>{" "}
         {t("studio.gallerySlugWarnPost")}
       </div>
-      {error && <p className="text-ui-sm text-semantic-danger">{error}</p>}
-      <div className="flex justify-end">
-        <button
-          type="button"
-          onClick={save}
-          disabled={disabled}
-          className="text-sm px-3 py-1.5 rounded-md border border-line-subtle hover:bg-surface-sunken disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {saving ? t("common.saving") : t("common.save")}
-        </button>
-      </div>
+      {error && <p className="text-sm text-semantic-danger">{error}</p>}
     </section>
   );
 }

--- a/apps/frontend/src/components/studio/GallerySlugEditor.tsx
+++ b/apps/frontend/src/components/studio/GallerySlugEditor.tsx
@@ -6,22 +6,26 @@ import { useT } from "@/lib/i18n";
 import { useErrorText } from "@/lib/error-i18n";
 
 /**
- * Owner-only editor for the gallery's public share slug (/g/<slug>).
+ * Owner/admin editor for the gallery's public share slug (/g/<slug>).
  * Rendered above SharePanel in the "share" tab, styled to match its
  * section convention (rounded-lg/p-4, div-wrapped heading+description)
  * since the slug is the base the share links build on top of. Hidden
- * entirely for non-owners — a disabled field would still leak the fact
+ * entirely for members — a disabled field would still leak the fact
  * that the control exists.
  */
 export function GallerySlugEditor({
   galleryId,
   slug,
-  isOwner,
+  canEdit,
+  publicAccess,
+  hasPassword,
   onChanged,
 }: {
   galleryId: string;
   slug: string;
-  isOwner: boolean;
+  canEdit: boolean;
+  publicAccess: boolean;
+  hasPassword: boolean;
   onChanged: () => Promise<void>;
 }) {
   const t = useT();
@@ -31,7 +35,7 @@ export function GallerySlugEditor({
   const [error, setError] = useState<string | null>(null);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
 
-  if (!isOwner) return null;
+  if (!canEdit) return null;
 
   const cleaned = value.trim().toLowerCase();
   const disabled = saving || !cleaned || cleaned === slug;
@@ -90,6 +94,11 @@ export function GallerySlugEditor({
         </span>{" "}
         {t("studio.gallerySlugWarnPost")}
       </div>
+      {publicAccess && !hasPassword && (
+        <div className="rounded-md bg-semantic-warning/10 border border-semantic-warning/30 px-3 py-2 text-xs text-ink-secondary leading-relaxed">
+          {t("studio.gallerySlugWarnGuessable")}
+        </div>
+      )}
       {error && <p className="text-sm text-semantic-danger">{error}</p>}
     </section>
   );

--- a/apps/frontend/src/components/studio/GallerySlugEditor.tsx
+++ b/apps/frontend/src/components/studio/GallerySlugEditor.tsx
@@ -66,6 +66,7 @@ export function GallerySlugEditor({
           value={value}
           onChange={(e) => setValue(e.target.value.toLowerCase().replace(/\s/g, ""))}
           maxLength={60}
+          aria-label={t("studio.gallerySlugHeading")}
           autoCapitalize="off"
           autoCorrect="off"
           spellCheck={false}

--- a/apps/frontend/src/components/studio/GallerySlugEditor.tsx
+++ b/apps/frontend/src/components/studio/GallerySlugEditor.tsx
@@ -49,14 +49,12 @@ export function GallerySlugEditor({
 
   return (
     <section className="rounded-md border border-line-subtle bg-surface-raised p-5 space-y-3">
-      <div>
-        <h2 className="text-ui-md font-medium text-ink-primary">
-          {t("studio.gallerySlugHeading")}
-        </h2>
-        <p className="text-ui-sm text-ink-tertiary -mt-1">
-          {t("studio.gallerySlugDesc")}
-        </p>
-      </div>
+      <h2 className="text-ui-md font-medium text-ink-primary">
+        {t("studio.gallerySlugHeading")}
+      </h2>
+      <p className="text-ui-sm text-ink-tertiary -mt-1">
+        {t("studio.gallerySlugDesc")}
+      </p>
       <div className="flex items-center gap-2">
         <span className="text-ui-sm text-ink-tertiary font-mono whitespace-nowrap">
           {origin}/g/

--- a/apps/frontend/src/components/studio/GallerySlugEditor.tsx
+++ b/apps/frontend/src/components/studio/GallerySlugEditor.tsx
@@ -57,21 +57,23 @@ export function GallerySlugEditor({
           {t("studio.gallerySlugDesc")}
         </p>
       </div>
-      <div className="flex items-center gap-2">
-        <span className="text-sm text-ink-tertiary font-mono whitespace-nowrap">
-          {origin}/g/
-        </span>
-        <input
-          type="text"
-          value={value}
-          onChange={(e) => setValue(e.target.value.toLowerCase().replace(/\s/g, ""))}
-          maxLength={60}
-          aria-label={t("studio.gallerySlugHeading")}
-          autoCapitalize="off"
-          autoCorrect="off"
-          spellCheck={false}
-          className="flex-1 rounded-md border border-line-subtle px-3 py-2 text-sm disabled:opacity-50"
-        />
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <span className="text-sm text-ink-tertiary font-mono whitespace-nowrap">
+            {origin}/g/
+          </span>
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => setValue(e.target.value.toLowerCase().replace(/\s/g, ""))}
+            maxLength={60}
+            aria-label={t("studio.gallerySlugHeading")}
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
+            className="flex-1 min-w-0 rounded-md border border-line-subtle px-3 py-2 text-sm disabled:opacity-50"
+          />
+        </div>
         <button
           type="button"
           onClick={save}

--- a/apps/frontend/src/lib/i18n/de.ts
+++ b/apps/frontend/src/lib/i18n/de.ts
@@ -68,7 +68,7 @@ export const de: LocaleDict = {
       "CAPTCHA-Prüfung fehlgeschlagen. Bitte lade die Seite neu und versuche es erneut.",
     customerMismatch: "Session gehört nicht zu diesem Tenant.",
     emailTaken: "Diese E-Mail-Adresse ist im Studio bereits vergeben.",
-    gallerySlugOwnerOnly: "Nur der Owner kann die Galerie-URL ändern.",
+    gallerySlugForbidden: "Nur Owner oder Admin können die Galerie-URL ändern.",
     gallerySlugTaken: "Diese Galerie-URL ist bereits vergeben.",
     inUse:
       "Es gibt Bestellungen mit dieser Variante. Deaktiviere stattdessen.",
@@ -595,6 +595,8 @@ export const de: LocaleDict = {
       "Der öffentliche Link, unter dem Kunden diese Galerie erreichen (/g/…). Geteilte Links aktualisieren sich automatisch, sobald du hier speicherst.",
     gallerySlugWarnPre: "Nach dem Ändern ist der bisherige Link",
     gallerySlugWarnPost: "nicht mehr erreichbar.",
+    gallerySlugWarnGuessable:
+      "Diese Galerie ist öffentlich und hat kein Passwort — die URL selbst ist der einzige Zugriffsschutz. Eine lesbare URL lässt sich leichter erraten als eine zufällige.",
     gallerySlugSaveError: "Galerie-URL konnte nicht geändert werden",
     selected: "Ausgewählt",
     secSyncTitle: "Files mit dem Tag in die Section, andere raus",

--- a/apps/frontend/src/lib/i18n/de.ts
+++ b/apps/frontend/src/lib/i18n/de.ts
@@ -68,6 +68,8 @@ export const de: LocaleDict = {
       "CAPTCHA-Prüfung fehlgeschlagen. Bitte lade die Seite neu und versuche es erneut.",
     customerMismatch: "Session gehört nicht zu diesem Tenant.",
     emailTaken: "Diese E-Mail-Adresse ist im Studio bereits vergeben.",
+    gallerySlugOwnerOnly: "Nur der Owner kann die Galerie-URL ändern.",
+    gallerySlugTaken: "Diese Galerie-URL ist bereits vergeben.",
     inUse:
       "Es gibt Bestellungen mit dieser Variante. Deaktiviere stattdessen.",
     invalidChallenge: "Bitte erneut anmelden.",
@@ -588,6 +590,12 @@ export const de: LocaleDict = {
     activeUploads: "Aktive Uploads",
     galleryTags: "Galerie-Tags",
     galleryTagsDesc: "Ordnen die ganze Galerie in der Übersicht ein (nicht zu verwechseln mit Tags auf einzelnen Bildern).",
+    gallerySlugHeading: "Galerie-URL",
+    gallerySlugDesc:
+      "Der öffentliche Link, unter dem Kunden diese Galerie erreichen (/g/…). Geteilte Links aktualisieren sich automatisch, sobald du hier speicherst.",
+    gallerySlugWarnPre: "Nach dem Ändern ist der bisherige Link",
+    gallerySlugWarnPost: "nicht mehr erreichbar.",
+    gallerySlugSaveError: "Galerie-URL konnte nicht geändert werden",
     selected: "Ausgewählt",
     secSyncTitle: "Files mit dem Tag in die Section, andere raus",
     secSyncing: "Sync…",

--- a/apps/frontend/src/lib/i18n/en.ts
+++ b/apps/frontend/src/lib/i18n/en.ts
@@ -69,6 +69,8 @@ export const en = {
       "CAPTCHA check failed. Please reload the page and try again.",
     customerMismatch: "This session does not belong to this tenant.",
     emailTaken: "That email address is already in use in this studio.",
+    gallerySlugOwnerOnly: "Only the owner can change the gallery URL.",
+    gallerySlugTaken: "That gallery URL is already taken.",
     inUse:
       "There are orders using this variant. Deactivate it instead.",
     invalidChallenge: "Please sign in again.",
@@ -589,6 +591,12 @@ export const en = {
     activeUploads: "Active uploads",
     galleryTags: "Gallery tags",
     galleryTagsDesc: "Categorize the whole gallery in the overview (not to be confused with tags on individual images).",
+    gallerySlugHeading: "Gallery URL",
+    gallerySlugDesc:
+      "The public link clients use to reach this gallery (/g/…). Shared links update automatically once you save here.",
+    gallerySlugWarnPre: "After changing it, the previous link",
+    gallerySlugWarnPost: "is no longer reachable.",
+    gallerySlugSaveError: "The gallery URL could not be changed",
     selected: "Selected",
     secSyncTitle: "Files with the tag into the section, others out",
     secSyncing: "Sync…",

--- a/apps/frontend/src/lib/i18n/en.ts
+++ b/apps/frontend/src/lib/i18n/en.ts
@@ -69,7 +69,7 @@ export const en = {
       "CAPTCHA check failed. Please reload the page and try again.",
     customerMismatch: "This session does not belong to this tenant.",
     emailTaken: "That email address is already in use in this studio.",
-    gallerySlugOwnerOnly: "Only the owner can change the gallery URL.",
+    gallerySlugForbidden: "Only the studio owner or an admin can change the gallery URL.",
     gallerySlugTaken: "That gallery URL is already taken.",
     inUse:
       "There are orders using this variant. Deactivate it instead.",
@@ -596,6 +596,8 @@ export const en = {
       "The public link clients use to reach this gallery (/g/…). Shared links update automatically once you save here.",
     gallerySlugWarnPre: "After changing it, the previous link",
     gallerySlugWarnPost: "is no longer reachable.",
+    gallerySlugWarnGuessable:
+      "This gallery is public and has no password — the URL itself is what keeps it private. A readable slug is easier to guess than a random one.",
     gallerySlugSaveError: "The gallery URL could not be changed",
     selected: "Selected",
     secSyncTitle: "Files with the tag into the section, others out",

--- a/apps/frontend/src/lib/i18n/fi.ts
+++ b/apps/frontend/src/lib/i18n/fi.ts
@@ -69,6 +69,8 @@ export const fi = {
       "CAPTCHA-tarkistus epäonnistui. Lataa sivu uudelleen ja yritä uudestaan.",
     customerMismatch: "Tämä istunto ei kuulu tälle studiolle.",
     emailTaken: "Tämä sähköpostiosoite on jo käytössä tässä studiossa.",
+    gallerySlugOwnerOnly: "Vain omistaja voi muuttaa gallerian URL-osoitetta.",
+    gallerySlugTaken: "Kyseinen gallerian URL-osoite on jo varattu.",
     inUse:
       "Tähän varianttiin liittyy tilauksia. Poista se sen sijaan käytöstä.",
     invalidChallenge: "Kirjaudu sisään uudelleen.",
@@ -589,6 +591,12 @@ export const fi = {
     activeUploads: "Aktiiviset lähetykset",
     galleryTags: "Gallerian tunnisteet",
     galleryTagsDesc: "Luokittele koko galleria yleiskatsauksessa (älä sekoita yksittäisten kuvien tunnisteisiin).",
+    gallerySlugHeading: "Gallerian URL",
+    gallerySlugDesc:
+      "Julkinen linkki, jolla asiakkaat löytävät tämän gallerian (/g/…). Jaetut linkit päivittyvät automaattisesti tallennuksen jälkeen.",
+    gallerySlugWarnPre: "Muutoksen jälkeen aiempi linkki",
+    gallerySlugWarnPost: "ei ole enää käytettävissä.",
+    gallerySlugSaveError: "Gallerian URL-osoitetta ei voitu muuttaa",
     selected: "Valitut",
     secSyncTitle: "Tunnisteella merkityt tiedostot osioon, muut pois",
     secSyncing: "Synkronoidaan…",

--- a/apps/frontend/src/lib/i18n/fi.ts
+++ b/apps/frontend/src/lib/i18n/fi.ts
@@ -69,7 +69,7 @@ export const fi = {
       "CAPTCHA-tarkistus epäonnistui. Lataa sivu uudelleen ja yritä uudestaan.",
     customerMismatch: "Tämä istunto ei kuulu tälle studiolle.",
     emailTaken: "Tämä sähköpostiosoite on jo käytössä tässä studiossa.",
-    gallerySlugOwnerOnly: "Vain omistaja voi muuttaa gallerian URL-osoitetta.",
+    gallerySlugForbidden: "Vain omistaja tai admin voi muuttaa gallerian URL-osoitetta.",
     gallerySlugTaken: "Kyseinen gallerian URL-osoite on jo varattu.",
     inUse:
       "Tähän varianttiin liittyy tilauksia. Poista se sen sijaan käytöstä.",
@@ -596,6 +596,8 @@ export const fi = {
       "Julkinen linkki, jolla asiakkaat löytävät tämän gallerian (/g/…). Jaetut linkit päivittyvät automaattisesti tallennuksen jälkeen.",
     gallerySlugWarnPre: "Muutoksen jälkeen aiempi linkki",
     gallerySlugWarnPost: "ei ole enää käytettävissä.",
+    gallerySlugWarnGuessable:
+      "Tämä galleria on julkinen eikä siinä ole salasanaa — itse URL-osoite on ainoa pääsynhallinta. Luettava osoite on helpompi arvata kuin satunnainen.",
     gallerySlugSaveError: "Gallerian URL-osoitetta ei voitu muuttaa",
     selected: "Valitut",
     secSyncTitle: "Tunnisteella merkityt tiedostot osioon, muut pois",

--- a/apps/frontend/src/lib/i18n/it.ts
+++ b/apps/frontend/src/lib/i18n/it.ts
@@ -66,7 +66,7 @@ export const it: LocaleDict = {
       "Verifica CAPTCHA non riuscita. Ricarica la pagina e riprova.",
     customerMismatch: "Questa sessione non appartiene a questo tenant.",
     emailTaken: "Questo indirizzo email è già in uso in questo studio.",
-    gallerySlugOwnerOnly: "Solo il proprietario può modificare l'URL della galleria.",
+    gallerySlugForbidden: "Solo il proprietario o un admin possono modificare l'URL della galleria.",
     gallerySlugTaken: "Questo URL della galleria è già in uso.",
     inUse:
       "Ci sono ordini che usano questa variante. Disattivala invece di eliminarla.",
@@ -595,6 +595,8 @@ export const it: LocaleDict = {
       "Il link pubblico con cui i clienti raggiungono questa galleria (/g/…). I link condivisi si aggiornano automaticamente al salvataggio.",
     gallerySlugWarnPre: "Dopo la modifica, il link precedente",
     gallerySlugWarnPost: "non sarà più raggiungibile.",
+    gallerySlugWarnGuessable:
+      "Questa galleria è pubblica e non ha una password: l'URL stesso è ciò che ne protegge l'accesso. Uno slug leggibile è più facile da indovinare rispetto a uno casuale.",
     gallerySlugSaveError: "Non è stato possibile modificare l'URL della galleria",
     selected: "Selezionati",
     secSyncTitle: "File con il tag nel capitolo, gli altri fuori",

--- a/apps/frontend/src/lib/i18n/it.ts
+++ b/apps/frontend/src/lib/i18n/it.ts
@@ -66,6 +66,8 @@ export const it: LocaleDict = {
       "Verifica CAPTCHA non riuscita. Ricarica la pagina e riprova.",
     customerMismatch: "Questa sessione non appartiene a questo tenant.",
     emailTaken: "Questo indirizzo email è già in uso in questo studio.",
+    gallerySlugOwnerOnly: "Solo il proprietario può modificare l'URL della galleria.",
+    gallerySlugTaken: "Questo URL della galleria è già in uso.",
     inUse:
       "Ci sono ordini che usano questa variante. Disattivala invece di eliminarla.",
     invalidChallenge: "Accedi di nuovo.",
@@ -588,6 +590,12 @@ export const it: LocaleDict = {
     activeUploads: "Caricamenti attivi",
     galleryTags: "Tag della galleria",
     galleryTagsDesc: "Classifica l'intera galleria nella panoramica (da non confondere con i tag sulle singole immagini).",
+    gallerySlugHeading: "URL della galleria",
+    gallerySlugDesc:
+      "Il link pubblico con cui i clienti raggiungono questa galleria (/g/…). I link condivisi si aggiornano automaticamente al salvataggio.",
+    gallerySlugWarnPre: "Dopo la modifica, il link precedente",
+    gallerySlugWarnPost: "non sarà più raggiungibile.",
+    gallerySlugSaveError: "Non è stato possibile modificare l'URL della galleria",
     selected: "Selezionati",
     secSyncTitle: "File con il tag nel capitolo, gli altri fuori",
     secSyncing: "Sincronizzazione…",

--- a/docs/MULTI_TENANT.de.md
+++ b/docs/MULTI_TENANT.de.md
@@ -162,6 +162,30 @@ trägt tenantId, nicht slug).
 
 ---
 
+## Individuelle Galerie-Slugs und Erratbarkeit
+
+Owner und Admins können den zufälligen Share-Slug einer Galerie
+(`/g/<zufällig>`) über den Share-Tab der Galerie durch einen lesbaren
+ersetzen (`/g/mueller-hochzeit`). Bevor du das Kunden erzählst, ist
+Folgendes wichtig:
+
+Bei einer Galerie mit aktiviertem öffentlichen Zugriff und ohne
+Passwort *ist* der Slug der Zugriffsschutz — wer ihn kennt (oder errät),
+kommt rein. Der zufällige Standard-Slug ist kryptografisch nicht
+erratbar; ein lesbarer, besonders für ein benanntes Ereignis wie eine
+Hochzeit, ist es nicht. Das fällt auf einer geteilten/SaaS-Instanz am
+meisten ins Gewicht, wo plausibel mehr Leute raten könnten als auf
+einem Single-Tenant-Self-Host.
+
+Die Studio-Oberfläche zeigt im Slug-Editor eine Warnung, sobald die
+Galerie sowohl öffentlich als auch passwortlos ist. Eine harte
+Einschränkung beim Setzen eines individuellen Slugs gibt es trotzdem
+nicht — eine saubere URL ist ein legitimer Wunsch, und das ist die
+Entscheidung des Studios — aber wer einen eigenen Client gegen die API
+baut, sollte denselben Hinweis beibehalten statt ihn wegzulassen.
+
+---
+
 ## Welches Verfahren wofür
 
 | Wofür                            | Verfahren                            |

--- a/docs/MULTI_TENANT.it.md
+++ b/docs/MULTI_TENANT.it.md
@@ -108,6 +108,16 @@ Il primo tenant, creato tramite `npm run create-admin`, ha slug=`default`. Se ge
 
 ---
 
+## Slug personalizzati della galleria e prevedibilità
+
+Owner e admin possono sostituire lo slug di condivisione casuale di una galleria (`/g/<casuale>`) con uno leggibile (`/g/mueller-hochzeit`) dalla tab Condividi della galleria. Prima di parlarne ai clienti, è utile sapere quanto segue:
+
+Per una galleria con accesso pubblico attivo e senza password, lo slug *è* il controllo d'accesso: chiunque lo conosca (o lo indovini) entra. Lo slug casuale predefinito è crittograficamente impossibile da indovinare; uno leggibile, specialmente per un evento con un nome come un matrimonio, non lo è. Questo pesa di più su un'istanza condivisa/SaaS, dove è plausibile che più persone possano tentare di indovinarlo rispetto a un self-host single-tenant.
+
+L'interfaccia dello studio mostra un avviso nell'editor dello slug ogni volta che la galleria è sia pubblica che senza password. Non c'è comunque una restrizione rigida all'impostazione di uno slug personalizzato — un URL pulito è una richiesta legittima, ed è una scelta dello studio — ma chi costruisce un proprio client contro l'API dovrebbe mantenere lo stesso avviso invece di ometterlo.
+
+---
+
 ## Quale metodo per cosa
 
 | Per cosa                            | Metodo                            |

--- a/docs/MULTI_TENANT.md
+++ b/docs/MULTI_TENANT.md
@@ -108,6 +108,16 @@ The first tenant, created via `npm run create-admin`, has slug=`default`. If you
 
 ---
 
+## Custom gallery slugs and guessability
+
+Studio owners and admins can replace a gallery's random share slug (`/g/<random>`) with a readable one (`/g/mueller-hochzeit`) from the gallery's Share tab. Worth knowing before you tell clients about it:
+
+For a gallery with public access enabled and no password, the slug *is* the access control — anyone who has (or guesses) it gets in. The default random slug is cryptographically unguessable; a readable one, especially for a named event like a wedding, is not. This matters most on a shared/SaaS instance, where more people could plausibly be guessing than on a single-tenant self-host.
+
+The studio UI shows a warning in the slug editor whenever the gallery is both public and passwordless. There's no hard restriction on setting a custom slug there anyway — a clean URL is a legitimate ask, and it's the studio's call — but if you build your own client against the API, keep the same disclosure rather than dropping it.
+
+---
+
 ## Which method for what
 
 | For what                            | Method                            |


### PR DESCRIPTION
## Summary
- Studio owners can now set a readable custom slug for a gallery's public share link (/g/<slug>), instead of only the auto-generated random string.
- Reuses the existing tenant-slug validation (format, reserved words, uniqueness) from services/slugs.ts, with a longer max length (60 vs 30) since a gallery slug is a path segment, not a DNS label.
- Owner-only, since changing the slug breaks previously shared links (same tradeoff as the tenant subdomain change).

Closes #28

## Test plan
- [x] `npm test` in apps/api (new services/slugs.test.ts, 205/205 tests pass, no regressions)
- [x] `tsc --noEmit` clean in apps/api and apps/frontend
- [x] `npm run check:i18n` in apps/frontend passes
- [x] Manual: create gallery, set custom slug as owner, confirm old /g/<slug> now 404s and new one resolves
- [x] Manual: non-owner cannot see/use the new settings section; direct API call returns 403
- [x] Manual: collision with an existing slug returns 409; invalid format/reserved word returns 400